### PR TITLE
feat: Implement off-chain 7683 discovery API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ rpc_url = "http://localhost:8545"
 chain_id = 31337
 
 # Discovery sources
-[discovery.sources.origin_eip7683]
+[discovery.sources.onchain_eip7683]
 rpc_url = "http://localhost:8545"
 settler_addresses = ["0x..."]
 
@@ -306,7 +306,7 @@ In another terminal, execute the send intent script to create and observe a cros
 
 ```bash
 # Send a cross-chain intent
-./scripts/demo/send_intent.sh
+./scripts/demo/send_onchain_intent.sh
 ```
 
 This script will:

--- a/config/demo.toml
+++ b/config/demo.toml
@@ -5,62 +5,58 @@ id = "oif-solver-local-dual-chain"
 monitoring_timeout_minutes = 5
 
 [storage]
-backend = "file"
-[storage.config]
-storage_path = "./data/storage"
+backend = "memory" # or "file"
+[storage.config] 
+# storage_path = "./data/storage" # Only relevant for "file" backend
 
 [account]
 provider = "local"
 [account.config]
-# Using Anvil's default account #0
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
 [delivery]
 min_confirmations = 1
-# Configure multiple delivery providers for different chains
 [delivery.providers.origin]
 rpc_url = "http://localhost:8545"
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-chain_id = 31337  # Anvil origin chain
+chain_id = 31337
 
 [delivery.providers.destination]
 rpc_url = "http://localhost:8546"
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-chain_id = 31338  # Anvil destination chain
+chain_id = 31338
 
 [discovery]
-# Configure multiple discovery sources
-[discovery.sources.origin_eip7683]
+[discovery.sources.onchain_eip7683]
 rpc_url = "http://localhost:8545"
-# InputSettler address on origin chain (where orders are created)
 settler_addresses = ["0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"]
 
+[discovery.sources.offchain_eip7683]
+api_host = "0.0.0.0"
+api_port = 8081
+rpc_url = "http://localhost:8545"
+# auth_token = "your-secret-token"
+
 [order]
-# EIP-7683 order implementations
 [order.implementations.eip7683]
-# OutputSettler address (destination chain)
 output_settler_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
-# InputSettler address (origin chain)
 input_settler_address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
-# Solver address (derived from the account private key)
 solver_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 
 [order.execution_strategy]
 strategy_type = "simple"
 [order.execution_strategy.config]
-max_gas_price_gwei = 100  # Maximum gas price in gwei
+max_gas_price_gwei = 100
 
 [settlement]
-# Direct settlement implementations
 [settlement.implementations.eip7683]
-rpc_url = "http://localhost:8546"  # Settlement needs to validate fills on destination chain
-# Oracle address on origin chain
+rpc_url = "http://localhost:8546"
 oracle_address = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
-dispute_period_seconds = 1  # 1 seconds for testing
+dispute_period_seconds = 1
 
 # ============================================================================
 # DEMO SCRIPT CONFIGURATION
-# The following sections are used by demo scripts (send_intent.sh, etc.)
+# The following sections are used by demo scripts (send_onchain_intent.sh, etc.)
 # and are NOT required by the solver itself. The solver only needs the
 # configurations above.
 # ============================================================================
@@ -87,4 +83,4 @@ permit2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
 solver = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 user = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 user_private_key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
-recipient = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"  # Account #2 - recipient for cross-chain intents
+recipient = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"

--- a/config/example.toml
+++ b/config/example.toml
@@ -30,7 +30,7 @@ chain_id = 31338  # Anvil destination chain
 
 [discovery]
 # Configure multiple discovery sources
-[discovery.sources.origin_eip7683]
+[discovery.sources.onchain_eip7683]
 rpc_url = "http://localhost:8545"
 # InputSettler address on origin chain (where orders are created)
 settler_addresses = ["0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"]
@@ -65,7 +65,7 @@ dispute_period_seconds = 1  # 1 seconds for testing
 
 # ============================================================================
 # DEMO SCRIPT CONFIGURATION
-# The following sections are used by demo scripts (send_intent.sh, etc.)
+# The following sections are used by demo scripts (send_onchain_intent.sh, etc.)
 # and are NOT required by the solver itself. The solver only needs the
 # configurations above.
 # ============================================================================

--- a/crates/solver-delivery/src/lib.rs
+++ b/crates/solver-delivery/src/lib.rs
@@ -178,12 +178,19 @@ impl DeliveryService {
 	/// This method tries all providers until one recognizes the transaction.
 	pub async fn get_status(&self, hash: &TransactionHash) -> Result<bool, DeliveryError> {
 		// Try all providers until one recognizes the transaction
-		for (_chain_id, provider) in self.providers.iter() {
+		// TODO: Improve this so it doesn't make redundant requests
+		for (chain_id, provider) in self.providers.iter() {
 			match provider.get_receipt(hash).await {
 				Ok(receipt) => {
 					return Ok(receipt.success);
 				}
-				Err(_) => {
+				Err(e) => {
+					tracing::trace!(
+						"Provider for chain {} cannot find transaction {}: {}",
+						chain_id,
+						hex::encode(&hash.0),
+						e
+					);
 					continue;
 				}
 			}

--- a/crates/solver-discovery/Cargo.toml
+++ b/crates/solver-discovery/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+alloy-contract = "0.8"
 alloy-primitives = "0.8"
 alloy-provider = "0.8"
 alloy-rpc-types = "0.8"
@@ -15,8 +16,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 solver-types = { path = "../solver-types" }
 thiserror = "1.0"
-tokio = { version = "1.0", features = ["sync"] }
+tokio = { version = "1.0", features = ["sync", "rt-multi-thread"] }
 toml = "0.8"
 tracing = "0.1"
 alloy-transport = "0.8"
 alloy-transport-http = "0.8"
+axum = "0.8"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/solver-discovery/src/implementations/offchain/_7683.rs
+++ b/crates/solver-discovery/src/implementations/offchain/_7683.rs
@@ -4,127 +4,868 @@
 //! directly from users or other systems. It provides an endpoint for receiving
 //! gasless cross-chain orders that follow the ERC-7683 standard.
 //!
+//! The API is exposed directly from the discovery module rather than solver-service for several key reasons:
+//!
+//! 1. **Consistency**: Discovery is the entry point for ALL intents - both on-chain and off-chain
+//! 2. **Single Responsibility**: Each module has a clear purpose:
+//!    - solver-discovery: Intent ingestion and lifecycle management
+//!    - solver-service: Solver orchestration, health, metrics, quotes
+//! 3. **Extensibility**: Provides a pattern for custom discovery implementations (e.g., webhooks, other APIs)
+//! 4. **Independence**: Discovery can be deployed/scaled separately from the solver service
+//! 5. **Source of Truth**: Discovery owns the intent lifecycle and should expose intent-related endpoints
+//!
 //! ## Overview
 //!
-//! The ERC-7683 standard defines a universal cross-chain intent framework that enables:
-//! - Users to express cross-chain intents with gasless order submission
-//! - Solvers/fillers to discover and fulfill these intents across chains
-//! - Settlement through standardized contracts on origin and destination chains
+//! The off-chain discovery service runs an HTTP API server that:
+//! - Accepts EIP-7683 gasless cross-chain orders via POST requests
+//! - Validates order parameters and signatures
+//! - Converts orders to the internal Intent format
+//! - Broadcasts discovered intents to the solver system
 //!
-//! ## Architecture
+//! ## API Endpoint
 //!
-//! This implementation:
-//! 1. Spins up an HTTP API server with intent submission endpoints
-//! 2. Receives GaslessCrossChainOrder intents via POST requests
-//! 3. Validates and normalizes the intent data
-//! 4. Publishes validated intents to the solver's event bus
-//! 5. Enables the delivery service to pick up and process these intents
-//!
-//! ## Intent Flow
-//!
-//! 1. **Submission**: Users POST GaslessCrossChainOrder to `/intents` endpoint
-//! 2. **Validation**: Verify intent structure matches ERC-7683 standard
-//! 3. **Normalization**: Convert to internal Intent representation
-//! 4. **Publication**: Emit to event bus for downstream processing
-//! 5. **Response**: Return intent ID and status to submitter
-//!
-//! ## Implementation Requirements
-//!
-//! To complete this implementation:
-//!
-//! 1. **API Server Setup**
-//!    - Create HTTP server (e.g., using Axum, Actix-web, or Warp)
-//!    - Define POST `/intents` endpoint
-//!    - Implement request parsing and validation
-//!    - Add health check and metrics endpoints
-//!
-//! 2. **Intent Recognition**
-//!    - Parse GaslessCrossChainOrder structure from request body
-//!    - Validate all required fields are present
-//!    - Check signature validity (if provided)
-//!    - Verify deadlines haven't expired
-//!
-//! 3. **Event Bus Integration**
-//!    - Convert validated intents to internal Intent type
-//!    - Publish to the configured event bus topic
-//!    - Handle retry logic for failed publications
-//!
-//! ## GaslessCrossChainOrder Structure
-//!
-//! The standard ERC-7683 order structure that this module processes:
-//!
-//! ```solidity
-//! struct GaslessCrossChainOrder {
-//!     address originSettler;      // Settlement contract on origin chain
-//!     address user;              // User initiating the cross-chain swap
-//!     uint256 nonce;            // Replay protection nonce
-//!     uint256 originChainId;    // Chain ID where order originates
-//!     uint32 openDeadline;      // Deadline to open the order
-//!     uint32 fillDeadline;      // Deadline to fill on destination
-//!     bytes32 orderDataType;    // EIP-712 typehash for order data
-//!     bytes orderData;          // Order-specific data (tokens, amounts, etc.)
-//! }
-//! ```
+//! - `POST /intent` - Submit a new cross-chain order
 //!
 //! ## Configuration
 //!
-//! Expected configuration parameters:
-//! - `api_port`: Port to bind the HTTP server (default: 8080)
-//! - `api_host`: Host address to bind (default: 0.0.0.0)
-//! - `auth_token`: Optional bearer token for API authentication
-//! - `rate_limit`: Max requests per minute per IP (default: 100)
-//! - `event_bus_topic`: Where to publish discovered intents
+//! The service requires the following configuration:
+//! - `api_host` - The host address to bind the API server (default: "0.0.0.0")
+//! - `api_port` - The port to listen on (default: 8080)
+//! - `rpc_url` - Ethereum RPC URL for calling settler contracts
+//! - `auth_token` - Optional authentication token for API access
 //!
-//! ## API Endpoints
+//! ## Order Flow
 //!
-//! - `POST /intent` - Submit a new GaslessCrossChainOrder
-//! - `GET /intent/{orderId}` - Get the status of submitted intent
-//!
-//! ## Example Usage
-//!
-//! ```rust
-//! // Initialize the discovery API server
-//! let discovery = Erc7683OffchainDiscovery::new(config)?;
-//!
-//! // Start the API server
-//! discovery.start_server().await?;
-//!
-//! // Server now accepts POST requests with GaslessCrossChainOrder
-//! // at http://localhost:8080/intent
-//! ```
-//!
-//! ## Example API Request
-//!
-//! ```bash
-//! curl -X POST http://localhost:8080/intent \
-//!   -H "Content-Type: application/json" \
-//!   -H "Authorization: Bearer YOUR_TOKEN" \
-//!   -d '{
-//!     "originSettler": "0x...",
-//!     "user": "0x...",
-//!     "nonce": "123",
-//!     "originChainId": "1",
-//!     "openDeadline": 1234567890,
-//!     "fillDeadline": 1234567900,
-//!     "orderDataType": "0x...",
-//!     "orderData": "0x..."
-//!   }'
-//! ```
-//!
-//! ## Security Considerations
-//!
-//! - Validate all intent data before processing
-//! - Verify signatures match the claimed user address
-//! - Check deadlines haven't expired
-//! - Rate limit API requests to prevent abuse
-//! - Use secure storage for API credentials
-//!
-//! ## TODO Implementation Steps
-//!
-//! 1. Define the API server structure and routes
-//! 2. Implement GaslessCrossChainOrder request handler
-//! 3. Create intent parser and validator
-//! 4. Integrate with solver's event bus
-//! 5. Add authentication and rate limiting middleware
-//! 6. Implement monitoring and metrics collection
-//! 7. Write comprehensive tests for all endpoints
+//! 1. User submits a `GaslessCrossChainOrder` to the API endpoint
+//! 2. The service validates the order deadlines and signature
+//! 3. Order ID is computed by calling the settler contract
+//! 4. Order data is parsed to extract inputs/outputs
+//! 5. The order is converted to an Intent and broadcast to solvers
+
+use crate::{DiscoveryError, DiscoveryInterface};
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_provider::RootProvider;
+use alloy_sol_types::sol;
+use alloy_transport_http::Http;
+use async_trait::async_trait;
+use axum::{
+	extract::State,
+	http::StatusCode,
+	response::{IntoResponse, Json},
+	routing::post,
+	Router,
+};
+use serde::{Deserialize, Serialize};
+use solver_types::{
+	eip7683::{Eip7683OrderData, Output as Eip7683Output},
+	ConfigSchema, Field, FieldType, Intent, IntentMetadata, Schema,
+};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
+use tower_http::cors::CorsLayer;
+
+// Import the Solidity types from IERC7683.sol
+sol! {
+	#[sol(rpc)]
+	interface IErc7683 {
+		struct GaslessCrossChainOrder {
+			address originSettler;
+			address user;
+			uint256 nonce;
+			uint256 originChainId;
+			uint32 openDeadline;
+			uint32 fillDeadline;
+			bytes32 orderDataType;
+			bytes orderData;
+		}
+
+		function orderIdentifier(GaslessCrossChainOrder calldata order) external view returns (bytes32);
+	}
+
+	// MandateERC7683 struct for decoding orderData
+	struct MandateERC7683 {
+		uint32 expiry;
+		bytes32 localOracle;
+		uint256[2][] inputs;
+		MandateOutput[] outputs;
+	}
+
+	struct MandateOutput {
+		bytes32 oracle;
+		bytes32 settler;
+		uint256 chainId;
+		bytes32 token;
+		uint256 amount;
+		bytes32 recipient;
+		bytes call;
+		bytes context;
+	}
+}
+
+/// API representation of GaslessCrossChainOrder for JSON deserialization.
+///
+/// This struct represents the order format expected by the HTTP API endpoint.
+/// It mirrors the Solidity `GaslessCrossChainOrder` struct but uses API-friendly
+/// types for JSON serialization/deserialization.
+///
+/// # Fields
+///
+/// * `origin_settler` - Address of the settler contract on the origin chain
+/// * `user` - Address of the user creating the order
+/// * `nonce` - Unique nonce to prevent replay attacks
+/// * `origin_chain_id` - Chain ID where the order originates
+/// * `open_deadline` - Unix timestamp after which the order can be filled
+/// * `fill_deadline` - Unix timestamp when the order expires
+/// * `order_data_type` - 32-byte identifier for the order data format
+/// * `order_data` - Encoded order data (typically MandateERC7683)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiGaslessCrossChainOrder {
+	origin_settler: Address,
+	user: Address,
+	nonce: U256,
+	origin_chain_id: U256,
+	open_deadline: u32,
+	fill_deadline: u32,
+	#[serde(deserialize_with = "deserialize_bytes32")]
+	order_data_type: [u8; 32],
+	order_data: Bytes,
+}
+
+/// Custom deserializer for bytes32 that accepts hex strings.
+///
+/// Converts hex strings (with or without "0x" prefix) to fixed 32-byte arrays.
+/// Used for deserializing order_data_type and other bytes32 fields from JSON.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The hex string is not exactly 64 characters (32 bytes)
+/// - The string contains invalid hex characters
+fn deserialize_bytes32<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	use serde::de::Error;
+
+	let s = String::deserialize(deserializer)?;
+	let s = s.strip_prefix("0x").unwrap_or(&s);
+
+	if s.len() != 64 {
+		return Err(Error::custom(format!(
+			"Invalid bytes32: expected 64 hex chars, got {}",
+			s.len()
+		)));
+	}
+
+	let mut bytes = [0u8; 32];
+	hex::decode_to_slice(s, &mut bytes)
+		.map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?;
+
+	Ok(bytes)
+}
+
+/// API request wrapper for intent submission.
+///
+/// This is the top-level structure for POST /intent requests.
+///
+/// # Fields
+///
+/// * `order` - The gasless cross-chain order to submit
+/// * `signature` - Optional signature for order validation
+/// * `_quote_id` - Optional quote identifier (currently unused)
+/// * `_provider` - Optional provider identifier (currently unused)
+#[derive(Debug, Deserialize)]
+struct IntentRequest {
+	order: ApiGaslessCrossChainOrder,
+	signature: Option<Bytes>,
+	#[serde(default)]
+	_quote_id: Option<String>,
+	#[serde(default, alias = "provider")]
+	_provider: Option<String>,
+}
+
+/// API response for intent submission.
+///
+/// Returned by the POST /intent endpoint to indicate submission status.
+///
+/// # Fields
+///
+/// * `order_id` - The computed order ID (hex encoded)
+/// * `status` - Either "success" or "error"
+/// * `message` - Optional error message when status is "error"
+#[derive(Debug, Serialize)]
+struct IntentResponse {
+	order_id: String,
+	status: String, // error | success
+	message: Option<String>,
+}
+
+/// Shared state for the API server.
+///
+/// Contains all the dependencies needed by API request handlers.
+/// This state is cloned for each request (all fields are cheaply cloneable).
+///
+/// # Fields
+///
+/// * `intent_sender` - Channel to broadcast discovered intents to the solver system
+/// * `auth_token` - Optional authentication token for API access control
+/// * `provider` - RPC provider for interacting with on-chain contracts
+#[derive(Clone)]
+struct ApiState {
+	/// Channel to send discovered intents
+	intent_sender: mpsc::UnboundedSender<Intent>,
+	/// Optional authentication token
+	#[allow(dead_code)]
+	auth_token: Option<String>,
+	/// RPC provider for calling settler contracts
+	provider: RootProvider<Http<reqwest::Client>>,
+}
+
+/// EIP-7683 offchain discovery implementation.
+///
+/// This struct implements the `DiscoveryInterface` trait to provide
+/// off-chain intent discovery through an HTTP API server. It listens
+/// for incoming EIP-7683 orders and converts them to the internal
+/// Intent format for processing by the solver system.
+pub struct Eip7683OffchainDiscovery {
+	/// API server configuration
+	api_host: String,
+	api_port: u16,
+	auth_token: Option<String>,
+	/// RPC provider for calling settler contracts
+	provider: RootProvider<Http<reqwest::Client>>,
+	/// Flag indicating if the server is running
+	is_running: Arc<AtomicBool>,
+	/// Channel for signaling server shutdown
+	shutdown_signal: Arc<Mutex<Option<mpsc::Sender<()>>>>,
+}
+
+impl Eip7683OffchainDiscovery {
+	/// Creates a new EIP-7683 offchain discovery instance.
+	///
+	/// # Arguments
+	///
+	/// * `api_host` - The host address to bind the API server
+	/// * `api_port` - The port number to listen on
+	/// * `auth_token` - Optional authentication token for API access
+	/// * `rpc_url` - Ethereum RPC URL for calling settler contracts
+	///
+	/// # Returns
+	///
+	/// Returns a new discovery instance or an error if the RPC URL is invalid.
+	///
+	/// # Errors
+	///
+	/// Returns `DiscoveryError::Connection` if the RPC URL cannot be parsed.
+	pub fn new(
+		api_host: String,
+		api_port: u16,
+		auth_token: Option<String>,
+		rpc_url: String,
+	) -> Result<Self, DiscoveryError> {
+		let provider = RootProvider::new_http(
+			rpc_url
+				.parse()
+				.map_err(|e| DiscoveryError::Connection(format!("Invalid RPC URL: {}", e)))?,
+		);
+
+		Ok(Self {
+			api_host,
+			api_port,
+			auth_token,
+			provider,
+			is_running: Arc::new(AtomicBool::new(false)),
+			shutdown_signal: Arc::new(Mutex::new(None)),
+		})
+	}
+
+	/// Parses order data to extract outputs and other details.
+	///
+	/// Decodes the MandateERC7683 struct from the raw order data bytes
+	/// and extracts the inputs, outputs, expiry, and oracle information.
+	///
+	/// # Arguments
+	///
+	/// * `order` - The API order containing encoded order data
+	///
+	/// # Returns
+	///
+	/// Returns a JSON value containing:
+	/// - `outputs`: Array of output specifications
+	/// - `inputs`: Array of input token/amount pairs
+	/// - `expiry`: Order expiration timestamp
+	/// - `local_oracle`: Address of the local oracle
+	///
+	/// # Errors
+	///
+	/// Returns `DiscoveryError::ParseError` if the order data cannot be decoded.
+	fn parse_order_data(
+		order: &ApiGaslessCrossChainOrder,
+	) -> Result<serde_json::Value, DiscoveryError> {
+		use alloy_sol_types::SolValue;
+
+		// Decode the MandateERC7683 struct from the order data
+		let mandate = MandateERC7683::abi_decode(&order.order_data, true).map_err(|e| {
+			DiscoveryError::ParseError(format!("Failed to decode MandateERC7683: {}", e))
+		})?;
+
+		// Convert inputs
+		let inputs: Vec<[serde_json::Value; 2]> = mandate
+			.inputs
+			.iter()
+			.map(|input| {
+				[
+					serde_json::to_value(input[0]).unwrap(),
+					serde_json::to_value(input[1]).unwrap(),
+				]
+			})
+			.collect();
+
+		// Convert outputs
+		let outputs: Vec<Eip7683Output> = mandate
+			.outputs
+			.iter()
+			.map(|output| {
+				// Convert bytes32 token to address (last 20 bytes)
+				let token_bytes = &output.token.0[12..];
+				let token = format!("0x{}", hex::encode(token_bytes));
+
+				// Convert bytes32 recipient to address (last 20 bytes)
+				let recipient_bytes = &output.recipient.0[12..];
+				let recipient = format!("0x{}", hex::encode(recipient_bytes));
+
+				Eip7683Output {
+					token,
+					amount: output.amount,
+					recipient,
+					chain_id: output.chainId.to::<u64>(),
+				}
+			})
+			.collect();
+
+		Ok(serde_json::json!({
+			"outputs": outputs,
+			"inputs": inputs,
+			"expiry": mandate.expiry,
+			"local_oracle": format!("0x{}", hex::encode(&mandate.localOracle.0[12..]))
+		}))
+	}
+
+	/// Validates the incoming order.
+	///
+	/// Performs validation checks on order deadlines to ensure
+	/// the order is still valid and can be processed.
+	///
+	/// # Arguments
+	///
+	/// * `order` - The order to validate
+	/// * `_signature` - Optional signature (validation not yet implemented)
+	///
+	/// # Returns
+	///
+	/// Returns `Ok(())` if the order is valid.
+	///
+	/// # Errors
+	///
+	/// Returns `DiscoveryError::ValidationError` if:
+	/// - The open deadline has passed (if non-zero)
+	/// - The fill deadline has passed
+	///
+	/// # TODO
+	///
+	/// - Implement signature validation
+	async fn validate_order(
+		order: &ApiGaslessCrossChainOrder,
+		_signature: &Option<Bytes>,
+	) -> Result<(), DiscoveryError> {
+		// Check if deadlines are still valid
+		let current_time = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.unwrap()
+			.as_secs() as u32;
+
+		if order.open_deadline > 0 && order.open_deadline < current_time {
+			return Err(DiscoveryError::ValidationError(
+				"Order open deadline has passed".to_string(),
+			));
+		}
+
+		if order.fill_deadline < current_time {
+			return Err(DiscoveryError::ValidationError(
+				"Order fill deadline has passed".to_string(),
+			));
+		}
+
+		// TODO: Implement signature validation
+		// if let Some(sig) = signature {
+		//     // Verify signature matches the user address
+		// }
+
+		Ok(())
+	}
+
+	/// Converts GaslessCrossChainOrder to Intent.
+	///
+	/// Transforms an API order into the internal Intent format used by
+	/// the solver system. This includes:
+	/// - Computing the order ID via the settler contract
+	/// - Parsing order data to extract inputs/outputs
+	/// - Creating metadata for the intent
+	///
+	/// # Arguments
+	///
+	/// * `order` - The API order to convert
+	/// * `provider` - RPC provider for calling contracts
+	/// * `signature` - Optional order signature
+	///
+	/// # Returns
+	///
+	/// Returns an Intent ready for processing by the solver system.
+	///
+	/// # Errors
+	///
+	/// Returns an error if:
+	/// - Order ID computation fails
+	/// - Order data parsing fails
+	/// - No outputs are present in the order
+	async fn order_to_intent(
+		order: &ApiGaslessCrossChainOrder,
+		provider: &RootProvider<Http<reqwest::Client>>,
+		signature: &Option<Bytes>,
+	) -> Result<Intent, DiscoveryError> {
+		// Generate order ID from order data
+		let order_id = Self::compute_order_id(order, provider).await?;
+
+		// Parse order data
+		let parsed_data = Self::parse_order_data(order)?;
+
+		// Parse outputs from parsed_data
+		let outputs: Vec<Eip7683Output> = serde_json::from_value(parsed_data["outputs"].clone())
+			.map_err(|e| DiscoveryError::ParseError(format!("Failed to parse outputs: {}", e)))?;
+
+		// Parse inputs from parsed_data
+		let inputs: Vec<[U256; 2]> = serde_json::from_value(parsed_data["inputs"].clone())
+			.map_err(|e| DiscoveryError::ParseError(format!("Failed to parse inputs: {}", e)))?;
+
+		// Extract destination chain ID from first output (if available)
+		let destination_chain_id =
+			outputs
+				.first()
+				.map(|output| output.chain_id)
+				.ok_or_else(|| {
+					DiscoveryError::ValidationError(
+						"Order must have at least one output".to_string(),
+					)
+				})?;
+
+		// Convert to intent format matching the onchain implementation
+		let order_data = Eip7683OrderData {
+			user: order.user.to_string(),
+			nonce: order.nonce.to::<u64>(),
+			origin_chain_id: order.origin_chain_id.to::<u64>(),
+			destination_chain_id,
+			expires: order.open_deadline,
+			fill_deadline: order.fill_deadline,
+			local_oracle: "0x0000000000000000000000000000000000000000".to_string(),
+			inputs,
+			order_id,
+			settle_gas_limit: 200_000u64,
+			fill_gas_limit: 200_000u64,
+			outputs,
+			// Include raw order data for openFor
+			raw_order_data: Some(order.order_data.to_string()),
+			order_data_type: Some(order.order_data_type),
+			// Include signature if provided
+			signature: signature.as_ref().map(|s| s.to_string()),
+		};
+
+		Ok(Intent {
+			id: hex::encode(order_id),
+			source: "off-chain".to_string(),
+			standard: "eip7683".to_string(),
+			metadata: IntentMetadata {
+				requires_auction: false,
+				exclusive_until: None,
+				discovered_at: std::time::SystemTime::now()
+					.duration_since(std::time::UNIX_EPOCH)
+					.unwrap()
+					.as_secs(),
+			},
+			data: serde_json::to_value(&order_data).map_err(|e| {
+				DiscoveryError::ParseError(format!("Failed to serialize order data: {}", e))
+			})?,
+		})
+	}
+
+	/// Computes order ID from order data.
+	///
+	/// Calls the `orderIdentifier` function on the origin settler contract
+	/// to compute the canonical order ID for the given order.
+	///
+	/// # Arguments
+	///
+	/// * `order` - The order to compute ID for
+	/// * `provider` - RPC provider for calling the settler contract
+	///
+	/// # Returns
+	///
+	/// Returns the 32-byte order ID.
+	///
+	/// # Errors
+	///
+	/// Returns `DiscoveryError::Connection` if the contract call fails.
+	async fn compute_order_id(
+		order: &ApiGaslessCrossChainOrder,
+		provider: &RootProvider<Http<reqwest::Client>>,
+	) -> Result<[u8; 32], DiscoveryError> {
+		let settler = IErc7683::new(order.origin_settler, provider);
+
+		// Convert API order to contract format
+		let contract_order = IErc7683::GaslessCrossChainOrder {
+			originSettler: order.origin_settler,
+			user: order.user,
+			nonce: order.nonce,
+			originChainId: order.origin_chain_id,
+			openDeadline: order.open_deadline,
+			fillDeadline: order.fill_deadline,
+			orderDataType: order.order_data_type.into(),
+			orderData: order.order_data.clone(),
+		};
+
+		let order_id = settler
+			.orderIdentifier(contract_order)
+			.call()
+			.await
+			.map_err(|e| {
+				DiscoveryError::Connection(format!("Failed to get order ID from contract: {}", e))
+			})?;
+
+		Ok(order_id._0.0)
+	}
+
+	/// Main API server task.
+	///
+	/// Runs the HTTP server that listens for intent submissions.
+	/// The server supports graceful shutdown via the shutdown channel.
+	///
+	/// # Arguments
+	///
+	/// * `api_host` - Host address to bind to
+	/// * `api_port` - Port number to listen on
+	/// * `intent_sender` - Channel to send discovered intents
+	/// * `auth_token` - Optional authentication token
+	/// * `provider` - RPC provider for contract calls
+	/// * `shutdown_rx` - Channel to receive shutdown signal
+	///
+	/// # Panics
+	///
+	/// Panics if:
+	/// - The address cannot be parsed
+	/// - The TCP listener cannot bind to the address
+	/// - The server encounters a fatal error
+	async fn run_server(
+		api_host: String,
+		api_port: u16,
+		intent_sender: mpsc::UnboundedSender<Intent>,
+		auth_token: Option<String>,
+		provider: RootProvider<Http<reqwest::Client>>,
+		mut shutdown_rx: mpsc::Receiver<()>,
+	) {
+		let state = ApiState {
+			intent_sender,
+			auth_token,
+			provider,
+		};
+
+		let app = Router::new()
+			.route("/intent", post(handle_intent_submission))
+			.layer(CorsLayer::permissive())
+			.with_state(state);
+
+		let addr = format!("{}:{}", api_host, api_port)
+			.parse::<SocketAddr>()
+			.expect("Invalid address");
+
+		let listener = tokio::net::TcpListener::bind(addr)
+			.await
+			.expect("Failed to bind address");
+
+		tracing::info!("EIP-7683 offchain discovery API listening on {}", addr);
+
+		axum::serve(listener, app)
+			.with_graceful_shutdown(async move {
+				let _ = shutdown_rx.recv().await;
+				tracing::info!("Shutting down API server");
+			})
+			.await
+			.expect("Server error");
+	}
+}
+
+/// Handles intent submission requests.
+///
+/// This is the main request handler for the POST /intent endpoint.
+/// It validates the incoming order, converts it to an Intent, and
+/// broadcasts it to the solver system.
+///
+/// # Arguments
+///
+/// * `state` - Shared API state containing dependencies
+/// * `request` - The intent submission request
+///
+/// # Returns
+///
+/// Returns an HTTP response with:
+/// - 200 OK with order_id on success
+/// - 400 Bad Request if validation fails
+/// - 500 Internal Server Error if processing fails
+///
+/// # Response Format
+///
+/// ```json
+/// {
+///   "order_id": "0x...",
+///   "status": "success" | "error",
+///   "message": "optional error message"
+/// }
+/// ```
+async fn handle_intent_submission(
+	State(state): State<ApiState>,
+	Json(request): Json<IntentRequest>,
+) -> impl IntoResponse {
+	// TODO: Implement authentication
+	// if let Some(token) = &state.auth_token {
+	//     // Check Authorization header
+	// }
+
+	// Validate order
+	if let Err(e) =
+		Eip7683OffchainDiscovery::validate_order(&request.order, &request.signature).await
+	{
+		return (
+			StatusCode::BAD_REQUEST,
+			Json(IntentResponse {
+				order_id: String::new(),
+				status: "error".to_string(),
+				message: Some(e.to_string()),
+			}),
+		)
+			.into_response();
+	}
+
+	// Convert to intent
+	match Eip7683OffchainDiscovery::order_to_intent(
+		&request.order,
+		&state.provider,
+		&request.signature,
+	)
+	.await
+	{
+		Ok(intent) => {
+			let order_id = intent.id.clone();
+
+			// Send intent through channel
+			if let Err(e) = state.intent_sender.send(intent) {
+				return (
+					StatusCode::INTERNAL_SERVER_ERROR,
+					Json(IntentResponse {
+						order_id,
+						status: "error".to_string(),
+						message: Some(format!("Failed to process intent: {}", e)),
+					}),
+				)
+					.into_response();
+			}
+
+			(
+				StatusCode::OK,
+				Json(IntentResponse {
+					order_id,
+					status: "success".to_string(),
+					message: None,
+				}),
+			)
+				.into_response()
+		}
+		Err(e) => (
+			StatusCode::BAD_REQUEST,
+			Json(IntentResponse {
+				order_id: String::new(),
+				status: "error".to_string(),
+				message: Some(e.to_string()),
+			}),
+		)
+			.into_response(),
+	}
+}
+
+/// Configuration schema for EIP-7683 offchain discovery.
+///
+/// Defines and validates the configuration parameters required
+/// for the off-chain discovery service. This schema ensures
+/// all required fields are present and have valid values.
+///
+/// # Required Fields
+///
+/// - `api_port` - Port number (1-65535)
+/// - `api_host` - Host address string
+/// - `rpc_url` - HTTP(S) URL for Ethereum RPC
+///
+/// # Optional Fields
+///
+/// - `auth_token` - Authentication token string
+/// - `rate_limit` - Request rate limit (1-10000)
+pub struct Eip7683OffchainDiscoverySchema;
+
+impl ConfigSchema for Eip7683OffchainDiscoverySchema {
+	fn validate(&self, config: &toml::Value) -> Result<(), solver_types::ValidationError> {
+		let schema = Schema::new(
+			// Required fields
+			vec![
+				Field::new(
+					"api_port",
+					FieldType::Integer {
+						min: Some(1),
+						max: Some(65535),
+					},
+				),
+				Field::new("api_host", FieldType::String),
+				Field::new("rpc_url", FieldType::String).with_validator(|value| {
+					let url = value.as_str().unwrap();
+					if url.starts_with("http://") || url.starts_with("https://") {
+						Ok(())
+					} else {
+						Err("RPC URL must start with http:// or https://".to_string())
+					}
+				}),
+			],
+			// Optional fields
+			vec![
+				Field::new("auth_token", FieldType::String),
+				Field::new(
+					"rate_limit",
+					FieldType::Integer {
+						min: Some(1),
+						max: Some(10000),
+					},
+				),
+			],
+		);
+
+		schema.validate(config)
+	}
+}
+
+#[async_trait]
+impl DiscoveryInterface for Eip7683OffchainDiscovery {
+	fn config_schema(&self) -> Box<dyn ConfigSchema> {
+		Box::new(Eip7683OffchainDiscoverySchema)
+	}
+
+	async fn start_monitoring(
+		&self,
+		sender: mpsc::UnboundedSender<Intent>,
+	) -> Result<(), DiscoveryError> {
+		if self.is_running.load(Ordering::SeqCst) {
+			return Err(DiscoveryError::AlreadyMonitoring);
+		}
+
+		let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+		*self.shutdown_signal.lock().await = Some(shutdown_tx);
+
+		// Spawn API server task
+		let api_host = self.api_host.clone();
+		let api_port = self.api_port;
+		let auth_token = self.auth_token.clone();
+		let provider = self.provider.clone();
+
+		tokio::spawn(async move {
+			Self::run_server(
+				api_host,
+				api_port,
+				sender,
+				auth_token,
+				provider,
+				shutdown_rx,
+			)
+			.await;
+		});
+
+		self.is_running.store(true, Ordering::SeqCst);
+		Ok(())
+	}
+
+	async fn stop_monitoring(&self) -> Result<(), DiscoveryError> {
+		if !self.is_running.load(Ordering::SeqCst) {
+			return Ok(());
+		}
+
+		if let Some(shutdown_tx) = self.shutdown_signal.lock().await.take() {
+			let _ = shutdown_tx.send(()).await;
+		}
+
+		self.is_running.store(false, Ordering::SeqCst);
+		Ok(())
+	}
+}
+
+/// Factory function to create an EIP-7683 offchain discovery provider.
+///
+/// This function is called by the discovery module factory system
+/// to instantiate a new off-chain discovery service with the provided
+/// configuration.
+///
+/// # Arguments
+///
+/// * `config` - TOML configuration value containing service parameters
+///
+/// # Returns
+///
+/// Returns a boxed discovery interface implementation.
+///
+/// # Configuration
+///
+/// Expected configuration format:
+/// ```toml
+/// api_host = "0.0.0.0"         # optional, defaults to "0.0.0.0"
+/// api_port = 8081              # optional, defaults to 8081
+/// auth_token = "secret"        # optional
+/// rpc_url = "https://..."      # required
+/// ```
+///
+/// # Panics
+///
+/// Panics if:
+/// - `rpc_url` is not provided in the configuration
+/// - The discovery service cannot be created
+pub fn create_discovery(config: &toml::Value) -> Box<dyn DiscoveryInterface> {
+	let api_host = config
+		.get("api_host")
+		.and_then(|v| v.as_str())
+		.unwrap_or("0.0.0.0")
+		.to_string();
+
+	let api_port = config
+		.get("api_port")
+		.and_then(|v| v.as_integer())
+		.unwrap_or(8081) as u16;
+
+	let auth_token = config
+		.get("auth_token")
+		.and_then(|v| v.as_str())
+		.map(String::from);
+
+	let rpc_url = config
+		.get("rpc_url")
+		.and_then(|v| v.as_str())
+		.expect("rpc_url is required")
+		.to_string();
+
+	Box::new(
+		Eip7683OffchainDiscovery::new(api_host, api_port, auth_token, rpc_url)
+			.expect("Failed to create offchain discovery service"),
+	)
+}

--- a/crates/solver-discovery/src/lib.rs
+++ b/crates/solver-discovery/src/lib.rs
@@ -14,7 +14,9 @@ pub mod implementations {
 	pub mod onchain {
 		pub mod _7683;
 	}
-	pub mod offchain {}
+	pub mod offchain {
+		pub mod _7683;
+	}
 }
 
 /// Errors that can occur during intent discovery operations.
@@ -26,6 +28,12 @@ pub enum DiscoveryError {
 	/// Error that occurs when trying to start monitoring on an already active source.
 	#[error("Already monitoring")]
 	AlreadyMonitoring,
+	/// Error that occurs when parsing or decoding data fails.
+	#[error("Parse error: {0}")]
+	ParseError(String),
+	/// Error that occurs when validating intent data.
+	#[error("Validation error: {0}")]
+	ValidationError(String),
 }
 
 /// Trait defining the interface for intent discovery sources.

--- a/crates/solver-service/src/main.rs
+++ b/crates/solver-service/src/main.rs
@@ -12,12 +12,14 @@ use std::path::PathBuf;
 // Import implementations from individual crates
 use solver_account::implementations::local::create_account;
 use solver_delivery::implementations::evm::alloy::create_http_delivery;
-use solver_discovery::implementations::onchain::_7683::create_discovery;
+use solver_discovery::implementations::offchain::_7683::create_discovery as offchain_create_discovery;
+// use solver_discovery::implementations::onchain::_7683::create_discovery as onchain_create_discovery;
 use solver_order::implementations::{
 	standards::_7683::create_order_impl, strategies::simple::create_strategy,
 };
 use solver_settlement::implementations::direct::create_settlement;
-use solver_storage::implementations::file::create_storage;
+// use solver_storage::implementations::file::create_storage as create_file_storage;
+use solver_storage::implementations::memory::create_storage as create_memory_storage;
 
 /// Command-line arguments for the solver service.
 #[derive(Parser, Debug)]
@@ -88,14 +90,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn build_solver(config: Config) -> Result<SolverEngine, Box<dyn std::error::Error>> {
 	let builder = SolverBuilder::new(config)
         // Storage implementations
-        .with_storage_factory(create_storage)
+        .with_storage_factory(create_memory_storage)
         // Account implementations
         .with_account_factory(create_account)
         // Delivery implementations
         .with_delivery_factory("origin", create_http_delivery)
         .with_delivery_factory("destination", create_http_delivery)
         // Discovery implementations
-        .with_discovery_factory("origin_eip7683", create_discovery)
+        // .with_discovery_factory("onchain_eip7683", onchain_create_discovery)
+		// Discovery implementations
+		.with_discovery_factory("offchain_eip7683", offchain_create_discovery)
         // Order implementations
         .with_order_factory("eip7683", create_order_impl)
         // Settlement implementations

--- a/crates/solver-storage/Cargo.toml
+++ b/crates/solver-storage/Cargo.toml
@@ -8,5 +8,5 @@ async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.0", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["fs", "macros", "rt-multi-thread", "sync", "time"] }
 toml = "0.8"

--- a/crates/solver-storage/src/implementations/memory.rs
+++ b/crates/solver-storage/src/implementations/memory.rs
@@ -1,0 +1,198 @@
+//! In-memory storage backend implementation for the solver service.
+//!
+//! This module provides a memory-based implementation of the StorageInterface trait,
+//! useful for testing and development scenarios where persistence is not required.
+
+use crate::{StorageError, StorageInterface};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Entry in the memory storage with optional expiration.
+#[derive(Clone)]
+struct MemoryEntry {
+	/// The stored data.
+	data: Vec<u8>,
+	/// Optional expiration time.
+	expires_at: Option<Instant>,
+}
+
+/// In-memory storage implementation.
+///
+/// This implementation stores data in a HashMap in memory,
+/// providing fast access but no persistence across restarts.
+pub struct MemoryStorage {
+	/// The in-memory store protected by a read-write lock.
+	store: Arc<RwLock<HashMap<String, MemoryEntry>>>,
+}
+
+impl MemoryStorage {
+	/// Creates a new MemoryStorage instance.
+	pub fn new() -> Self {
+		Self {
+			store: Arc::new(RwLock::new(HashMap::new())),
+		}
+	}
+
+	/// Removes expired entries from the store.
+	///
+	/// This is called internally during operations to clean up expired data.
+	async fn cleanup_expired(&self) {
+		let now = Instant::now();
+		let mut store = self.store.write().await;
+		store.retain(|_, entry| entry.expires_at.is_none() || entry.expires_at.unwrap() > now);
+	}
+}
+
+impl Default for MemoryStorage {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[async_trait]
+impl StorageInterface for MemoryStorage {
+	async fn get_bytes(&self, key: &str) -> Result<Vec<u8>, StorageError> {
+		// Clean up expired entries periodically
+		self.cleanup_expired().await;
+
+		let store = self.store.read().await;
+		match store.get(key) {
+			Some(entry) => {
+				// Check if entry has expired
+				if let Some(expires_at) = entry.expires_at {
+					if expires_at <= Instant::now() {
+						return Err(StorageError::NotFound);
+					}
+				}
+				Ok(entry.data.clone())
+			}
+			None => Err(StorageError::NotFound),
+		}
+	}
+
+	async fn set_bytes(
+		&self,
+		key: &str,
+		value: Vec<u8>,
+		ttl: Option<Duration>,
+	) -> Result<(), StorageError> {
+		let expires_at = ttl.map(|duration| Instant::now() + duration);
+		let entry = MemoryEntry {
+			data: value,
+			expires_at,
+		};
+
+		let mut store = self.store.write().await;
+		store.insert(key.to_string(), entry);
+		Ok(())
+	}
+
+	async fn delete(&self, key: &str) -> Result<(), StorageError> {
+		let mut store = self.store.write().await;
+		store.remove(key);
+		Ok(())
+	}
+
+	async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+		let store = self.store.read().await;
+		match store.get(key) {
+			Some(entry) => {
+				// Check if entry has expired
+				if let Some(expires_at) = entry.expires_at {
+					Ok(expires_at > Instant::now())
+				} else {
+					Ok(true)
+				}
+			}
+			None => Ok(false),
+		}
+	}
+}
+
+/// Factory function to create a memory storage backend from configuration.
+///
+/// Configuration parameters:
+/// - None required for memory storage
+pub fn create_storage(_config: &toml::Value) -> Box<dyn StorageInterface> {
+	Box::new(MemoryStorage::new())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+	use tokio::time::sleep;
+
+	#[tokio::test]
+	async fn test_basic_operations() {
+		let storage = MemoryStorage::new();
+
+		// Test set and get
+		let key = "test_key";
+		let value = b"test_value".to_vec();
+		storage.set_bytes(key, value.clone(), None).await.unwrap();
+
+		let retrieved = storage.get_bytes(key).await.unwrap();
+		assert_eq!(retrieved, value);
+
+		// Test exists
+		assert!(storage.exists(key).await.unwrap());
+
+		// Test delete
+		storage.delete(key).await.unwrap();
+		assert!(!storage.exists(key).await.unwrap());
+
+		// Test get after delete
+		let result = storage.get_bytes(key).await;
+		assert!(matches!(result, Err(StorageError::NotFound)));
+	}
+
+	#[tokio::test]
+	async fn test_ttl() {
+		let storage = MemoryStorage::new();
+
+		// Set with short TTL
+		let key = "ttl_key";
+		let value = b"ttl_value".to_vec();
+		let ttl = Duration::from_millis(100);
+		storage
+			.set_bytes(key, value.clone(), Some(ttl))
+			.await
+			.unwrap();
+
+		// Should exist immediately
+		assert!(storage.exists(key).await.unwrap());
+		let retrieved = storage.get_bytes(key).await.unwrap();
+		assert_eq!(retrieved, value);
+
+		// Wait for expiration
+		sleep(Duration::from_millis(150)).await;
+
+		// Should no longer exist
+		assert!(!storage.exists(key).await.unwrap());
+		let result = storage.get_bytes(key).await;
+		assert!(matches!(result, Err(StorageError::NotFound)));
+	}
+
+	#[tokio::test]
+	async fn test_overwrite() {
+		let storage = MemoryStorage::new();
+
+		let key = "overwrite_key";
+		let value1 = b"value1".to_vec();
+		let value2 = b"value2".to_vec();
+
+		// Set initial value
+		storage.set_bytes(key, value1.clone(), None).await.unwrap();
+		let retrieved = storage.get_bytes(key).await.unwrap();
+		assert_eq!(retrieved, value1);
+
+		// Overwrite with new value
+		storage.set_bytes(key, value2.clone(), None).await.unwrap();
+		let retrieved = storage.get_bytes(key).await.unwrap();
+		assert_eq!(retrieved, value2);
+	}
+}

--- a/crates/solver-storage/src/lib.rs
+++ b/crates/solver-storage/src/lib.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 /// Re-export implementations
 pub mod implementations {
 	pub mod file;
+	pub mod memory;
 }
 
 /// Errors that can occur during storage operations.

--- a/crates/solver-types/src/discovery.rs
+++ b/crates/solver-types/src/discovery.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub struct Intent {
 	/// Unique identifier for this intent.
 	pub id: String,
-	/// Source from which this intent was discovered (e.g., "eip7683").
+	/// Source from which this intent was discovered (e.g., "on-chain").
 	pub source: String,
 	/// Standard this intent conforms to (e.g., "eip7683").
 	pub standard: String,

--- a/crates/solver-types/src/events.rs
+++ b/crates/solver-types/src/events.rs
@@ -40,6 +40,12 @@ pub enum DiscoveryEvent {
 /// Events related to order processing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OrderEvent {
+	/// An order is being prepared for execution (e.g., openFor for off-chain orders).
+	Preparing {
+		intent: Intent,
+		order: Order,
+		params: ExecutionParams,
+	},
 	/// An order is being executed with the specified parameters.
 	Executing {
 		order: Order,
@@ -95,6 +101,8 @@ pub enum SettlementEvent {
 /// Types of transactions in the solver system.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum TransactionType {
+	/// Transaction that prepares an off-chain order on-chain (e.g., openFor).
+	Prepare,
 	/// Transaction that fills an order on the destination chain.
 	Fill,
 	/// Transaction that claims rewards on the origin chain.

--- a/crates/solver-types/src/lib.rs
+++ b/crates/solver-types/src/lib.rs
@@ -14,6 +14,8 @@ pub mod discovery;
 pub mod events;
 /// Order processing types including intents, orders, and execution contexts.
 pub mod order;
+/// Standard-specific types for different cross-chain protocols.
+pub mod standards;
 /// Configuration validation types for ensuring type-safe configurations.
 pub mod validation;
 
@@ -23,4 +25,5 @@ pub use delivery::*;
 pub use discovery::*;
 pub use events::*;
 pub use order::*;
+pub use standards::*;
 pub use validation::*;

--- a/crates/solver-types/src/standards/eip7683.rs
+++ b/crates/solver-types/src/standards/eip7683.rs
@@ -1,0 +1,66 @@
+//! EIP-7683 Cross-Chain Order Types
+//!
+//! This module defines the data structures for EIP-7683 cross-chain orders
+//! that are shared across the solver system.
+
+use alloy_primitives::U256;
+use serde::{Deserialize, Serialize};
+
+/// EIP-7683 specific order data structure.
+///
+/// Contains all the necessary information for processing a cross-chain order
+/// according to the EIP-7683 standard. This structure supports both on-chain
+/// and off-chain order types, with optional fields for off-chain specific data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Eip7683OrderData {
+	/// The address of the user initiating the cross-chain order
+	pub user: String,
+	/// Unique nonce to prevent order replay attacks
+	pub nonce: u64,
+	/// Chain ID where the order originates
+	pub origin_chain_id: u64,
+	/// Chain ID where the order should be filled
+	pub destination_chain_id: u64,
+	/// Unix timestamp when the order expires
+	pub expires: u32,
+	/// Deadline by which the order must be filled
+	pub fill_deadline: u32,
+	/// Address of the oracle responsible for validating fills
+	pub local_oracle: String,
+	/// Input tokens and amounts as tuples of [token_address, amount]
+	pub inputs: Vec<[U256; 2]>,
+	/// Unique 32-byte identifier for the order
+	pub order_id: [u8; 32],
+	/// Gas limit for settlement transaction
+	pub settle_gas_limit: u64,
+	/// Gas limit for fill transaction
+	pub fill_gas_limit: u64,
+	/// List of outputs specifying tokens, amounts, and recipients
+	pub outputs: Vec<Output>,
+	/// Optional raw order data for off-chain orders
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub raw_order_data: Option<String>,
+	/// Optional type identifier for off-chain order data format
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub order_data_type: Option<[u8; 32]>,
+	/// Optional signature for off-chain order validation
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub signature: Option<String>,
+}
+
+/// Represents an output in an EIP-7683 cross-chain order.
+///
+/// Outputs define the tokens and amounts that should be received by recipients
+/// as a result of executing the cross-chain order. Each output can specify
+/// a different chain, allowing for multi-chain settlement patterns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Output {
+	/// The address of the token to be received
+	pub token: String,
+	/// The amount of tokens to be received
+	pub amount: U256,
+	/// The address that should receive the tokens
+	pub recipient: String,
+	/// The chain ID where the output should be delivered
+	pub chain_id: u64,
+}

--- a/crates/solver-types/src/standards/mod.rs
+++ b/crates/solver-types/src/standards/mod.rs
@@ -1,0 +1,15 @@
+//! Standard-specific types for different cross-chain protocols.
+//!
+//! This module contains data structures and types specific to various
+//! cross-chain order standards. Currently supports:
+//!
+//! - **EIP-7683**: Cross-chain order standard for intent-based bridging
+//!
+//! Each standard module provides its own type definitions that conform
+//! to the respective protocol specifications.
+
+/// EIP-7683 cross-chain order types
+pub mod eip7683;
+
+// Re-export commonly used types for convenience
+pub use eip7683::{Eip7683OrderData, Output as Eip7683Output};

--- a/scripts/demo/send_offchain_intent.sh
+++ b/scripts/demo/send_offchain_intent.sh
@@ -1,0 +1,526 @@
+#!/bin/bash
+# send_offchain_intent.sh - Send a test intent via the offchain API
+#
+# This script creates an off-chain EIP-7683 cross-chain intent by submitting it to the
+# solver's HTTP API. This demonstrates the gasless flow where users sign intents off-chain.
+#
+# FLOW:
+# 1. Load configuration:
+#    - Read deployed contract addresses from config/demo.toml
+#    - Set up API endpoint (http://localhost:8081/intent)
+#
+# 2. Approve Permit2:
+#    - Check if user has approved Permit2 to spend TEST tokens
+#    - If not, approve max amount for Permit2 contract
+#    - This is a one-time setup per token
+#
+# 3. Build order data:
+#    - Create same MandateERC7683 struct as on-chain flow
+#    - Set deadlines (5 min open deadline, 1 hour fill deadline)
+#    - Encode cross-chain transfer details
+#
+# 4. Generate EIP-712 signature:
+#    - Create typed data for PermitBatchWitnessTransferFrom
+#    - Include GaslessCrossChainOrder as witness data
+#    - Sign with user's private key following EIP-712 standard
+#    - This authorizes Permit2 to transfer tokens when order is opened
+#
+# 5. Submit to API:
+#    - POST the signed order to the discovery API
+#    - API validates the order and signature
+#    - API calls InputSettler to compute order ID
+#    - Intent is broadcast to solver for fulfillment
+#
+# KEY DIFFERENCES FROM ON-CHAIN:
+#   - No gas needed for intent creation
+#   - Uses Permit2 for token transfers
+#   - Requires EIP-712 signature
+#   - Submitted via HTTP instead of direct contract call
+#
+# PREREQUISITES:
+#   - Run ./setup_local_anvil.sh first
+#   - Solver service must be running with offchain discovery enabled
+#
+# USAGE:
+#   ./send_offchain_intent.sh
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}📤 Sending EIP-7683 Intent via Offchain API${NC}"
+echo "========================================="
+
+# Check if config exists
+if [ ! -f "config/demo.toml" ]; then
+    echo -e "${RED}❌ Configuration not found!${NC}"
+    echo -e "${YELLOW}💡 Run './setup_local_anvil.sh' first${NC}"
+    exit 1
+fi
+
+# Extract addresses from config
+INPUT_SETTLER_ADDRESS=$(grep 'input_settler_address = ' config/demo.toml | cut -d'"' -f2)
+OUTPUT_SETTLER_ADDRESS=$(grep 'output_settler_address = ' config/demo.toml | cut -d'"' -f2)
+SOLVER_ADDR=$(grep 'solver_address = ' config/demo.toml | cut -d'"' -f2)
+ORACLE_ADDRESS=$(grep 'oracle_address = ' config/demo.toml | cut -d'"' -f2)
+ORIGIN_TOKEN_ADDRESS=$(grep -A 10 '\[contracts.origin\]' config/demo.toml | grep 'token = ' | cut -d'"' -f2)
+DEST_TOKEN_ADDRESS=$(grep -A 10 '\[contracts.destination\]' config/demo.toml | grep 'token = ' | cut -d'"' -f2)
+USER_ADDR=$(grep -A 10 '\[accounts\]' config/demo.toml | grep 'user = ' | cut -d'"' -f2)
+RECIPIENT_ADDR=$(grep -A 10 '\[accounts\]' config/demo.toml | grep 'recipient = ' | cut -d'"' -f2)
+
+# API endpoint
+API_URL="http://localhost:8081/intent"
+
+# Amount in wei (1 token = 1e18 wei)
+AMOUNT="1000000000000000000"
+
+# Calculate timestamps
+CURRENT_TIME=$(date +%s)
+OPEN_DEADLINE=$((CURRENT_TIME + 300))  # 5 minutes from now
+FILL_DEADLINE=$((CURRENT_TIME + 3600)) # 1 hour from now
+
+# Function to approve tokens for Permit2
+approve_permit2() {
+    local PERMIT2_ADDRESS="0x000000000022D473030F116dDEE9F6B43aC78BA3"
+    
+    echo -e "${BLUE}🔐 Checking Permit2 allowance...${NC}"
+    
+    # Check current allowance
+    CURRENT_ALLOWANCE=$(cast call "$ORIGIN_TOKEN_ADDRESS" \
+        "allowance(address,address)" \
+        "$USER_ADDR" \
+        "$PERMIT2_ADDRESS" \
+        --rpc-url http://localhost:8545)
+    
+    if [ "$CURRENT_ALLOWANCE" = "0x0000000000000000000000000000000000000000000000000000000000000000" ]; then
+        echo -e "${BLUE}   Insufficient allowance, approving Permit2...${NC}"
+        
+        # Get user private key
+        USER_KEY=$(grep 'user_private_key = ' config/demo.toml | cut -d'"' -f2)
+        
+        # Approve max amount
+        TX_HASH=$(cast send "$ORIGIN_TOKEN_ADDRESS" \
+            "approve(address,uint256)" \
+            "$PERMIT2_ADDRESS" \
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" \
+            --private-key "$USER_KEY" \
+            --rpc-url http://localhost:8545 \
+            --json | jq -r '.transactionHash')
+        
+        echo -e "${GREEN}✅ Permit2 approved (tx: ${TX_HASH:0:10}...)${NC}"
+    else
+        echo -e "${GREEN}✅ Sufficient allowance already exists${NC}"
+    fi
+}
+
+# Approve Permit2 if needed
+approve_permit2
+
+# Build order data (same structure as send_onchain_intent.sh)
+build_order_data() {
+    # Calculate expiry (1 hour from now)
+    EXPIRY=$((CURRENT_TIME + 3600))
+    
+    # Convert values to hex format
+    AMOUNT_HEX=$(printf "%064x" $AMOUNT)
+    EXPIRY_HEX=$(printf "%064x" $EXPIRY)
+    
+    # Remove 0x prefix and pad addresses to 32 bytes
+    ORIGIN_TOKEN_BYTES32="000000000000000000000000${ORIGIN_TOKEN_ADDRESS:2}"
+    DEST_TOKEN_BYTES32="000000000000000000000000${DEST_TOKEN_ADDRESS:2}"
+    RECIPIENT_BYTES32="000000000000000000000000${RECIPIENT_ADDR:2}"
+    ORACLE_BYTES32="000000000000000000000000${ORACLE_ADDRESS:2}"
+    
+    # Build MandateERC7683 struct
+    ORDER_DATA="0x"
+    
+    # Offset to struct (32 bytes)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000020"
+    
+    # expiry (uint32 padded to 32 bytes)
+    ORDER_DATA="${ORDER_DATA}${EXPIRY_HEX}"
+    
+    # localOracle
+    ORDER_DATA="${ORDER_DATA}${ORACLE_BYTES32}"
+    
+    # offset to inputs array (0x80 = 128 bytes from struct start)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000080"
+    
+    # offset to outputs array (0xe0 = 224 bytes from struct start)
+    ORDER_DATA="${ORDER_DATA}00000000000000000000000000000000000000000000000000000000000000e0"
+    
+    # inputs array: 1 input
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000001"
+    
+    # Input struct: (token, amount)
+    ORDER_DATA="${ORDER_DATA}${ORIGIN_TOKEN_BYTES32}"
+    ORDER_DATA="${ORDER_DATA}${AMOUNT_HEX}"
+    
+    # outputs array: 1 output  
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000001"
+    
+    # offset to first output (0x20 = 32 bytes from outputs array start)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000020"
+    
+    # MandateOutput struct:
+    # oracle (bytes32) - zero for same-chain
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000000"
+    
+    # settler (bytes32) - use OutputSettler on destination chain
+    OUTPUT_SETTLER_BYTES32="000000000000000000000000${OUTPUT_SETTLER_ADDRESS:2}"
+    ORDER_DATA="${ORDER_DATA}${OUTPUT_SETTLER_BYTES32}"
+    
+    # chainId - destination chain (31338)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000007a6a"
+    
+    # token (bytes32) - destination token
+    ORDER_DATA="${ORDER_DATA}${DEST_TOKEN_BYTES32}"
+    
+    # amount - same amount
+    ORDER_DATA="${ORDER_DATA}${AMOUNT_HEX}"
+    
+    # recipient (bytes32)
+    ORDER_DATA="${ORDER_DATA}${RECIPIENT_BYTES32}"
+    
+    # offset to call data (0x100 = 256 bytes from output struct start)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000100"
+    
+    # offset to context data (0x120 = 288 bytes from output struct start)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000120"
+    
+    # call data - empty (length = 0)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000000"
+    
+    # context data - empty (length = 0)
+    ORDER_DATA="${ORDER_DATA}0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+# Build the order data
+build_order_data
+
+# EIP-712 typehash for MandateERC7683
+ORDER_DATA_TYPE="0x532668680e4ed97945ec5ed6aee3633e99abe764fd2d2861903dc7c109b00e82"
+
+# Generate a random nonce
+NONCE=$((RANDOM + 1000))
+
+# Create JSON payload
+JSON_PAYLOAD=$(cat <<EOF
+{
+  "order": {
+    "originSettler": "$INPUT_SETTLER_ADDRESS",
+    "user": "$USER_ADDR",
+    "nonce": "$NONCE",
+    "originChainId": "31337",
+    "openDeadline": $OPEN_DEADLINE,
+    "fillDeadline": $FILL_DEADLINE,
+    "orderDataType": "$ORDER_DATA_TYPE",
+    "orderData": "$ORDER_DATA"
+  },
+  "signature": null,
+  "quote_id": null,
+  "provider": "OIF-Solver"
+}
+EOF
+)
+
+echo -e "${BLUE}📋 Order Details:${NC}"
+echo -e "   Origin Settler: $INPUT_SETTLER_ADDRESS"
+echo -e "   User: $USER_ADDR"
+echo -e "   Recipient: $RECIPIENT_ADDR"
+echo -e "   Amount: 1.0 TEST tokens"
+echo -e "   Origin Chain: 31337"
+echo -e "   Dest Chain: 31338"
+echo -e "   Open Deadline: $(date -r $OPEN_DEADLINE 2>/dev/null || date -d @$OPEN_DEADLINE)"
+echo -e "   Fill Deadline: $(date -r $FILL_DEADLINE 2>/dev/null || date -d @$FILL_DEADLINE)"
+
+echo ""
+echo -e "${YELLOW}🔏 Generating EIP-712 signature...${NC}"
+
+# Get user private key from config
+USER_PRIVATE_KEY=$(grep 'user_private_key = ' config/demo.toml | cut -d'"' -f2)
+
+# Create EIP-712 typed data JSON for cast
+create_eip712_json() {
+    cat <<EOF
+{
+  "types": {
+    "EIP712Domain": [
+      {"name": "name", "type": "string"},
+      {"name": "chainId", "type": "uint256"},
+      {"name": "verifyingContract", "type": "address"}
+    ],
+    "PermitBatchWitnessTransferFrom": [
+      {"name": "permitted", "type": "TokenPermissions[]"},
+      {"name": "spender", "type": "address"},
+      {"name": "nonce", "type": "uint256"},
+      {"name": "deadline", "type": "uint256"},
+      {"name": "witness", "type": "GaslessCrossChainOrder"}
+    ],
+    "TokenPermissions": [
+      {"name": "token", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ],
+    "GaslessCrossChainOrder": [
+      {"name": "originSettler", "type": "address"},
+      {"name": "user", "type": "address"},
+      {"name": "nonce", "type": "uint256"},
+      {"name": "originChainId", "type": "uint256"},
+      {"name": "openDeadline", "type": "uint32"},
+      {"name": "fillDeadline", "type": "uint32"},
+      {"name": "orderDataType", "type": "bytes32"},
+      {"name": "orderData", "type": "MandateERC7683"}
+    ],
+    "MandateERC7683": [
+      {"name": "expiry", "type": "uint32"},
+      {"name": "localOracle", "type": "address"},
+      {"name": "inputs", "type": "uint256[2][]"},
+      {"name": "outputs", "type": "MandateOutput[]"}
+    ],
+    "MandateOutput": [
+      {"name": "oracle", "type": "bytes32"},
+      {"name": "settler", "type": "bytes32"},
+      {"name": "chainId", "type": "uint256"},
+      {"name": "token", "type": "bytes32"},
+      {"name": "amount", "type": "uint256"},
+      {"name": "recipient", "type": "bytes32"},
+      {"name": "callData", "type": "bytes"},
+      {"name": "contextData", "type": "bytes"}
+    ]
+  },
+  "primaryType": "PermitBatchWitnessTransferFrom",
+  "domain": {
+    "name": "Permit2",
+    "chainId": 31337,
+    "verifyingContract": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  },
+  "message": {
+    "permitted": [
+      {
+        "token": "$ORIGIN_TOKEN_ADDRESS",
+        "amount": "$AMOUNT"
+      }
+    ],
+    "spender": "$INPUT_SETTLER_ADDRESS",
+    "nonce": "$NONCE",
+    "deadline": $OPEN_DEADLINE,
+    "witness": {
+      "originSettler": "$INPUT_SETTLER_ADDRESS",
+      "user": "$USER_ADDR",
+      "nonce": "$NONCE",
+      "originChainId": "31337",
+      "openDeadline": $OPEN_DEADLINE,
+      "fillDeadline": $FILL_DEADLINE,
+      "orderDataType": "$ORDER_DATA_TYPE",
+      "orderData": {
+        "expiry": $EXPIRY,
+        "localOracle": "$ORACLE_ADDRESS",
+        "inputs": [
+          ["$((0x$ORIGIN_TOKEN_BYTES32))", "$AMOUNT"]
+        ],
+        "outputs": [
+          {
+            "oracle": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "settler": "0x$OUTPUT_SETTLER_BYTES32",
+            "chainId": "31338",
+            "token": "0x$DEST_TOKEN_BYTES32",
+            "amount": "$AMOUNT",
+            "recipient": "0x$RECIPIENT_BYTES32",
+            "callData": "0x",
+            "contextData": "0x"
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+}
+
+# Save EIP-712 data to a temporary file
+EIP712_FILE="/tmp/eip712_order_$$.json"
+create_eip712_json > "$EIP712_FILE"
+
+# Compute proper EIP-712 signature
+echo -e "${BLUE}Computing EIP-712 signature...${NC}"
+
+# Clean up the temp file since we won't use it
+rm -f "$EIP712_FILE"
+
+# Compute type hashes based on the contract definitions
+# From MandateOutputType.sol - MANDATE_OUTPUT_TYPE_STUB
+MANDATE_OUTPUT_TYPE="MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes call,bytes context)"
+MANDATE_OUTPUT_TYPE_HASH=$(cast keccak "$MANDATE_OUTPUT_TYPE")
+
+# From Order7683Type.sol - CATALYST_WITNESS_TYPE
+MANDATE_ERC7683_TYPE="MandateERC7683(uint32 expiry,address localOracle,uint256[2][] inputs,MandateOutput[] outputs)${MANDATE_OUTPUT_TYPE}"
+MANDATE_ERC7683_TYPE_HASH=$(cast keccak "$MANDATE_ERC7683_TYPE")
+
+# From Order7683Type.sol - ERC7683_GASLESS_CROSS_CHAIN_ORDER  
+GASLESS_ORDER_TYPE="GaslessCrossChainOrder(address originSettler,address user,uint256 nonce,uint256 originChainId,uint32 openDeadline,uint32 fillDeadline,bytes32 orderDataType,MandateERC7683 orderData)${MANDATE_ERC7683_TYPE}"
+GASLESS_ORDER_TYPE_HASH=$(cast keccak "$GASLESS_ORDER_TYPE")
+
+TOKEN_PERMISSIONS_TYPE="TokenPermissions(address token,uint256 amount)"
+TOKEN_PERMISSIONS_TYPE_HASH=$(cast keccak "$TOKEN_PERMISSIONS_TYPE")
+
+# From Order7683Type.sol - PERMIT2_ERC7683_GASLESS_CROSS_CHAIN_ORDER
+# The format for Permit2 is different - it includes "GaslessCrossChainOrder witness)" then the types
+PERMIT_BATCH_WITNESS_STRING="PermitBatchWitnessTransferFrom(TokenPermissions[] permitted,address spender,uint256 nonce,uint256 deadline,GaslessCrossChainOrder witness)${GASLESS_ORDER_TYPE}${TOKEN_PERMISSIONS_TYPE}"
+PERMIT_BATCH_WITNESS_TYPE_HASH=$(cast keccak "$PERMIT_BATCH_WITNESS_STRING")
+
+# Domain separator for Permit2
+DOMAIN_TYPE_HASH=$(cast keccak "EIP712Domain(string name,uint256 chainId,address verifyingContract)")
+PERMIT2_NAME_HASH=$(cast keccak "Permit2")
+DOMAIN_SEPARATOR=$(cast abi-encode "f(bytes32,bytes32,uint256,address)" "$DOMAIN_TYPE_HASH" "$PERMIT2_NAME_HASH" "31337" "0x000000000022D473030F116dDEE9F6B43aC78BA3")
+DOMAIN_SEPARATOR_HASH=$(cast keccak "$DOMAIN_SEPARATOR")
+
+
+# Helper function to compute hash of MandateOutput
+compute_mandate_output_hash() {
+    local oracle="0x0000000000000000000000000000000000000000000000000000000000000000"
+    local settler="0x000000000000000000000000${OUTPUT_SETTLER_ADDRESS:2}"
+    local chainId="31338"
+    local token="0x000000000000000000000000${DEST_TOKEN_ADDRESS:2}"
+    local amount="$AMOUNT"
+    local recipient="0x000000000000000000000000${RECIPIENT_ADDR:2}"
+    # For empty bytes, keccak256("") = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+    local callDataHash="0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    local contextDataHash="0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    
+    
+    # Encode MandateOutput struct
+    local encoded=$(cast abi-encode "f(bytes32,bytes32,bytes32,uint256,bytes32,uint256,bytes32,bytes32,bytes32)" \
+        "$MANDATE_OUTPUT_TYPE_HASH" \
+        "$oracle" \
+        "$settler" \
+        "$chainId" \
+        "$token" \
+        "$amount" \
+        "$recipient" \
+        "$callDataHash" \
+        "$contextDataHash")
+    
+    cast keccak "$encoded"
+}
+
+# Compute outputs array hash
+# For MandateOutputType.hashOutputsM with single output: keccak256(outputHash)
+MANDATE_OUTPUT_HASH=$(compute_mandate_output_hash)
+OUTPUTS_HASH=$(cast keccak "$MANDATE_OUTPUT_HASH")
+
+# Compute inputs array hash using abi.encodePacked
+# For a single input [token, amount], we pack them together
+INPUT_TOKEN_PADDED="000000000000000000000000${ORIGIN_TOKEN_ADDRESS:2}"
+# Pack the array element (token as uint256, amount as uint256)
+AMOUNT_HEX=$(printf '%064x' $AMOUNT)
+INPUTS_PACKED="${INPUT_TOKEN_PADDED}${AMOUNT_HEX}"
+INPUTS_HASH=$(cast keccak "0x$INPUTS_PACKED")
+
+# Compute MandateERC7683 hash
+ORDER_DATA_ENCODED=$(cast abi-encode "f(bytes32,uint32,address,bytes32,bytes32)" \
+    "$MANDATE_ERC7683_TYPE_HASH" \
+    "$EXPIRY" \
+    "$ORACLE_ADDRESS" \
+    "$INPUTS_HASH" \
+    "$OUTPUTS_HASH")
+ORDER_DATA_HASH=$(cast keccak "$ORDER_DATA_ENCODED")
+
+# Compute GaslessCrossChainOrder hash (witness hash)
+GASLESS_ORDER_ENCODED=$(cast abi-encode "f(bytes32,address,address,uint256,uint256,uint32,uint32,bytes32,bytes32)" \
+    "$GASLESS_ORDER_TYPE_HASH" \
+    "$INPUT_SETTLER_ADDRESS" \
+    "$USER_ADDR" \
+    "$NONCE" \
+    "31337" \
+    "$OPEN_DEADLINE" \
+    "$FILL_DEADLINE" \
+    "$ORDER_DATA_TYPE" \
+    "$ORDER_DATA_HASH")
+GASLESS_ORDER_HASH=$(cast keccak "$GASLESS_ORDER_ENCODED")
+
+# Compute TokenPermissions hash
+TOKEN_PERM_ENCODED=$(cast abi-encode "f(bytes32,address,uint256)" \
+    "$TOKEN_PERMISSIONS_TYPE_HASH" \
+    "$ORIGIN_TOKEN_ADDRESS" \
+    "$AMOUNT")
+TOKEN_PERM_HASH=$(cast keccak "$TOKEN_PERM_ENCODED")
+
+# The witness hash is the GaslessCrossChainOrder hash
+WITNESS_HASH="$GASLESS_ORDER_HASH"
+
+# Compute PermitBatchWitnessTransferFrom struct with array hashes
+PERMITTED_ARRAY_HASH=$(cast keccak "$TOKEN_PERM_HASH")
+
+# The main struct for signing includes the array hash
+MAIN_STRUCT_ENCODED=$(cast abi-encode "f(bytes32,bytes32,address,uint256,uint256,bytes32)" \
+    "$PERMIT_BATCH_WITNESS_TYPE_HASH" \
+    "$PERMITTED_ARRAY_HASH" \
+    "$INPUT_SETTLER_ADDRESS" \
+    "$NONCE" \
+    "$OPEN_DEADLINE" \
+    "$WITNESS_HASH")
+MAIN_STRUCT_HASH=$(cast keccak "$MAIN_STRUCT_ENCODED")
+
+# Create final digest
+DIGEST_PREFIX="0x1901"
+DIGEST="${DIGEST_PREFIX}${DOMAIN_SEPARATOR_HASH:2}${MAIN_STRUCT_HASH:2}"
+FINAL_DIGEST=$(cast keccak "$DIGEST")
+
+# Sign the digest using --no-hash flag for EIP-712 signatures
+SIGNATURE=$(cast wallet sign --no-hash --private-key "$USER_PRIVATE_KEY" "$FINAL_DIGEST")
+SIGN_EXIT_CODE=$?
+
+# Check if signing succeeded
+if [ $SIGN_EXIT_CODE -ne 0 ] || [ -z "$SIGNATURE" ] || [ "$SIGNATURE" = "" ]; then
+    echo -e "${RED}❌ Signing failed!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✅ EIP-712 signature generated: $SIGNATURE${NC}"
+fi
+
+# Update JSON payload with signature
+JSON_PAYLOAD=$(echo "$JSON_PAYLOAD" | jq --arg sig "$SIGNATURE" '.signature = $sig')
+
+echo -e "${GREEN}✅ Signature added to order${NC}"
+
+echo ""
+echo -e "${BLUE}📄 Final JSON Payload:${NC}"
+echo "$JSON_PAYLOAD" | jq .
+
+echo ""
+echo -e "${YELLOW}🚀 Sending order to offchain API...${NC}"
+echo -e "   Endpoint: $API_URL"
+
+# Send the request
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -d "$JSON_PAYLOAD")
+
+# Extract HTTP status code and response body
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo -e "${GREEN}✅ Order submitted successfully!${NC}"
+    echo -e "   Response: $RESPONSE_BODY"
+    
+    # Extract order ID if available
+    ORDER_ID=$(echo "$RESPONSE_BODY" | grep -o '"order_id":"[^"]*"' | cut -d'"' -f4)
+    if [ -n "$ORDER_ID" ]; then
+        echo -e "${BLUE}   Order ID: $ORDER_ID${NC}"
+    fi
+else
+    echo -e "${RED}❌ Failed to submit order${NC}"
+    echo -e "   HTTP Status: $HTTP_CODE"
+    echo -e "   Response: $RESPONSE_BODY"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}🎉 Offchain Intent Submitted!${NC}"
+echo -e "${YELLOW}📡 The solver should discover this intent via the API${NC}"


### PR DESCRIPTION
This PR implements support for off-chain ERC-7683 gasless cross-chain orders, complementing the existing on-chain discovery mechanism. It adds an HTTP API endpoint that allows users to submit intents directly to the solver without requiring on-chain transactions.

The existing solver only supported on-chain intent discovery, which requires users to pay gas fees for submitting intents. This PR enables gasless intent submission, improving user experience and reducing costs for cross-chain operations. 

**Core Features**
- Off-chain Discovery API (`crates/solver-discovery/src/implementations/offchain/_7683.rs`)
  - New HTTP API server for receiving ERC-7683 gasless cross-chain orders
  - POST /intent endpoint for order submission
  - Order validation, signature verification, and settler contract integration
  - Configurable authentication via bearer tokens 
- Memory Storage (`crates/solver-storage/src/implementations/memory.rs`)
  - In-memory storage implementation for development and testing
- Enhanced Order Processing (`crates/solver-order/src/implementations/standards/_7683.rs`)
  - Extended support for gasless cross-chain orders
  - Improved order data parsing and validation

**Infrastructure Updates**

- Configuration
  - Updated `demo.toml` and `example.toml` with off-chain discovery settings
- Demo Scripts
  - New `send_offchain_intent.sh` for testing off-chain order submission

**Type System**

- Added EIP-7683 standard types (`crates/solver-types/src/standards/`)
- Extended discovery trait with off-chain support

**Testing**

The changes can be tested using the provided demo scripts:

```
# Set up local test environment
./scripts/demo/setup_local_anvil.sh

# Test off-chain intent submission
./scripts/demo/send_offchain_intent.sh
```