### PR TITLE
chore: Update endpoints syntax

### DIFF
--- a/config/demo.toml
+++ b/config/demo.toml
@@ -55,8 +55,8 @@ rpc_url = "http://localhost:8546"
 oracle_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
 dispute_period_seconds = 1
 # Domain configuration for EIP-712 signatures in quotes
-domain_chain_id = 1  # Ethereum mainnet 
-domain_address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+domain_chain_id = 1  # Ethereum mainnet
+domain_address = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
 
 # API server configuration
 [api]

--- a/crates/solver-service/src/apis/order.rs
+++ b/crates/solver-service/src/apis/order.rs
@@ -13,7 +13,7 @@ use solver_types::{
 };
 use tracing::info;
 
-/// Handles GET /order/{id} requests.
+/// Handles GET /orders/{id} requests.
 ///
 /// This endpoint retrieves order details by ID, providing status information
 /// and execution details for cross-chain intent orders.
@@ -182,10 +182,10 @@ async fn convert_eip7683_order_to_response(
 
 	// Create settlement data from the raw order data
 	let settlement_data = serde_json::json!({
-		"raw_order_data": order.data.get("raw_order_data").cloned().unwrap_or_else(|| serde_json::json!(null)),
-		"signature": order.data.get("signature").cloned().unwrap_or_else(|| serde_json::json!(null)),
-		"nonce": order.data.get("nonce").cloned().unwrap_or_else(|| serde_json::json!(null)),
-		"expires": order.data.get("expires").cloned().unwrap_or_else(|| serde_json::json!(null))
+		"raw_order_data": order.data.get("raw_order_data").cloned().unwrap_or(serde_json::json!(null)),
+		"signature": order.data.get("signature").cloned().unwrap_or(serde_json::json!(null)),
+		"nonce": order.data.get("nonce").cloned().unwrap_or(serde_json::json!(null)),
+		"expires": order.data.get("expires").cloned().unwrap_or(serde_json::json!(null))
 	});
 
 	// Try to retrieve fill transaction hash from storage

--- a/crates/solver-types/src/events.rs
+++ b/crates/solver-types/src/events.rs
@@ -69,13 +69,16 @@ pub enum DeliveryEvent {
 	},
 	/// A transaction has been confirmed on-chain.
 	TransactionConfirmed {
+		order_id: String,
 		tx_hash: TransactionHash,
-		receipt: TransactionReceipt,
 		tx_type: TransactionType,
+		receipt: TransactionReceipt,
 	},
 	/// A transaction has failed.
 	TransactionFailed {
+		order_id: String,
 		tx_hash: TransactionHash,
+		tx_type: TransactionType,
 		error: String,
 	},
 }

--- a/scripts/demo/setup_local_anvil.sh
+++ b/scripts/demo/setup_local_anvil.sh
@@ -342,6 +342,9 @@ max_gas_price_gwei = 100
 rpc_url = "http://localhost:$DEST_PORT"
 oracle_address = "$ORACLE"
 dispute_period_seconds = 1
+# Domain configuration for EIP-712 signatures in quotes
+domain_chain_id = 1  # Ethereum mainnet
+domain_address = "$INPUT_SETTLER"
 
 # API server configuration
 [api]

--- a/scripts/demo/test_quote_api.sh
+++ b/scripts/demo/test_quote_api.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Test script for the OIF Solver Quote API
-# This script demonstrates how to call the POST /quote endpoint
+# This script demonstrates how to call the POST /quotes endpoint
 # 
 # Note: All addresses use ERC-7930 Interoperable Address format:
 # - 0x010000011401742d35cc6634c0532925a3b8d4ad62d93b3d1234 = User address on Ethereum mainnet (chain ID 1)
@@ -12,7 +12,7 @@
 set -e
 
 API_URL="http://127.0.0.1:3000"
-QUOTE_ENDPOINT="$API_URL/api/quote"
+QUOTE_ENDPOINT="$API_URL/api/quotes"
 
 echo "Testing OIF Solver Quote API at $QUOTE_ENDPOINT"
 echo "================================================="


### PR DESCRIPTION
- Pluralize `/quote` and `/order` API to `/quotes` and `/orders`
- Remove redundant code
- Fix clippy warnings
- Add Solver `/api/orders` POST endpoint which forwards to `7683` off-chain discovery implementation