### PR TITLE
fix: Use simple nonce manager

### DIFF
--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
 use alloy_provider::{
-	fillers::{CachedNonceManager, ChainIdFiller, GasFiller, NonceFiller},
+	fillers::{ChainIdFiller, GasFiller, NonceFiller, SimpleNonceManager},
 	DynProvider, Provider, ProviderBuilder,
 };
 use alloy_rpc_client::RpcClient;
@@ -107,7 +107,7 @@ impl AlloyDelivery {
 
 			// Create provider with simple nonce management and retry capabilities
 			let provider = ProviderBuilder::new()
-				.filler(NonceFiller::new(CachedNonceManager::default()))
+				.filler(NonceFiller::new(SimpleNonceManager::default()))
 				.filler(GasFiller)
 				.filler(ChainIdFiller::default())
 				.wallet(wallet)

--- a/crates/solver-pricing/src/implementations/coingecko.rs
+++ b/crates/solver-pricing/src/implementations/coingecko.rs
@@ -473,7 +473,7 @@ impl PricingInterface for CoinGeckoPricing {
 			"Converted gas cost: {} wei = {} ETH = ${} USD (ETH price: ${})",
 			wei_amount,
 			eth_amount_str,
-			result.round_dp(2),
+			result.round_dp(8),
 			eth_price
 		);
 		Ok(result.round_dp(2).to_string())


### PR DESCRIPTION
# Summary

This PR switches from using a cached nonce manager to a simple nonce manager in the Alloy implementation for Ethereum transaction delivery. It also improves debug logging precision for gas cost calculations.

- Replace` CachedNonceManager` with `SimpleNonceManager` in the Alloy provider configuration

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
