### PR TITLE
chore: Use verified token address for Arbitrum mainnet

### DIFF
--- a/config/mainnet/networks.toml
+++ b/config/mainnet/networks.toml
@@ -28,7 +28,7 @@ allocator_address = "0xb8Eb0f7851B4F5E44cFE21C856FAb5A6378AD280"
 http = "https://arb1.arbitrum.io/rpc"
 
 [[networks.42161.tokens]]
-address = "0x36AC0B9F17815e80d9D271fd5081A83FD7c1804e"
+address = "0x7e13E59a15E4703a54a0976dDd970F8Fe52d3a76"
 symbol = "USDC"
 decimals = 6
 


### PR DESCRIPTION
# Summary

Switched unverified ERC20 token address to a verified token address for Arbitrum Mainnet. This should make it easier for users to mint using the explorer UI directly.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated USDC token address configuration to reflect current protocol requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->