### PR TITLE
feat: add admin whitelist endpoint and response structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ The admin API enables authorized wallet addresses to perform administrative oper
 - **DELETE `/api/v1/admin/tokens`** - Remove a token from a network (protected)
 - **POST `/api/v1/admin/tokens/approve`** - Approve token allowance for settlements (protected)
 - **POST `/api/v1/admin/withdrawals`** - Perform an admin withdrawal (protected)
+- **GET `/api/v1/admin/whitelist`** - List current admins (protected)
 - **POST `/api/v1/admin/whitelist`** - Add a new admin (protected)
 - **DELETE `/api/v1/admin/whitelist`** - Remove an admin (protected)
 - **GET `/api/v1/admin/fees`** - Get fee configuration (protected)
@@ -1063,6 +1064,10 @@ curl http://localhost:3000/api/v1/admin/balances \
 
 # Admin: Get solver config snapshot (protected)
 curl http://localhost:3000/api/v1/admin/config \
+  -H "Authorization: Bearer $TOKEN"
+
+# Admin: Get admin whitelist (protected)
+curl http://localhost:3000/api/v1/admin/whitelist \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/api-spec/admin-api.yaml
+++ b/api-spec/admin-api.yaml
@@ -175,6 +175,45 @@ paths:
                 $ref: "#/components/schemas/AdminAuthErrorResponse"
 
   /admin/whitelist:
+    get:
+      summary: Get admin whitelist
+      description: |
+        Returns the configured list of admin wallet addresses.
+      operationId: getAdminWhitelist
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current admin whitelist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminWhitelistResponse"
+              example:
+                admins:
+                  - "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+                  - "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
+                count: 2
+        "401":
+          description: Unauthorized (JWT failure)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAuthErrorResponse"
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAuthErrorResponse"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAuthErrorResponse"
     post:
       summary: Add an admin
       description: |
@@ -806,6 +845,26 @@ components:
           type: string
           description: Admin address
           example: "0x1234567890abcdef1234567890abcdef12345678"
+
+    AdminWhitelistResponse:
+      type: object
+      required:
+        - admins
+        - count
+      properties:
+        admins:
+          type: array
+          description: Configured admin wallet addresses
+          items:
+            type: string
+            pattern: "^0x[a-fA-F0-9]{40}$"
+          example:
+            - "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+            - "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
+        count:
+          type: integer
+          description: Number of configured admin wallet addresses
+          example: 2
 
     SignedAdminRequestAddToken:
       type: object

--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -27,9 +27,9 @@ use solver_storage::{
 };
 pub use solver_types::admin_api::{
 	AdminActionResponse, AdminConfigResponse, AdminConfigSummary, AdminNetworkResponse,
-	AdminSolverResponse, AdminTokenResponse, ApproveTokensResponse, BalancesResponse,
-	ChainBalances, Eip712Domain, Eip712TypeInfo, FeeConfigResponse, GasConfigResponse,
-	GasFlowResponse, NonceResponse, TokenBalance, WithdrawalResponse,
+	AdminSolverResponse, AdminTokenResponse, AdminWhitelistResponse, ApproveTokensResponse,
+	BalancesResponse, ChainBalances, Eip712Domain, Eip712TypeInfo, FeeConfigResponse,
+	GasConfigResponse, GasFlowResponse, NonceResponse, TokenBalance, WithdrawalResponse,
 };
 use solver_types::{
 	format_token_amount, with_0x_prefix, AdminConfig, OperatorAdminConfig, OperatorConfig,
@@ -317,6 +317,27 @@ pub async fn handle_get_gas(
 ) -> Result<Json<GasConfigResponse>, AdminAuthError> {
 	let versioned = state.config_store.get().await.map_err(config_store_error)?;
 	Ok(Json(gas_config_response(&versioned.data.gas)))
+}
+
+/// GET /api/v1/admin/whitelist
+///
+/// Returns the configured admin whitelist.
+pub async fn handle_get_whitelist(
+	State(state): State<AdminApiState>,
+) -> Result<Json<AdminWhitelistResponse>, AdminAuthError> {
+	let versioned = state.config_store.get().await.map_err(config_store_error)?;
+	let admins: Vec<String> = versioned
+		.data
+		.admin
+		.admin_addresses
+		.iter()
+		.map(|addr| with_0x_prefix(&hex::encode(addr.as_slice())))
+		.collect();
+
+	Ok(Json(AdminWhitelistResponse {
+		count: admins.len(),
+		admins,
+	}))
 }
 
 /// POST /api/v1/admin/whitelist
@@ -1364,6 +1385,22 @@ mod tests {
 
 		let json = serde_json::to_string(&response).unwrap();
 		assert!(json.contains("\"success\":true"));
+	}
+
+	#[test]
+	fn test_admin_whitelist_response_serialization() {
+		let response = AdminWhitelistResponse {
+			admins: vec![
+				"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".to_string(),
+				"0x70997970c51812dc3a010c7d01b50e0d17dc79c8".to_string(),
+			],
+			count: 2,
+		};
+
+		let json = serde_json::to_string(&response).unwrap();
+		assert!(json.contains("\"admins\""));
+		assert!(json.contains("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"));
+		assert!(json.contains("\"count\":2"));
 	}
 
 	#[test]
@@ -2500,6 +2537,31 @@ mod tests {
 		assert_eq!(response.expires_in, 300);
 		assert_eq!(response.domain, "test.example.com");
 		assert_eq!(response.chain_id, 1);
+	}
+
+	#[tokio::test]
+	async fn test_handle_get_whitelist_returns_configured_admins() {
+		let admin_one = alloy_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+		let admin_two = alloy_address("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+		let mut operator_config =
+			build_operator_config(admin_one, OperatorWithdrawalsConfig { enabled: false });
+		operator_config.admin.admin_addresses.push(admin_two);
+
+		let state = create_admin_state_with_operator_config(
+			operator_config,
+			create_delivery_service(None, false),
+		)
+		.await;
+		let response = handle_get_whitelist(State(state)).await.unwrap().0;
+
+		assert_eq!(response.count, 2);
+		assert_eq!(
+			response.admins,
+			vec![
+				"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".to_string(),
+				"0x70997970c51812dc3a010c7d01b50e0d17dc79c8".to_string(),
+			]
+		);
 	}
 
 	#[tokio::test]

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -7,8 +7,8 @@ use crate::{
 	apis::admin::{
 		handle_add_admin, handle_add_token, handle_add_tokens, handle_approve_tokens,
 		handle_get_balances, handle_get_config, handle_get_fees, handle_get_gas, handle_get_nonce,
-		handle_get_types, handle_remove_admin, handle_remove_token, handle_update_fees,
-		handle_update_gas, handle_withdrawal, AdminApiState,
+		handle_get_types, handle_get_whitelist, handle_remove_admin, handle_remove_token,
+		handle_update_fees, handle_update_gas, handle_withdrawal, AdminApiState,
 	},
 	apis::health::handle_health,
 	apis::order::get_order_by_id,
@@ -346,8 +346,12 @@ pub async fn start_server(
 			.route("/balances", get(handle_get_balances))
 			.route("/nonce", get(handle_get_nonce).post(handle_get_nonce))
 			.route("/types", get(handle_get_types))
-			.route("/whitelist", post(handle_add_admin))
-			.route("/whitelist", delete(handle_remove_admin))
+			.route(
+				"/whitelist",
+				get(handle_get_whitelist)
+					.post(handle_add_admin)
+					.delete(handle_remove_admin),
+			)
 			.route("/tokens/batch", post(handle_add_tokens))
 			.route("/tokens", post(handle_add_token))
 			.route("/tokens", delete(handle_remove_token))

--- a/crates/solver-types/src/admin_api.rs
+++ b/crates/solver-types/src/admin_api.rs
@@ -23,6 +23,14 @@ pub struct AdminActionResponse {
 	pub admin: String,
 }
 
+/// Response for reading the admin whitelist.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminWhitelistResponse {
+	pub admins: Vec<String>,
+	pub count: usize,
+}
+
 /// Response for balances across networks.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
- Introduced a new GET endpoint  to retrieve the list of current admin wallet addresses.
- Added  structure to define the response format, including the list of admins and their count.
- Updated the server routing to handle the new endpoint and integrated the corresponding handler function.
- Enhanced the README and API specification documentation to reflect the new functionality.

# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected API endpoint (GET /api/v1/admin/whitelist) that returns the configured admin wallet addresses and a count.

* **Documentation**
  * Updated Admin API docs with the new endpoint and an example curl demonstrating authenticated access.

* **Tests**
  * Added tests covering the whitelist response format and endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->