### PR TITLE
feat: 2 basefee multiplier

### DIFF
--- a/crates/solver-delivery/src/implementations/evm/fees.rs
+++ b/crates/solver-delivery/src/implementations/evm/fees.rs
@@ -37,12 +37,9 @@ impl ChainFeePolicy {
 }
 
 // Note: we deliberately do NOT carry an `average_block_time_ms` here.
-// The 1.25× base-fee projection in `SolverEip1559Estimator::estimate`
-// is "absorb one block of base-fee movement," which is roughly the same
-// per-block adjustment ratio across every EIP-1559 chain (the protocol
-// caps base-fee changes at 1.125×). If a future strategy needs a
-// per-chain projection multiplier, add the field then — not as
-// speculative config now.
+// The 2× base-fee projection in `SolverEip1559Estimator::estimate`
+// follows alloy's default headroom. If a future strategy needs a per-chain
+// projection multiplier, add the field then — not as speculative config now.
 
 /// Errors returned when parsing/validating a [`FeePolicyConfig`] into a
 /// [`FeePolicyRegistry`]. Each variant carries enough context (chain id,
@@ -253,10 +250,8 @@ impl SolverEip1559Estimator {
 			.max(self.policy.min_priority_fee_per_gas.unwrap_or(0))
 			.max(self.policy.priority_fee_fallback);
 
-		// Project base fee one block forward at 1.25x. We picked 1.25 over
-		// alloy's default 2x to avoid systematically over-quoting; rationale
-		// is documented in the Quote Cost Strategy section.
-		let projected_base = base_fee.saturating_mul(125) / 100;
+		// Project base fee forward using alloy's default 2x headroom.
+		let projected_base = base_fee.saturating_mul(2);
 		let raw_max = projected_base.saturating_add(priority);
 		let max_fee = self
 			.policy
@@ -305,6 +300,21 @@ mod tests {
 		let estimator = SolverEip1559Estimator { policy };
 		let est = estimator.estimate(30_000_000, &[]);
 		assert!(est.max_priority_fee_per_gas > 0);
+	}
+
+	#[test]
+	fn eip1559_estimator_projects_base_fee_at_2x() {
+		let policy = ChainFeePolicy::default_for_chain(1);
+		let estimator = SolverEip1559Estimator { policy };
+		let rewards = vec![vec![100_000_000u128]];
+		let base_fee = 500_000_000u128;
+
+		let est = estimator.estimate(base_fee, &rewards);
+
+		assert_eq!(
+			est.max_fee_per_gas,
+			base_fee.saturating_mul(2) + 100_000_000
+		);
 	}
 
 	#[test]

--- a/docs/fee-policy.md
+++ b/docs/fee-policy.md
@@ -149,7 +149,7 @@ This is what the actual transaction was signed with. For a single intent, expect
 - `max_priority_fee_per_gas` should match either:
   - your configured `min_priority_fee_per_gas` (when network is quieter than your floor), or
   - the percentile estimate from `eth_feeHistory` (when network is busier).
-- `max_fee_per_gas ≈ base_fee × 1.25 + max_priority_fee_per_gas`. If you set a `gas_price_cap` and the network is hot, expect `max_fee_per_gas == cap`.
+- `max_fee_per_gas ≈ base_fee × 2 + max_priority_fee_per_gas`. If you set a `gas_price_cap` and the network is hot, expect `max_fee_per_gas == cap`.
 - Quote-time and submit-time values for the same chain should match within the cache TTL window (3s mainnet, 1s Katana, 2s others). Mismatch beyond that = a fresh resolution between quote and submit.
 
 ## Troubleshooting


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated base-fee projection for gas fee estimation to use a 2x multiplier instead of the previous 1.25x calculation, resulting in more conservative maximum gas fee projections.

* **Documentation**
  * Updated fee policy guidance to reflect the new base-fee projection formula.

* **Tests**
  * Added test coverage for the updated base-fee projection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->