### PR TITLE
Implement background retry for token approvals on native gas shortfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,11 +858,12 @@ sequenceDiagram
 #### Health
 
 - **GET `/health`** - Health check endpoint
-  - Returns solver health status including Redis connectivity and persistence info
-  - Response:
+  - Returns solver health status including storage readiness, Redis persistence info, and startup readiness.
+  - **Steady-state response (fully operational):**
     ```json
     {
       "status": "healthy",
+      "storage": { "backend": "Redis", "ready": true, "checks": [], "details": {} },
       "redis": {
         "connected": true,
         "persistence_enabled": true,
@@ -870,10 +871,29 @@ sequenceDiagram
         "aof_enabled": false
       },
       "solver_id": "my-solver",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "startup": { "approvals_ready": true }
     }
     ```
-  - Status codes: `200 OK` (healthy), `503 Service Unavailable` (unhealthy)
+  - **While the signer needs native gas to complete startup approvals**, the API stays up and HTTP `200 OK` is returned, but `startup.approvals_ready` is `false` and `blocked_signers` lists the addresses that need funding. The solver retries approvals every 30 seconds and the field flips to `true` automatically once they succeed.
+    ```json
+    {
+      "status": "healthy",
+      "storage": { "backend": "Redis", "ready": true, "checks": [], "details": {} },
+      "redis": { "connected": true, "persistence_enabled": true, "rdb_enabled": true, "aof_enabled": false },
+      "solver_id": "my-solver",
+      "version": "0.1.0",
+      "startup": {
+        "approvals_ready": false,
+        "reason": "waiting_for_native_gas",
+        "blocked_signers": [
+          { "chain_id": 1, "signer": "0x3c0189...", "balance_wei": "0" }
+        ]
+      }
+    }
+    ```
+  - Frontends should branch on `startup.approvals_ready`, not on the HTTP status, to surface a "fund this address" prompt.
+  - Status codes: `200 OK` when storage is ready (regardless of startup readiness), `503 Service Unavailable` when storage or another core dependency is not ready.
 
 #### Admin API (Wallet-Based Authentication)
 

--- a/api-spec/health-api.yaml
+++ b/api-spec/health-api.yaml
@@ -1,0 +1,290 @@
+openapi: 3.0.3
+info:
+  title: OIF Solver Health API
+  description: |
+    Health check endpoint for the OIF Solver. Reports storage readiness,
+    Redis persistence status (when applicable), and startup readiness so
+    operators and frontends can detect process-up-but-not-yet-operational
+    states such as "waiting on signer to be funded with native gas".
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+    description: Local development server
+  - url: https://api.solver.example.com
+    description: Production server (replace with actual URL)
+
+paths:
+  /health:
+    get:
+      summary: Solver health check
+      description: |
+        Returns the solver's health, storage readiness, and startup readiness.
+
+        - `200 OK` indicates the API process is alive and storage is reachable.
+        - `503 Service Unavailable` indicates storage or another core dependency
+          is not ready.
+        - The `startup` block reports whether startup token approvals have
+          completed. While `approvals_ready: false`, the API is still up and
+          read-only/admin endpoints work, but submitted orders cannot be
+          filled until the listed signers are funded with native gas.
+      operationId: getHealth
+      tags:
+        - Health
+      responses:
+        "200":
+          description: |
+            Storage is ready. The response may still indicate that startup
+            approvals are pending (`startup.approvals_ready == false`).
+            Frontends should inspect `startup` to decide whether to surface a
+            "fund this address" prompt.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              examples:
+                healthy:
+                  summary: Fully operational
+                  value:
+                    status: "healthy"
+                    storage:
+                      backend: "Redis"
+                      ready: true
+                      checks: []
+                      details: {}
+                    redis:
+                      connected: true
+                      persistence_enabled: true
+                      rdb_enabled: true
+                      aof_enabled: false
+                    solver_id: "my-solver"
+                    version: "0.1.0"
+                    startup:
+                      approvals_ready: true
+                waiting_for_native_gas:
+                  summary: Process up, startup approvals deferred
+                  value:
+                    status: "healthy"
+                    storage:
+                      backend: "Redis"
+                      ready: true
+                      checks: []
+                      details: {}
+                    redis:
+                      connected: true
+                      persistence_enabled: true
+                      rdb_enabled: true
+                      aof_enabled: false
+                    solver_id: "my-solver"
+                    version: "0.1.0"
+                    startup:
+                      approvals_ready: false
+                      reason: "waiting_for_native_gas"
+                      blocked_signers:
+                        - chain_id: 1
+                          signer: "0x3c0189d526e484824881217322048c055cb20f29"
+                          balance_wei: "0"
+        "503":
+          description: |
+            Storage or another core dependency is not ready. The body still
+            includes the `startup` block when available so callers can
+            distinguish "storage broken" from "waiting on funding".
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: "unhealthy"
+                storage:
+                  backend: "Redis"
+                  ready: false
+                  checks: []
+                  details: {}
+                  error: "Connection refused"
+                redis:
+                  connected: false
+                  persistence_enabled: false
+                  rdb_enabled: false
+                  aof_enabled: false
+                  error: "Connection refused"
+                solver_id: "my-solver"
+                version: "0.1.0"
+                startup:
+                  approvals_ready: true
+
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      description: Solver health, storage readiness, and startup readiness.
+      required:
+        - status
+        - storage
+        - solver_id
+        - version
+        - startup
+      properties:
+        status:
+          type: string
+          enum: ["healthy", "unhealthy"]
+          description: |
+            Overall health status. `healthy` means storage is ready; the
+            startup block must be inspected separately to know whether
+            startup approvals have completed.
+          example: "healthy"
+        storage:
+          $ref: "#/components/schemas/StorageHealth"
+        redis:
+          $ref: "#/components/schemas/RedisHealth"
+          nullable: true
+          description: Present only when the storage backend is Redis.
+        solver_id:
+          type: string
+          description: Solver ID from configuration.
+          example: "my-solver"
+        version:
+          type: string
+          description: Application version.
+          example: "0.1.0"
+        startup:
+          $ref: "#/components/schemas/StartupReadiness"
+
+    StorageHealth:
+      type: object
+      description: Generic storage backend health.
+      required:
+        - backend
+        - ready
+        - checks
+        - details
+      properties:
+        backend:
+          type: string
+          description: Backend name.
+          example: "Redis"
+        ready:
+          type: boolean
+          description: Whether the backend is ready for operation.
+          example: true
+        checks:
+          type: array
+          description: Individual readiness checks.
+          items:
+            $ref: "#/components/schemas/ReadinessCheck"
+        details:
+          type: object
+          description: Additional details for debugging.
+          additionalProperties:
+            type: string
+        error:
+          type: string
+          nullable: true
+          description: Optional error message when readiness check failed.
+
+    ReadinessCheck:
+      type: object
+      required:
+        - name
+        - passed
+        - status
+      properties:
+        name:
+          type: string
+          example: "connectivity"
+        passed:
+          type: boolean
+          example: true
+        status:
+          type: string
+          example: "CONNECTED"
+        message:
+          type: string
+          nullable: true
+
+    RedisHealth:
+      type: object
+      description: Redis-specific health info, only populated for Redis backends.
+      required:
+        - connected
+        - persistence_enabled
+        - rdb_enabled
+        - aof_enabled
+      properties:
+        connected:
+          type: boolean
+          example: true
+        persistence_enabled:
+          type: boolean
+          description: True when either RDB or AOF persistence is enabled.
+          example: true
+        rdb_enabled:
+          type: boolean
+          example: true
+        aof_enabled:
+          type: boolean
+          example: false
+        error:
+          type: string
+          nullable: true
+
+    StartupReadiness:
+      type: object
+      description: |
+        Whether the solver completed its startup token approvals.
+        `approvals_ready: true` is the steady state. When the signer lacks
+        native gas at startup, `approvals_ready: false` is reported with a
+        list of `blocked_signers` so a frontend can prompt the operator to
+        fund the listed addresses. The solver retries approvals every 30
+        seconds in the background and flips back to `approvals_ready: true`
+        once they succeed.
+      required:
+        - approvals_ready
+      properties:
+        approvals_ready:
+          type: boolean
+          description: True when startup token approvals have completed.
+          example: false
+        reason:
+          type: string
+          nullable: true
+          description: |
+            Machine-readable reason while `approvals_ready` is false. Omitted
+            when approvals are ready.
+          enum: ["waiting_for_native_gas"]
+          example: "waiting_for_native_gas"
+        blocked_signers:
+          type: array
+          description: |
+            Per-signer detail explaining why startup approvals could not run.
+            Omitted when approvals are ready.
+          items:
+            $ref: "#/components/schemas/BlockedSigner"
+
+    BlockedSigner:
+      type: object
+      description: A signer that needs to be funded with native gas.
+      required:
+        - chain_id
+        - signer
+        - balance_wei
+      properties:
+        chain_id:
+          type: integer
+          format: int64
+          description: Chain on which the signer needs native gas.
+          example: 1
+        signer:
+          type: string
+          pattern: "^0x[a-fA-F0-9]{40}$"
+          description: Signer address to fund.
+          example: "0x3c0189d526e484824881217322048c055cb20f29"
+        balance_wei:
+          type: string
+          description: Current native balance in wei (decimal string).
+          example: "0"
+
+tags:
+  - name: Health
+    description: |
+      Health check endpoint for monitoring dashboards, load-balancer probes,
+      and frontends that need to detect deferred-startup conditions like
+      "waiting for the signer to be funded".

--- a/crates/solver-core/src/builder/mod.rs
+++ b/crates/solver-core/src/builder/mod.rs
@@ -26,6 +26,17 @@ fn native_gas_reserve_shortfall(balance: U256, configured_reserve: U256) -> Opti
 	(balance < configured_reserve).then(|| configured_reserve.saturating_sub(balance))
 }
 
+/// Returns true when a token manager error was caused by the signer lacking
+/// native gas to submit an approval transaction.
+fn is_insufficient_native_gas(error: &crate::engine::token_manager::TokenManagerError) -> bool {
+	matches!(
+		error,
+		crate::engine::token_manager::TokenManagerError::DeliveryError(
+			DeliveryError::InsufficientNativeGas(_)
+		)
+	)
+}
+
 /// Errors that can occur during solver engine construction.
 ///
 /// These errors indicate problems with configuration or missing required components
@@ -563,7 +574,9 @@ impl SolverBuilder {
 			}
 		}
 
-		// Ensure all token approvals are set
+		// Ensure all token approvals are set. If the signer has no native gas,
+		// don't crash startup — log a warning and retry in the background so the
+		// API stays up while an operator funds the signer.
 		match token_manager.ensure_approvals().await {
 			Ok(()) => {
 				tracing::info!(
@@ -571,6 +584,43 @@ impl SolverBuilder {
 					networks = self.static_config.networks.len(),
 					"Token manager initialized with approvals"
 				);
+			},
+			Err(e) if is_insufficient_native_gas(&e) => {
+				tracing::warn!(
+					component = "token_manager",
+					error = %e,
+					"Startup token approvals deferred: signer lacks native gas. \
+					 Retrying every 30s in the background."
+				);
+				let retry_token_manager = Arc::clone(&token_manager);
+				tokio::spawn(async move {
+					loop {
+						tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+						match retry_token_manager.ensure_approvals().await {
+							Ok(()) => {
+								tracing::info!(
+									component = "token_manager",
+									"Startup token approvals completed after native gas became available"
+								);
+								return;
+							},
+							Err(retry_err) if is_insufficient_native_gas(&retry_err) => {
+								tracing::debug!(
+									component = "token_manager",
+									error = %retry_err,
+									"Still waiting for native gas to complete startup approvals"
+								);
+							},
+							Err(retry_err) => {
+								tracing::error!(
+									component = "token_manager",
+									error = %retry_err,
+									"Startup approval retry failed with non-gas error"
+								);
+							},
+						}
+					}
+				});
 			},
 			Err(e) => {
 				tracing::error!(
@@ -756,5 +806,36 @@ mod tests {
 			native_gas_reserve_shortfall(U256::from(31u64), U256::from(30u64)),
 			None
 		);
+	}
+
+	#[test]
+	fn is_insufficient_native_gas_matches_delivery_native_gas_error() {
+		use crate::engine::token_manager::TokenManagerError;
+		use solver_delivery::{DeliveryError, InsufficientNativeGasInfo};
+
+		let err = TokenManagerError::DeliveryError(DeliveryError::InsufficientNativeGas(Box::new(
+			InsufficientNativeGasInfo {
+				chain_id: 8453,
+				signer: "0xsolver".to_string(),
+				balance_wei: "0".to_string(),
+				required_wei: "1000".to_string(),
+				shortfall_wei: "1000".to_string(),
+				gas_limit: None,
+				max_fee_per_gas: None,
+				gas_price: None,
+				value_wei: "0".to_string(),
+			},
+		)));
+
+		assert!(is_insufficient_native_gas(&err));
+	}
+
+	#[test]
+	fn is_insufficient_native_gas_rejects_unrelated_errors() {
+		use crate::engine::token_manager::TokenManagerError;
+
+		let err = TokenManagerError::ParseError("nope".to_string());
+
+		assert!(!is_insufficient_native_gas(&err));
 	}
 }

--- a/crates/solver-core/src/builder/mod.rs
+++ b/crates/solver-core/src/builder/mod.rs
@@ -55,6 +55,71 @@ fn blocked_signer_from_error(
 	}
 }
 
+/// Merges a known authoritative blocker (from the failing approval call)
+/// with the result of a per-chain native-balance scan. Any chain showing a
+/// strictly-zero balance is added; the primary blocker takes precedence
+/// for its own chain so a non-zero but insufficient balance is still
+/// reported correctly.
+fn merge_blocked_signers(
+	primary: Option<crate::engine::startup_readiness::BlockedSigner>,
+	solver_address: &str,
+	chain_balances: Vec<(u64, String)>,
+) -> Vec<crate::engine::startup_readiness::BlockedSigner> {
+	use crate::engine::startup_readiness::BlockedSigner;
+	use std::collections::HashSet;
+
+	let mut result: Vec<BlockedSigner> = Vec::new();
+	let mut seen: HashSet<u64> = HashSet::new();
+
+	if let Some(primary) = primary {
+		seen.insert(primary.chain_id);
+		result.push(primary);
+	}
+
+	for (chain_id, balance_wei) in chain_balances {
+		if seen.contains(&chain_id) {
+			continue;
+		}
+		if balance_wei == "0" {
+			result.push(BlockedSigner {
+				chain_id,
+				signer: solver_address.to_string(),
+				balance_wei,
+			});
+			seen.insert(chain_id);
+		}
+	}
+
+	result
+}
+
+/// Reads native balances on every configured chain for `solver_address`
+/// and merges with `primary` (the chain whose approval call actually
+/// errored, if known) to produce the full set of blocked signers for the
+/// frontend. Per-chain RPC failures are logged and skipped, never
+/// propagated — a degraded RPC must not turn into a startup crash.
+async fn discover_blocked_signers(
+	delivery: &Arc<solver_delivery::DeliveryService>,
+	networks: &solver_types::NetworksConfig,
+	solver_address: &str,
+	primary: Option<crate::engine::startup_readiness::BlockedSigner>,
+) -> Vec<crate::engine::startup_readiness::BlockedSigner> {
+	let mut chain_balances: Vec<(u64, String)> = Vec::with_capacity(networks.len());
+	for chain_id in networks.keys() {
+		match delivery.get_balance(*chain_id, solver_address, None).await {
+			Ok(balance) => chain_balances.push((*chain_id, balance)),
+			Err(error) => {
+				tracing::debug!(
+					chain_id = chain_id,
+					error = %error,
+					"Could not read native balance during blocked-signer scan; skipping chain"
+				);
+			},
+		}
+	}
+	merge_blocked_signers(primary, solver_address, chain_balances)
+}
+
 /// Errors that can occur during solver engine construction.
 ///
 /// These errors indicate problems with configuration or missing required components
@@ -596,8 +661,9 @@ impl SolverBuilder {
 		// don't crash startup — log a warning and retry in the background so the
 		// API stays up while an operator funds the signer. The deferred state is
 		// surfaced through the engine's startup readiness handle (see below).
-		let mut deferred_blocked_signer: Option<crate::engine::startup_readiness::BlockedSigner> =
-			None;
+		let solver_address_str = solver_address.to_string();
+		let mut deferred_blocked_signers: Vec<crate::engine::startup_readiness::BlockedSigner> =
+			Vec::new();
 		match token_manager.ensure_approvals().await {
 			Ok(()) => {
 				tracing::info!(
@@ -613,7 +679,13 @@ impl SolverBuilder {
 					"Startup token approvals deferred: signer lacks native gas. \
 					 Retrying every 30s in the background."
 				);
-				deferred_blocked_signer = blocked_signer_from_error(&e);
+				deferred_blocked_signers = discover_blocked_signers(
+					&delivery,
+					&self.static_config.networks,
+					&solver_address_str,
+					blocked_signer_from_error(&e),
+				)
+				.await;
 			},
 			Err(e) => {
 				tracing::error!(
@@ -761,6 +833,9 @@ impl SolverBuilder {
 		};
 
 		let retry_token_manager = Arc::clone(&token_manager);
+		let retry_delivery = Arc::clone(&delivery);
+		let retry_networks = self.static_config.networks.clone();
+		let retry_solver_address_str = solver_address_str.clone();
 
 		let engine = SolverEngine::new(
 			self.dynamic_config,
@@ -781,13 +856,15 @@ impl SolverBuilder {
 		// If startup approvals were deferred for native gas, publish the
 		// blocked-signer state on the engine's readiness handle and spawn the
 		// retry loop. Using the engine's shared handle means /health reflects
-		// updates without any extra plumbing.
-		if let Some(blocked_signer) = deferred_blocked_signer {
+		// updates without any extra plumbing. Each retry tick re-scans every
+		// configured chain so the frontend sees signers drop off the list as
+		// the operator funds them, not just one at a time.
+		if !deferred_blocked_signers.is_empty() {
 			let handle = engine.startup_readiness_handle();
 			*handle.write().await =
-				crate::engine::startup_readiness::StartupReadiness::waiting_for_native_gas(vec![
-					blocked_signer,
-				]);
+				crate::engine::startup_readiness::StartupReadiness::waiting_for_native_gas(
+					deferred_blocked_signers,
+				);
 			let retry_handle = Arc::clone(&handle);
 			tokio::spawn(async move {
 				loop {
@@ -808,10 +885,17 @@ impl SolverBuilder {
 								error = %retry_err,
 								"Still waiting for native gas to complete startup approvals"
 							);
-							if let Some(updated) = blocked_signer_from_error(&retry_err) {
+							let blocked = discover_blocked_signers(
+								&retry_delivery,
+								&retry_networks,
+								&retry_solver_address_str,
+								blocked_signer_from_error(&retry_err),
+							)
+							.await;
+							if !blocked.is_empty() {
 								*retry_handle.write().await =
 									crate::engine::startup_readiness::StartupReadiness::waiting_for_native_gas(
-										vec![updated],
+										blocked,
 									);
 							}
 						},
@@ -925,5 +1009,75 @@ mod tests {
 		let err = TokenManagerError::ParseError("nope".to_string());
 
 		assert!(blocked_signer_from_error(&err).is_none());
+	}
+
+	#[test]
+	fn merge_blocked_signers_lists_every_zero_balance_chain() {
+		let merged = merge_blocked_signers(
+			None,
+			"0xsolver",
+			vec![(1, "0".to_string()), (10, "0".to_string())],
+		);
+
+		assert_eq!(merged.len(), 2);
+		assert!(merged
+			.iter()
+			.any(|s| s.chain_id == 1 && s.balance_wei == "0"));
+		assert!(merged
+			.iter()
+			.any(|s| s.chain_id == 10 && s.balance_wei == "0"));
+	}
+
+	#[test]
+	fn merge_blocked_signers_preserves_primary_authoritative_balance() {
+		use crate::engine::startup_readiness::BlockedSigner;
+
+		// Primary error reports a non-zero but insufficient balance on chain 1.
+		// The naive scan also sees that balance as non-zero, so it would skip
+		// chain 1 — we must keep the primary's record.
+		let primary = Some(BlockedSigner {
+			chain_id: 1,
+			signer: "0xsolver".to_string(),
+			balance_wei: "500".to_string(),
+		});
+
+		let merged = merge_blocked_signers(
+			primary,
+			"0xsolver",
+			vec![(1, "500".to_string()), (10, "0".to_string())],
+		);
+
+		assert_eq!(merged.len(), 2);
+		let chain1 = merged.iter().find(|s| s.chain_id == 1).unwrap();
+		assert_eq!(chain1.balance_wei, "500"); // primary's value preserved, not duplicated
+		assert!(merged
+			.iter()
+			.any(|s| s.chain_id == 10 && s.balance_wei == "0"));
+	}
+
+	#[test]
+	fn merge_blocked_signers_omits_funded_chains() {
+		let merged = merge_blocked_signers(
+			None,
+			"0xsolver",
+			vec![
+				(1, "1000000000000000000".to_string()), // 1 ETH — funded
+				(10, "0".to_string()),
+			],
+		);
+
+		assert_eq!(merged.len(), 1);
+		assert_eq!(merged[0].chain_id, 10);
+	}
+
+	#[test]
+	fn merge_blocked_signers_empty_when_everything_funded_and_no_primary() {
+		let merged = merge_blocked_signers(
+			None,
+			"0xsolver",
+			vec![(1, "1000".to_string()), (10, "1".to_string())],
+		);
+
+		assert!(merged.is_empty());
 	}
 }

--- a/crates/solver-core/src/builder/mod.rs
+++ b/crates/solver-core/src/builder/mod.rs
@@ -37,6 +37,24 @@ fn is_insufficient_native_gas(error: &crate::engine::token_manager::TokenManager
 	)
 }
 
+/// Pulls the chain id, signer address, and current balance out of a token
+/// manager error caused by insufficient native gas. Returns `None` for any
+/// other error variant.
+fn blocked_signer_from_error(
+	error: &crate::engine::token_manager::TokenManagerError,
+) -> Option<crate::engine::startup_readiness::BlockedSigner> {
+	match error {
+		crate::engine::token_manager::TokenManagerError::DeliveryError(
+			DeliveryError::InsufficientNativeGas(info),
+		) => Some(crate::engine::startup_readiness::BlockedSigner {
+			chain_id: info.chain_id,
+			signer: info.signer.clone(),
+			balance_wei: info.balance_wei.clone(),
+		}),
+		_ => None,
+	}
+}
+
 /// Errors that can occur during solver engine construction.
 ///
 /// These errors indicate problems with configuration or missing required components
@@ -576,7 +594,10 @@ impl SolverBuilder {
 
 		// Ensure all token approvals are set. If the signer has no native gas,
 		// don't crash startup — log a warning and retry in the background so the
-		// API stays up while an operator funds the signer.
+		// API stays up while an operator funds the signer. The deferred state is
+		// surfaced through the engine's startup readiness handle (see below).
+		let mut deferred_blocked_signer: Option<crate::engine::startup_readiness::BlockedSigner> =
+			None;
 		match token_manager.ensure_approvals().await {
 			Ok(()) => {
 				tracing::info!(
@@ -592,35 +613,7 @@ impl SolverBuilder {
 					"Startup token approvals deferred: signer lacks native gas. \
 					 Retrying every 30s in the background."
 				);
-				let retry_token_manager = Arc::clone(&token_manager);
-				tokio::spawn(async move {
-					loop {
-						tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-						match retry_token_manager.ensure_approvals().await {
-							Ok(()) => {
-								tracing::info!(
-									component = "token_manager",
-									"Startup token approvals completed after native gas became available"
-								);
-								return;
-							},
-							Err(retry_err) if is_insufficient_native_gas(&retry_err) => {
-								tracing::debug!(
-									component = "token_manager",
-									error = %retry_err,
-									"Still waiting for native gas to complete startup approvals"
-								);
-							},
-							Err(retry_err) => {
-								tracing::error!(
-									component = "token_manager",
-									error = %retry_err,
-									"Startup approval retry failed with non-gas error"
-								);
-							},
-						}
-					}
-				});
+				deferred_blocked_signer = blocked_signer_from_error(&e);
 			},
 			Err(e) => {
 				tracing::error!(
@@ -767,7 +760,9 @@ impl SolverBuilder {
 			None
 		};
 
-		Ok(SolverEngine::new(
+		let retry_token_manager = Arc::clone(&token_manager);
+
+		let engine = SolverEngine::new(
 			self.dynamic_config,
 			self.static_config,
 			storage,
@@ -781,7 +776,58 @@ impl SolverBuilder {
 			EventBus::new(1000),
 			token_manager,
 			bridge_service,
-		))
+		);
+
+		// If startup approvals were deferred for native gas, publish the
+		// blocked-signer state on the engine's readiness handle and spawn the
+		// retry loop. Using the engine's shared handle means /health reflects
+		// updates without any extra plumbing.
+		if let Some(blocked_signer) = deferred_blocked_signer {
+			let handle = engine.startup_readiness_handle();
+			*handle.write().await =
+				crate::engine::startup_readiness::StartupReadiness::waiting_for_native_gas(vec![
+					blocked_signer,
+				]);
+			let retry_handle = Arc::clone(&handle);
+			tokio::spawn(async move {
+				loop {
+					tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+					match retry_token_manager.ensure_approvals().await {
+						Ok(()) => {
+							tracing::info!(
+								component = "token_manager",
+								"Startup token approvals completed after native gas became available"
+							);
+							*retry_handle.write().await =
+								crate::engine::startup_readiness::StartupReadiness::ready();
+							return;
+						},
+						Err(retry_err) if is_insufficient_native_gas(&retry_err) => {
+							tracing::debug!(
+								component = "token_manager",
+								error = %retry_err,
+								"Still waiting for native gas to complete startup approvals"
+							);
+							if let Some(updated) = blocked_signer_from_error(&retry_err) {
+								*retry_handle.write().await =
+									crate::engine::startup_readiness::StartupReadiness::waiting_for_native_gas(
+										vec![updated],
+									);
+							}
+						},
+						Err(retry_err) => {
+							tracing::error!(
+								component = "token_manager",
+								error = %retry_err,
+								"Startup approval retry failed with non-gas error"
+							);
+						},
+					}
+				}
+			});
+		}
+
+		Ok(engine)
 	}
 }
 
@@ -837,5 +883,47 @@ mod tests {
 		let err = TokenManagerError::ParseError("nope".to_string());
 
 		assert!(!is_insufficient_native_gas(&err));
+	}
+
+	#[test]
+	fn blocked_signer_from_native_gas_error_uses_chain_signer_balance() {
+		use crate::engine::startup_readiness::BlockedSigner;
+		use crate::engine::token_manager::TokenManagerError;
+		use solver_delivery::{DeliveryError, InsufficientNativeGasInfo};
+
+		let err = TokenManagerError::DeliveryError(DeliveryError::InsufficientNativeGas(Box::new(
+			InsufficientNativeGasInfo {
+				chain_id: 8453,
+				signer: "0xsolver".to_string(),
+				balance_wei: "1000000000000".to_string(),
+				required_wei: "5000000000000".to_string(),
+				shortfall_wei: "4000000000000".to_string(),
+				gas_limit: None,
+				max_fee_per_gas: None,
+				gas_price: None,
+				value_wei: "0".to_string(),
+			},
+		)));
+
+		let signer =
+			blocked_signer_from_error(&err).expect("native gas error yields blocked signer");
+
+		assert_eq!(
+			signer,
+			BlockedSigner {
+				chain_id: 8453,
+				signer: "0xsolver".to_string(),
+				balance_wei: "1000000000000".to_string(),
+			}
+		);
+	}
+
+	#[test]
+	fn blocked_signer_from_unrelated_error_is_none() {
+		use crate::engine::token_manager::TokenManagerError;
+
+		let err = TokenManagerError::ParseError("nope".to_string());
+
+		assert!(blocked_signer_from_error(&err).is_none());
 	}
 }

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -9,9 +9,14 @@ pub mod cost_profit;
 pub mod event_bus;
 pub mod lifecycle;
 pub mod post_fill_overrides;
+pub mod startup_readiness;
 pub mod token_manager;
 
-use self::{cost_profit::CostProfitService, token_manager::TokenManager};
+use self::{
+	cost_profit::CostProfitService,
+	startup_readiness::{SharedStartupReadiness, StartupReadiness},
+	token_manager::TokenManager,
+};
 use crate::handlers::{IntentHandler, OrderHandler, SettlementHandler, TransactionHandler};
 use crate::recovery::RecoveryService;
 use crate::state::OrderStateMachine;
@@ -98,6 +103,11 @@ pub struct SolverEngine {
 		Arc<tokio::sync::RwLock<solver_bridge::monitor::RebalanceMonitorStatus>>,
 	/// The solver's Ethereum address.
 	pub(crate) solver_address: solver_types::Address,
+	/// Public-facing startup readiness state. Defaults to `ready()`. The
+	/// builder writes a non-ready value here when startup approvals are
+	/// blocked on native gas; the retry loop flips it back when the next
+	/// approval pass succeeds.
+	pub(crate) startup_readiness: SharedStartupReadiness,
 }
 
 /// Number of orders to batch together for claim operations.
@@ -236,6 +246,7 @@ impl SolverEngine {
 			rebalance_monitor_status: Arc::new(tokio::sync::RwLock::new(
 				solver_bridge::monitor::RebalanceMonitorStatus::default(),
 			)),
+			startup_readiness: Arc::new(RwLock::new(StartupReadiness::ready())),
 		}
 	}
 
@@ -711,6 +722,20 @@ impl SolverEngine {
 		&self.solver_address
 	}
 
+	/// Returns a snapshot of the current startup readiness state. Cheap —
+	/// takes a read lock, clones, and releases. Safe to call from hot
+	/// paths like the health endpoint.
+	pub async fn startup_readiness(&self) -> StartupReadiness {
+		self.startup_readiness.read().await.clone()
+	}
+
+	/// Returns the shared handle for the startup readiness state. Used by
+	/// the builder to seed the initial value and hand a clone to the
+	/// background approval retry loop.
+	pub fn startup_readiness_handle(&self) -> SharedStartupReadiness {
+		Arc::clone(&self.startup_readiness)
+	}
+
 	/// Helper method to spawn handler tasks with semaphore-based concurrency control.
 	///
 	/// This method:
@@ -1044,5 +1069,94 @@ mod tests {
 			handler_error.to_string(),
 			"Handler error: test handler error"
 		);
+	}
+
+	#[tokio::test]
+	async fn engine_startup_readiness_defaults_to_ready() {
+		let (
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+		) = create_mock_services().await;
+
+		let engine = SolverEngine::new(
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+			None,
+		);
+
+		let snapshot = engine.startup_readiness().await;
+
+		assert!(snapshot.approvals_ready);
+		assert!(snapshot.reason.is_none());
+		assert!(snapshot.blocked_signers.is_empty());
+	}
+
+	#[tokio::test]
+	async fn engine_startup_readiness_handle_propagates_writes_to_getter() {
+		use crate::engine::startup_readiness::{BlockedSigner, StartupReadiness};
+
+		let (
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+		) = create_mock_services().await;
+
+		let engine = SolverEngine::new(
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+			None,
+		);
+
+		let handle = engine.startup_readiness_handle();
+		*handle.write().await = StartupReadiness::waiting_for_native_gas(vec![BlockedSigner {
+			chain_id: 1,
+			signer: "0xabc".to_string(),
+			balance_wei: "0".to_string(),
+		}]);
+
+		let snapshot = engine.startup_readiness().await;
+		assert!(!snapshot.approvals_ready);
+		assert_eq!(snapshot.reason.as_deref(), Some("waiting_for_native_gas"));
+		assert_eq!(snapshot.blocked_signers.len(), 1);
+		assert_eq!(snapshot.blocked_signers[0].chain_id, 1);
 	}
 }

--- a/crates/solver-core/src/engine/startup_readiness.rs
+++ b/crates/solver-core/src/engine/startup_readiness.rs
@@ -1,0 +1,100 @@
+//! Public-facing startup readiness state.
+//!
+//! Exposed via the health endpoint so operators and frontends can detect
+//! "process is up but waiting on signer funding" without inferring it from
+//! downstream order failures.
+
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Snapshot of whether the solver completed its startup approval pass.
+///
+/// `approvals_ready == true` is the steady state. When the signer lacks
+/// native gas at startup, the builder records a non-ready state with the
+/// list of blocked signers so a frontend can surface a "fund this address"
+/// prompt without parsing log lines.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StartupReadiness {
+	pub approvals_ready: bool,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub reason: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub blocked_signers: Vec<BlockedSigner>,
+}
+
+/// Per-signer reason a startup approval could not run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BlockedSigner {
+	pub chain_id: u64,
+	pub signer: String,
+	pub balance_wei: String,
+}
+
+impl StartupReadiness {
+	pub fn ready() -> Self {
+		Self {
+			approvals_ready: true,
+			reason: None,
+			blocked_signers: Vec::new(),
+		}
+	}
+
+	pub fn waiting_for_native_gas(blocked_signers: Vec<BlockedSigner>) -> Self {
+		Self {
+			approvals_ready: false,
+			reason: Some("waiting_for_native_gas".to_string()),
+			blocked_signers,
+		}
+	}
+}
+
+/// Shared handle to the startup readiness state. The engine owns one of
+/// these; the builder hands a clone to its retry task so updates flow back
+/// to the health endpoint.
+pub type SharedStartupReadiness = Arc<RwLock<StartupReadiness>>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ready_serializes_with_minimal_fields() {
+		let json = serde_json::to_string(&StartupReadiness::ready()).unwrap();
+
+		assert!(json.contains("\"approvals_ready\":true"));
+		assert!(!json.contains("reason"));
+		assert!(!json.contains("blocked_signers"));
+	}
+
+	#[test]
+	fn waiting_for_native_gas_serializes_with_blocked_signer_details() {
+		let status = StartupReadiness::waiting_for_native_gas(vec![BlockedSigner {
+			chain_id: 8453,
+			signer: "0xsolver".to_string(),
+			balance_wei: "1000000000000".to_string(),
+		}]);
+
+		let json = serde_json::to_string(&status).unwrap();
+
+		assert!(json.contains("\"approvals_ready\":false"));
+		assert!(json.contains("\"reason\":\"waiting_for_native_gas\""));
+		assert!(json.contains("\"chain_id\":8453"));
+		assert!(json.contains("\"signer\":\"0xsolver\""));
+		assert!(json.contains("\"balance_wei\":\"1000000000000\""));
+	}
+
+	#[test]
+	fn waiting_for_native_gas_omits_required_and_shortfall() {
+		let status = StartupReadiness::waiting_for_native_gas(vec![BlockedSigner {
+			chain_id: 1,
+			signer: "0xsolver".to_string(),
+			balance_wei: "0".to_string(),
+		}]);
+
+		let json = serde_json::to_string(&status).unwrap();
+
+		assert!(!json.contains("required_wei"));
+		assert!(!json.contains("shortfall_wei"));
+	}
+}

--- a/crates/solver-service/src/apis/health.rs
+++ b/crates/solver-service/src/apis/health.rs
@@ -6,6 +6,7 @@
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::Serialize;
+use solver_core::engine::startup_readiness::StartupReadiness;
 use solver_storage::{check_storage_readiness, PersistencePolicy, ReadinessCheck, StoreConfig};
 use std::collections::HashMap;
 
@@ -25,6 +26,11 @@ pub struct HealthResponse {
 	pub solver_id: String,
 	/// Application version
 	pub version: String,
+	/// Startup readiness state. `approvals_ready: true` when the solver
+	/// completed its startup token approvals; `false` while it is waiting
+	/// on the signer to be funded with native gas. Frontends can poll
+	/// `/health` and prompt the operator using `blocked_signers`.
+	pub startup: StartupReadiness,
 }
 
 /// Redis health status.
@@ -61,14 +67,17 @@ pub struct StorageHealth {
 
 /// GET /health - Full health check endpoint.
 ///
-/// Returns detailed health information including Redis status.
-/// Used for monitoring dashboards and alerting.
+/// Returns storage readiness, Redis persistence info, and startup
+/// readiness. Used for monitoring dashboards, load-balancer probes, and
+/// frontends that need to detect deferred-startup conditions (e.g.
+/// "waiting for the signer to be funded with native gas").
 ///
-/// # Response
+/// # Response (steady state)
 ///
 /// ```json
 /// {
 ///   "status": "healthy",
+///   "storage": { "backend": "Redis", "ready": true, "checks": [], "details": {} },
 ///   "redis": {
 ///     "connected": true,
 ///     "persistence_enabled": true,
@@ -76,15 +85,41 @@ pub struct StorageHealth {
 ///     "aof_enabled": false
 ///   },
 ///   "solver_id": "my-solver",
-///   "version": "0.1.0"
+///   "version": "0.1.0",
+///   "startup": { "approvals_ready": true }
+/// }
+/// ```
+///
+/// # Response (waiting on native gas)
+///
+/// HTTP status remains `200 OK` so load balancers do not flap. Frontends
+/// should branch on `startup.approvals_ready` to detect the deferred state.
+///
+/// ```json
+/// {
+///   "status": "healthy",
+///   "storage": { "backend": "Redis", "ready": true, "checks": [], "details": {} },
+///   "solver_id": "my-solver",
+///   "version": "0.1.0",
+///   "startup": {
+///     "approvals_ready": false,
+///     "reason": "waiting_for_native_gas",
+///     "blocked_signers": [
+///       { "chain_id": 1, "signer": "0x...", "balance_wei": "0" }
+///     ]
+///   }
 /// }
 /// ```
 ///
 /// # Status Codes
 ///
-/// - `200 OK` - Healthy (Redis connected)
-/// - `503 Service Unavailable` - Unhealthy (Redis disconnected)
+/// - `200 OK` - Storage is ready. `startup.approvals_ready` may still be
+///   `false` if startup token approvals are deferred for native gas.
+/// - `503 Service Unavailable` - Storage or another core dependency is
+///   not ready.
 pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
+	let startup = state.solver.startup_readiness().await;
+
 	let store_config = match StoreConfig::from_env() {
 		Ok(config) => config,
 		Err(e) => {
@@ -100,6 +135,7 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
 				redis: None,
 				solver_id: state.config.read().await.solver.id.clone(),
 				version: env!("CARGO_PKG_VERSION").to_string(),
+				startup: startup.clone(),
 			};
 
 			return (StatusCode::SERVICE_UNAVAILABLE, Json(response));
@@ -168,6 +204,7 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
 		redis: redis_health,
 		solver_id,
 		version: env!("CARGO_PKG_VERSION").to_string(),
+		startup,
 	};
 
 	let status_code = if response.status == "healthy" {
@@ -182,6 +219,65 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn health_response_includes_startup_field_when_waiting_for_native_gas() {
+		use solver_core::engine::startup_readiness::{BlockedSigner, StartupReadiness};
+
+		let response = HealthResponse {
+			status: "healthy".to_string(),
+			storage: StorageHealth {
+				backend: "Memory".to_string(),
+				ready: true,
+				checks: Vec::new(),
+				details: HashMap::new(),
+				error: None,
+			},
+			redis: None,
+			solver_id: "test-solver".to_string(),
+			version: "0.1.0".to_string(),
+			startup: StartupReadiness::waiting_for_native_gas(vec![BlockedSigner {
+				chain_id: 8453,
+				signer: "0xsolver".to_string(),
+				balance_wei: "0".to_string(),
+			}]),
+		};
+
+		let json = serde_json::to_string(&response).unwrap();
+
+		assert!(json.contains("\"startup\""));
+		assert!(json.contains("\"approvals_ready\":false"));
+		assert!(json.contains("\"reason\":\"waiting_for_native_gas\""));
+		assert!(json.contains("\"chain_id\":8453"));
+		assert!(json.contains("\"signer\":\"0xsolver\""));
+		assert!(json.contains("\"balance_wei\":\"0\""));
+	}
+
+	#[test]
+	fn health_response_omits_blocked_signers_when_ready() {
+		use solver_core::engine::startup_readiness::StartupReadiness;
+
+		let response = HealthResponse {
+			status: "healthy".to_string(),
+			storage: StorageHealth {
+				backend: "Memory".to_string(),
+				ready: true,
+				checks: Vec::new(),
+				details: HashMap::new(),
+				error: None,
+			},
+			redis: None,
+			solver_id: "test-solver".to_string(),
+			version: "0.1.0".to_string(),
+			startup: StartupReadiness::ready(),
+		};
+
+		let json = serde_json::to_string(&response).unwrap();
+
+		assert!(json.contains("\"approvals_ready\":true"));
+		assert!(!json.contains("blocked_signers"));
+		assert!(!json.contains("\"reason\""));
+	}
 
 	#[test]
 	fn test_health_response_serialization_healthy() {
@@ -203,6 +299,7 @@ mod tests {
 			}),
 			solver_id: "test-solver".to_string(),
 			version: "0.1.0".to_string(),
+			startup: solver_core::engine::startup_readiness::StartupReadiness::ready(),
 		};
 
 		let json = serde_json::to_string(&response).unwrap();
@@ -236,6 +333,7 @@ mod tests {
 			}),
 			solver_id: "test-solver".to_string(),
 			version: "0.1.0".to_string(),
+			startup: solver_core::engine::startup_readiness::StartupReadiness::ready(),
 		};
 
 		let json = serde_json::to_string(&response).unwrap();
@@ -423,6 +521,7 @@ mod tests {
 			redis: None,
 			solver_id: "test-solver".to_string(),
 			version: "0.1.0".to_string(),
+			startup: solver_core::engine::startup_readiness::StartupReadiness::ready(),
 		};
 
 		let json = serde_json::to_string(&response).unwrap();
@@ -451,6 +550,7 @@ mod tests {
 			redis: None,
 			solver_id: "file-solver".to_string(),
 			version: "0.1.0".to_string(),
+			startup: solver_core::engine::startup_readiness::StartupReadiness::ready(),
 		};
 
 		let json = serde_json::to_string(&response).unwrap();


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `/health` endpoint to include startup approval readiness status, indicating when the solver is waiting for native gas with detailed blocking signer information
  * Added background retry mechanism for token-approval failures caused by insufficient native gas

* **Documentation**
  * Updated health endpoint API specification and reference documentation with new response schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->