### PR TITLE
fix(security): reject malformed EIP-712 recovery id without panicking

### DIFF
--- a/crates/solver-service/src/eip712/mod.rs
+++ b/crates/solver-service/src/eip712/mod.rs
@@ -136,8 +136,17 @@ fn recover_signer(
 
 	let secp = Secp256k1::<All>::new();
 
-	// Create recoverable signature
-	let recovery_id = secp256k1::ecdsa::RecoveryId::try_from(recovery_id as i32).unwrap();
+	// Create recoverable signature. The `v` byte after EIP-155/2718 normalization
+	// must map to a valid secp256k1 recovery id (0..=3); anything else came from
+	// a malformed signature and must be rejected as a `BadRequest` rather than
+	// panicking the handler task.
+	let recovery_id = secp256k1::ecdsa::RecoveryId::try_from(recovery_id as i32).map_err(|_| {
+		APIError::BadRequest {
+			error_type: ApiErrorType::OrderValidationFailed,
+			message: "Invalid signature recovery id".to_string(),
+			details: None,
+		}
+	})?;
 	let recoverable_sig = RecoverableSignature::from_compact(signature_bytes, recovery_id)
 		.map_err(|_| APIError::BadRequest {
 			error_type: ApiErrorType::OrderValidationFailed,
@@ -322,5 +331,36 @@ mod tests {
 			err,
 			APIError::BadRequest { message, .. } if message.contains("Invalid signature length")
 		));
+	}
+
+	#[test]
+	fn validate_eip712_signature_rejects_invalid_recovery_id_without_panic() {
+		// secp256k1 recovery ids are 0..=3. Pre-normalization the v byte may be
+		// 0/1 or 27/28; everything else (e.g. 4..=26, 31..=255) is an attacker-
+		// controlled malformed signature and must produce a BadRequest rather
+		// than panicking the handler task.
+		for bad_v in [4u8, 5, 26, 31, 32, 100, 255] {
+			let mut signature_bytes = vec![0u8; 65];
+			signature_bytes[64] = bad_v;
+			let signature = Bytes::from(signature_bytes);
+
+			let err = validate_eip712_signature(
+				FixedBytes::from([0x77u8; 32]),
+				FixedBytes::from([0x88u8; 32]),
+				&signature,
+				AlloyAddress::from_slice(&[0u8; 20]),
+			)
+			.expect_err("invalid recovery id must surface as BadRequest");
+
+			assert!(
+				matches!(
+					&err,
+					APIError::BadRequest { message, .. }
+						if message.contains("recovery id")
+							|| message.contains("signature format")
+				),
+				"unexpected error for v={bad_v}: {err:?}"
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`eip712::recover_signer` unwraps the result of `RecoveryId::try_from(...)`. The `v` byte fed into that conversion comes directly from a user-supplied signature, so any value outside the valid set (`0`, `1`, `27`, `28` — or `2`, `3`, `29`, `30` after normalization) produces an `Err` that is then `.unwrap()`-ed and panics the handler task.

This path is reachable **unauthenticated** through `POST /api/v1/orders` for any ResourceLock order: the request body's signature byte at index 64 reaches `validate_eip712_signature → recover_signer` before any other check. Tokio isolates the panicking task so the whole process survives, but each attempt logs a backtrace, completes the connection with a 500, and burns a worker. A trivial scripted client can chain thousands of these to starve the request pool.

## Solution

Replace the `.unwrap()` with a `BadRequest` error that mirrors the existing error shape used downstream (invalid signature length, invalid signature format). The handler now returns a clean 400 for every malformed `v` byte instead of panicking.

Added a unit test that exercises the full range of bogus `v` values an attacker would try (`4`, `5`, `26`, `31`, `32`, `100`, `255`) and asserts each one surfaces as a `BadRequest` rather than panicking.

## Test plan

- [x] `cargo test -p solver-service --lib eip712::` passes
- [x] New `validate_eip712_signature_rejects_invalid_recovery_id_without_panic` exercises 7 malformed `v` byte values
- [ ] Existing signature-validation flows for ResourceLock orders still succeed end-to-end in staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced EIP712 signature validation to properly handle malformed recovery values, returning a clear error response instead of causing unexpected system failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openintentsframework/oif-solver/pull/338)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->