### PR TITLE
feat(recovery): integrate transaction attempt store into recovery ser…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,6 +5073,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,6 +5196,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
+ "async-trait",
  "hex",
  "reqwest",
  "serde",

--- a/crates/solver-core/Cargo.toml
+++ b/crates/solver-core/Cargo.toml
@@ -15,7 +15,9 @@ alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-provider = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-sol-types = { workspace = true }
+async-trait = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }
+hex = { workspace = true }
 lru = "0.16"
 once_cell = "1.19"
 rust_decimal = { workspace = true }
@@ -34,11 +36,10 @@ solver-types = { path = "../solver-types" }
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
+uuid = { workspace = true }
 
 [dev-dependencies]
 alloy-signer-local = { workspace = true }
-async-trait = { workspace = true }
-hex = { workspace = true }
 mockall = { workspace = true }
 proptest = "1"
 solver-account = { path = "../solver-account", features = ["testing"] }

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -19,6 +19,7 @@ use self::{
 };
 use crate::handlers::{IntentHandler, OrderHandler, SettlementHandler, TransactionHandler};
 use crate::recovery::RecoveryService;
+use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
 use solver_account::AccountService;
@@ -265,6 +266,9 @@ impl SolverEngine {
 	pub async fn initialize_with_recovery(&self) -> Result<Vec<Intent>, EngineError> {
 		tracing::info!("Initializing solver engine with state recovery");
 
+		let transaction_attempt_store =
+			Arc::new(TransactionAttemptStore::new(self.storage.clone()));
+
 		// Create recovery service with required dependencies
 		let recovery_service = RecoveryService::new(
 			self.storage.clone(),
@@ -272,6 +276,7 @@ impl SolverEngine {
 			self.delivery.clone(),
 			self.settlement.clone(),
 			self.event_bus.clone(),
+			transaction_attempt_store,
 		);
 
 		// Perform recovery

--- a/crates/solver-core/src/handlers/order.rs
+++ b/crates/solver-core/src/handlers/order.rs
@@ -4,9 +4,12 @@
 //! and fill transactions, updating order state and publishing appropriate events.
 
 use crate::engine::event_bus::EventBus;
+use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
-use solver_delivery::{DeliveryService, TransactionMonitoringEvent, TransactionTracking};
+use solver_delivery::{
+	DeliveryService, TransactionAttemptRecorder, TransactionMonitoringEvent, TransactionTracking,
+};
 use solver_order::OrderService;
 use solver_storage::StorageService;
 use solver_types::{
@@ -59,6 +62,10 @@ impl OrderHandler {
 			state_machine,
 			event_bus,
 		}
+	}
+
+	fn transaction_attempt_recorder(&self) -> Arc<dyn TransactionAttemptRecorder> {
+		Arc::new(TransactionAttemptStore::new(self.storage.clone()))
 	}
 
 	/// Handles order preparation for off-chain orders.
@@ -133,6 +140,7 @@ impl OrderHandler {
 			let tracking = TransactionTracking {
 				id: order.id.clone(),
 				tx_type: TransactionType::Prepare,
+				attempt_recorder: self.transaction_attempt_recorder(),
 				callback,
 			};
 
@@ -258,6 +266,7 @@ impl OrderHandler {
 		let tracking = TransactionTracking {
 			id: order.id.clone(),
 			tx_type: TransactionType::Fill,
+			attempt_recorder: self.transaction_attempt_recorder(),
 			callback,
 		};
 

--- a/crates/solver-core/src/handlers/settlement.rs
+++ b/crates/solver-core/src/handlers/settlement.rs
@@ -6,9 +6,12 @@
 
 use crate::engine::event_bus::EventBus;
 use crate::monitoring::SettlementMonitor;
+use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
-use solver_delivery::{DeliveryService, TransactionMonitoringEvent, TransactionTracking};
+use solver_delivery::{
+	DeliveryService, TransactionAttemptRecorder, TransactionMonitoringEvent, TransactionTracking,
+};
 use solver_order::OrderService;
 use solver_settlement::SettlementService;
 use solver_storage::StorageService;
@@ -82,6 +85,10 @@ impl SettlementHandler {
 			monitoring_timeout_minutes,
 			networks,
 		}
+	}
+
+	fn transaction_attempt_recorder(&self) -> Arc<dyn TransactionAttemptRecorder> {
+		Arc::new(TransactionAttemptStore::new(self.storage.clone()))
 	}
 
 	/// Helper method to spawn settlement monitoring task.
@@ -211,6 +218,7 @@ impl SettlementHandler {
 				let tracking = TransactionTracking {
 					id: order_id.clone(),
 					tx_type: TransactionType::PostFill,
+					attempt_recorder: self.transaction_attempt_recorder(),
 					callback,
 				};
 
@@ -363,6 +371,7 @@ impl SettlementHandler {
 				let tracking = TransactionTracking {
 					id: order_id.clone(),
 					tx_type: TransactionType::PreClaim,
+					attempt_recorder: self.transaction_attempt_recorder(),
 					callback,
 				};
 
@@ -495,6 +504,7 @@ impl SettlementHandler {
 			let tracking = TransactionTracking {
 				id: order.id.clone(),
 				tx_type: TransactionType::Claim,
+				attempt_recorder: self.transaction_attempt_recorder(),
 				callback,
 			};
 

--- a/crates/solver-core/src/recovery/mod.rs
+++ b/crates/solver-core/src/recovery/mod.rs
@@ -8,6 +8,7 @@ use crate::engine::event_bus::EventBus;
 use crate::state::order::{
 	FAILED_STATUS_KIND_INDEX_VALUE, FINALIZED_STATUS_KIND_INDEX_VALUE, STATUS_KIND_INDEX_FIELD,
 };
+use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
 use solver_delivery::DeliveryService;
@@ -15,7 +16,7 @@ use solver_settlement::{SettlementReadiness, SettlementService};
 use solver_storage::{QueryFilter, StorageService};
 use solver_types::{
 	with_0x_prefix, Intent, Order, OrderEvent, OrderStatus, SettlementEvent, SolverEvent,
-	StorageKey, TransactionType,
+	StorageKey, TransactionAttempt, TransactionAttemptStatus, TransactionHash, TransactionType,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -74,6 +75,53 @@ enum ReconcileResult {
 	Finalized,
 }
 
+fn recovery_status_rank(status: TransactionAttemptStatus) -> Option<u8> {
+	match status {
+		TransactionAttemptStatus::Confirmed => Some(3),
+		TransactionAttemptStatus::Broadcast => Some(2),
+		TransactionAttemptStatus::Indeterminate => Some(1),
+		TransactionAttemptStatus::Planned
+		| TransactionAttemptStatus::SubmitRejected
+		| TransactionAttemptStatus::Reverted => None,
+	}
+}
+
+fn choose_recovery_attempt_hash(
+	attempts: &[TransactionAttempt],
+	tx_type: TransactionType,
+) -> Option<TransactionHash> {
+	attempts
+		.iter()
+		.filter(|attempt| attempt.tx_type == tx_type)
+		.filter_map(|attempt| {
+			let rank = recovery_status_rank(attempt.status)?;
+			let tx_hash = attempt.tx_hash.clone()?;
+			Some((rank, attempt.updated_at, tx_hash))
+		})
+		.max_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)))
+		.map(|(_, _, tx_hash)| tx_hash)
+}
+
+fn order_stage_hash(order: &Order, tx_type: TransactionType) -> Option<TransactionHash> {
+	match tx_type {
+		TransactionType::Prepare => order.prepare_tx_hash.clone(),
+		TransactionType::Fill => order.fill_tx_hash.clone(),
+		TransactionType::PostFill => order.post_fill_tx_hash.clone(),
+		TransactionType::PreClaim => order.pre_claim_tx_hash.clone(),
+		TransactionType::Claim => order.claim_tx_hash.clone(),
+	}
+}
+
+fn set_order_stage_hash(order: &mut Order, tx_type: TransactionType, tx_hash: TransactionHash) {
+	match tx_type {
+		TransactionType::Prepare => order.prepare_tx_hash = Some(tx_hash),
+		TransactionType::Fill => order.fill_tx_hash = Some(tx_hash),
+		TransactionType::PostFill => order.post_fill_tx_hash = Some(tx_hash),
+		TransactionType::PreClaim => order.pre_claim_tx_hash = Some(tx_hash),
+		TransactionType::Claim => order.claim_tx_hash = Some(tx_hash),
+	}
+}
+
 /// Report of the recovery operation.
 #[derive(Debug, Default)]
 pub struct RecoveryReport {
@@ -97,6 +145,7 @@ pub struct RecoveryService {
 	delivery: Arc<DeliveryService>,
 	settlement: Arc<SettlementService>,
 	event_bus: EventBus,
+	attempt_store: Arc<TransactionAttemptStore>,
 }
 
 impl RecoveryService {
@@ -115,6 +164,7 @@ impl RecoveryService {
 		delivery: Arc<DeliveryService>,
 		settlement: Arc<SettlementService>,
 		event_bus: EventBus,
+		attempt_store: Arc<TransactionAttemptStore>,
 	) -> Self {
 		Self {
 			storage,
@@ -122,6 +172,7 @@ impl RecoveryService {
 			delivery,
 			settlement,
 			event_bus,
+			attempt_store,
 		}
 	}
 
@@ -157,8 +208,8 @@ impl RecoveryService {
 			}
 
 			match self.reconcile_with_blockchain(&order).await {
-				Ok(result) => {
-					self.publish_recovery_event(order, result).await;
+				Ok((reconciled_order, result)) => {
+					self.publish_recovery_event(reconciled_order, result).await;
 					report.reconciled_orders += 1;
 				},
 				Err(e) => {
@@ -257,6 +308,49 @@ impl RecoveryService {
 		Ok(orphaned)
 	}
 
+	async fn attempts_for_recovery(&self, order_id: &str) -> Vec<TransactionAttempt> {
+		match self.attempt_store.attempts_for_order(order_id).await {
+			Ok(attempts) => attempts,
+			Err(error) => {
+				tracing::warn!(
+					order_id = %order_id,
+					error = %error,
+					"Failed to load transaction attempts during recovery; falling back to order hashes only"
+				);
+				Vec::new()
+			},
+		}
+	}
+
+	async fn resolve_and_repair_stage_hash(
+		&self,
+		order: &mut Order,
+		attempts: &[TransactionAttempt],
+		tx_type: TransactionType,
+	) -> Option<TransactionHash> {
+		if let Some(tx_hash) = order_stage_hash(order, tx_type) {
+			return Some(tx_hash);
+		}
+
+		let tx_hash = choose_recovery_attempt_hash(attempts, tx_type)?;
+		set_order_stage_hash(order, tx_type, tx_hash.clone());
+
+		if let Err(error) = self
+			.state_machine
+			.set_transaction_hash(&order.id, tx_hash.clone(), tx_type)
+			.await
+		{
+			tracing::error!(
+				order_id = %order.id,
+				tx_type = ?tx_type,
+				error = %error,
+				"Recovered transaction hash from attempt ledger but failed to write it back to order"
+			);
+		}
+
+		Some(tx_hash)
+	}
+
 	/// Reconciles an order with blockchain state.
 	///
 	/// This method checks the actual status of transactions on the blockchain
@@ -274,26 +368,32 @@ impl RecoveryService {
 	async fn reconcile_with_blockchain(
 		&self,
 		order: &Order,
-	) -> Result<ReconcileResult, RecoveryError> {
-		// Check transactions in reverse order (claim -> fill -> prepare)
+	) -> Result<(Order, ReconcileResult), RecoveryError> {
+		let attempts = self.attempts_for_recovery(&order.id).await;
+		let mut order = order.clone();
+
+		// Check transactions in reverse order (claim -> pre-claim -> post-fill -> fill -> prepare)
 
 		// Check claim transaction
-		if let Some(ref claim_tx) = order.claim_tx_hash {
+		if let Some(claim_tx) = self
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::Claim)
+			.await
+		{
 			let chain_id = order
 				.input_chains
 				.first()
 				.map(|c| c.chain_id)
 				.ok_or_else(|| RecoveryError::Storage("No input chains in order".into()))?;
 
-			match self.delivery.get_status(claim_tx, chain_id).await {
+			match self.delivery.get_status(&claim_tx, chain_id).await {
 				Ok(true) => {
 					// Transaction succeeded
-					return Ok(ReconcileResult::Finalized);
+					return Ok((order, ReconcileResult::Finalized));
 				},
 				Ok(false) => {
 					// Transaction failed/reverted
 					tracing::warn!("Claim transaction {:?} failed/reverted", claim_tx);
-					return Ok(ReconcileResult::Failed(TransactionType::Claim));
+					return Ok((order, ReconcileResult::Failed(TransactionType::Claim)));
 				},
 				Err(e) => {
 					// Could not determine on-chain state. Surface as Unknown so the
@@ -303,13 +403,16 @@ impl RecoveryService {
 						"Could not get claim transaction status; treating as Unknown: {}",
 						e
 					);
-					return Ok(ReconcileResult::Unknown);
+					return Ok((order, ReconcileResult::Unknown));
 				},
 			}
 		}
 
 		// Check pre-claim transaction
-		if let Some(ref pre_claim_tx) = order.pre_claim_tx_hash {
+		if let Some(pre_claim_tx) = self
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::PreClaim)
+			.await
+		{
 			// PreClaim happens on origin chain (same as claim)
 			let chain_id = order
 				.input_chains
@@ -317,26 +420,34 @@ impl RecoveryService {
 				.map(|c| c.chain_id)
 				.ok_or_else(|| RecoveryError::Storage("No input chains in order".into()))?;
 
-			match self.delivery.get_status(pre_claim_tx, chain_id).await {
+			match self.delivery.get_status(&pre_claim_tx, chain_id).await {
 				Ok(true) => {
 					// Pre-claim confirmed, ready for claim
-					return Ok(ReconcileResult::NeedsClaim {
-						fill_proof: order.fill_proof.clone(),
-					});
+					return Ok((
+						order.clone(),
+						ReconcileResult::NeedsClaim {
+							fill_proof: order.fill_proof.clone(),
+						},
+					));
 				},
-				Ok(false) => return Ok(ReconcileResult::Failed(TransactionType::PreClaim)),
+				Ok(false) => {
+					return Ok((order, ReconcileResult::Failed(TransactionType::PreClaim)));
+				},
 				Err(e) => {
 					tracing::warn!(
 						"Could not get pre-claim transaction status; treating as Unknown: {}",
 						e
 					);
-					return Ok(ReconcileResult::Unknown);
+					return Ok((order, ReconcileResult::Unknown));
 				},
 			}
 		}
 
 		// Check post-fill transaction
-		if let Some(ref post_fill_tx) = order.post_fill_tx_hash {
+		if let Some(post_fill_tx) = self
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::PostFill)
+			.await
+		{
 			// PostFill happens on destination chain (same as fill)
 			let chain_id = order
 				.output_chains
@@ -344,46 +455,54 @@ impl RecoveryService {
 				.map(|c| c.chain_id)
 				.ok_or_else(|| RecoveryError::Storage("No output chains in order".into()))?;
 
-			match self.delivery.get_status(post_fill_tx, chain_id).await {
+			match self.delivery.get_status(&post_fill_tx, chain_id).await {
 				Ok(true) => {
 					// Post-fill confirmed, needs monitoring for settlement
-					return Ok(ReconcileResult::NeedsMonitoring);
+					return Ok((order, ReconcileResult::NeedsMonitoring));
 				},
-				Ok(false) => return Ok(ReconcileResult::Failed(TransactionType::PostFill)),
+				Ok(false) => {
+					return Ok((order, ReconcileResult::Failed(TransactionType::PostFill)));
+				},
 				Err(e) => {
 					tracing::warn!(
 						"Could not get post-fill transaction status; treating as Unknown: {}",
 						e
 					);
-					return Ok(ReconcileResult::Unknown);
+					return Ok((order, ReconcileResult::Unknown));
 				},
 			}
 		}
 
 		// Check fill transaction
-		if let Some(ref fill_tx) = order.fill_tx_hash {
+		if let Some(fill_tx) = self
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::Fill)
+			.await
+		{
 			let chain_id = order
 				.output_chains
 				.first()
 				.map(|c| c.chain_id)
 				.ok_or_else(|| RecoveryError::Storage("No output chains in order".into()))?;
 
-			match self.delivery.get_status(fill_tx, chain_id).await {
+			match self.delivery.get_status(&fill_tx, chain_id).await {
 				Ok(true) => {
 					// Fill confirmed, check what's needed next
 					if order.fill_proof.is_some() {
 						// Already have attestation, settled and may need pre-claim
-						return Ok(ReconcileResult::NeedsPreClaim {
-							fill_proof: order.fill_proof.clone(),
-						});
+						return Ok((
+							order.clone(),
+							ReconcileResult::NeedsPreClaim {
+								fill_proof: order.fill_proof.clone(),
+							},
+						));
 					} else {
 						// Fill is confirmed but local post-fill state may be missing due to a
 						// crash after submission. Recover it before deciding to resubmit.
-						match self.settlement.recover_post_fill_state(order).await {
-							Ok(true) => return Ok(ReconcileResult::NeedsMonitoring),
+						match self.settlement.recover_post_fill_state(&order).await {
+							Ok(true) => return Ok((order, ReconcileResult::NeedsMonitoring)),
 							Ok(false) => {
 								// Need to process post-fill and get attestation
-								return Ok(ReconcileResult::NeedsPostFill);
+								return Ok((order, ReconcileResult::NeedsPostFill));
 							},
 							Err(e) => {
 								tracing::error!(
@@ -402,7 +521,7 @@ impl RecoveryService {
 						"Fill transaction {} failed/reverted",
 						with_0x_prefix(&hex::encode(&fill_tx.0))
 					);
-					return Ok(ReconcileResult::Failed(TransactionType::Fill));
+					return Ok((order, ReconcileResult::Failed(TransactionType::Fill)));
 				},
 				Err(e) => {
 					// Could not determine on-chain state. Surface as Unknown so the
@@ -411,28 +530,31 @@ impl RecoveryService {
 						"Could not get fill transaction status; treating as Unknown: {}",
 						e
 					);
-					return Ok(ReconcileResult::Unknown);
+					return Ok((order, ReconcileResult::Unknown));
 				},
 			}
 		}
 
 		// Check prepare transaction
-		if let Some(ref prepare_tx) = order.prepare_tx_hash {
+		if let Some(prepare_tx) = self
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::Prepare)
+			.await
+		{
 			let chain_id = order
 				.input_chains
 				.first()
 				.map(|c| c.chain_id)
 				.ok_or_else(|| RecoveryError::Storage("No input chains in order".into()))?;
 
-			match self.delivery.get_status(prepare_tx, chain_id).await {
+			match self.delivery.get_status(&prepare_tx, chain_id).await {
 				Ok(true) => {
 					// Transaction succeeded, prepare confirmed
-					return Ok(ReconcileResult::NeedsFill);
+					return Ok((order, ReconcileResult::NeedsFill));
 				},
 				Ok(false) => {
 					// Transaction failed/reverted
 					tracing::warn!("Prepare transaction {:?} failed/reverted", prepare_tx);
-					return Ok(ReconcileResult::Failed(TransactionType::Prepare));
+					return Ok((order, ReconcileResult::Failed(TransactionType::Prepare)));
 				},
 				Err(e) => {
 					// Could not determine on-chain state. Surface as Unknown so the
@@ -441,13 +563,13 @@ impl RecoveryService {
 						"Could not get prepare transaction status; treating as Unknown: {}",
 						e
 					);
-					return Ok(ReconcileResult::Unknown);
+					return Ok((order, ReconcileResult::Unknown));
 				},
 			}
 		}
 
 		// No transactions yet, needs execution
-		Ok(ReconcileResult::NeedsExecution)
+		Ok((order, ReconcileResult::NeedsExecution))
 	}
 
 	/// Ensures the order is in the correct state based on reconciliation result.
@@ -883,10 +1005,14 @@ mod tests {
 	use mockall::predicate::*;
 	use solver_delivery::MockDeliveryInterface;
 	use solver_settlement::MockSettlementInterface;
-	use solver_storage::MockStorageInterface;
+	use solver_storage::{
+		implementations::file::{FileStorage, TtlConfig},
+		MockStorageInterface,
+	};
 	use solver_types::{
 		utils::tests::builders::{IntentBuilder, OrderBuilder},
-		ExecutionParams, FillProof, TransactionHash,
+		Address, ExecutionParams, FillProof, Transaction, TransactionAttempt,
+		TransactionAttemptStatus, TransactionHash,
 	};
 	use std::collections::HashMap;
 
@@ -913,6 +1039,390 @@ mod tests {
 			filled_timestamp: 1234567890,
 			oracle_address: "0x1234567890123456789012345678901234567890".to_string(),
 		}
+	}
+
+	fn empty_attempt_store() -> Arc<TransactionAttemptStore> {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		Arc::new(TransactionAttemptStore::new(storage))
+	}
+
+	fn sample_attempt(
+		id: &str,
+		tx_type: TransactionType,
+		status: TransactionAttemptStatus,
+		hash_byte: Option<u8>,
+		updated_at: u64,
+	) -> TransactionAttempt {
+		let mut attempt = TransactionAttempt::planned(
+			id.to_string(),
+			"test_order_123".to_string(),
+			Some(Address(vec![9; 20])),
+			tx_type,
+			Transaction {
+				to: Some(Address(vec![3; 20])),
+				data: vec![0xde, 0xad, 0xbe, 0xef],
+				value: alloy_primitives::U256::ZERO,
+				chain_id: 137,
+				nonce: Some(7),
+				gas_limit: Some(120000),
+				gas_price: None,
+				max_fee_per_gas: Some(2000),
+				max_priority_fee_per_gas: Some(20),
+			},
+		);
+		attempt.status = status;
+		attempt.tx_hash = hash_byte.map(|byte| TransactionHash(vec![byte; 32]));
+		attempt.updated_at = updated_at;
+		attempt
+	}
+
+	#[test]
+	fn choose_recovery_attempt_hash_prefers_confirmed_over_newer_broadcast() {
+		let attempts = vec![
+			sample_attempt(
+				"broadcast",
+				TransactionType::Fill,
+				TransactionAttemptStatus::Broadcast,
+				Some(0xbb),
+				200,
+			),
+			sample_attempt(
+				"confirmed",
+				TransactionType::Fill,
+				TransactionAttemptStatus::Confirmed,
+				Some(0xcc),
+				100,
+			),
+		];
+
+		let hash = choose_recovery_attempt_hash(&attempts, TransactionType::Fill).unwrap();
+
+		assert_eq!(hash, TransactionHash(vec![0xcc; 32]));
+	}
+
+	#[test]
+	fn choose_recovery_attempt_hash_uses_newest_indeterminate_when_no_better_attempt_exists() {
+		let attempts = vec![
+			sample_attempt(
+				"old",
+				TransactionType::Claim,
+				TransactionAttemptStatus::Indeterminate,
+				Some(0x11),
+				100,
+			),
+			sample_attempt(
+				"new",
+				TransactionType::Claim,
+				TransactionAttemptStatus::Indeterminate,
+				Some(0x22),
+				200,
+			),
+		];
+
+		let hash = choose_recovery_attempt_hash(&attempts, TransactionType::Claim).unwrap();
+
+		assert_eq!(hash, TransactionHash(vec![0x22; 32]));
+	}
+
+	#[test]
+	fn choose_recovery_attempt_hash_ignores_planned_reverted_and_submit_rejected() {
+		let attempts = vec![
+			sample_attempt(
+				"planned",
+				TransactionType::Fill,
+				TransactionAttemptStatus::Planned,
+				Some(0x01),
+				300,
+			),
+			sample_attempt(
+				"reverted",
+				TransactionType::Fill,
+				TransactionAttemptStatus::Reverted,
+				Some(0x02),
+				200,
+			),
+			sample_attempt(
+				"rejected",
+				TransactionType::Fill,
+				TransactionAttemptStatus::SubmitRejected,
+				Some(0x03),
+				100,
+			),
+		];
+
+		assert!(choose_recovery_attempt_hash(&attempts, TransactionType::Fill).is_none());
+	}
+
+	#[test]
+	fn choose_recovery_attempt_hash_ignores_wrong_transaction_type() {
+		let attempts = vec![sample_attempt(
+			"claim",
+			TransactionType::Claim,
+			TransactionAttemptStatus::Confirmed,
+			Some(0xcc),
+			100,
+		)];
+
+		assert!(choose_recovery_attempt_hash(&attempts, TransactionType::Fill).is_none());
+	}
+
+	fn sample_tx(chain_id: u64) -> Transaction {
+		Transaction {
+			to: Some(Address(vec![3; 20])),
+			data: vec![0xde, 0xad, 0xbe, 0xef],
+			value: alloy_primitives::U256::ZERO,
+			chain_id,
+			nonce: Some(7),
+			gas_limit: Some(120000),
+			gas_price: None,
+			max_fee_per_gas: Some(2000),
+			max_priority_fee_per_gas: Some(20),
+		}
+	}
+
+	#[tokio::test]
+	async fn recovery_repairs_missing_fill_hash_from_broadcast_attempt() {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
+
+		let mut order = create_test_order_with_status(OrderStatus::Executed);
+		order.fill_tx_hash = None;
+		order.post_fill_tx_hash = None;
+		order.settlement_name = Some("eip7683".to_string());
+		state_machine.store_order(&order).await.unwrap();
+
+		let tx_hash = TransactionHash(vec![0xbb; 32]);
+		let attempt = attempt_store
+			.create_planned_attempt(
+				&order.id,
+				Some(Address(vec![9; 20])),
+				TransactionType::Fill,
+				sample_tx(137),
+			)
+			.await
+			.unwrap();
+		attempt_store
+			.update_attempt_status(
+				&attempt.id,
+				TransactionAttemptStatus::Broadcast,
+				None,
+				|attempt| {
+					attempt.tx_hash = Some(tx_hash.clone());
+				},
+			)
+			.await
+			.unwrap();
+
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery
+			.expect_get_receipt()
+			.with(eq(tx_hash.clone()), eq(137u64))
+			.times(1)
+			.returning(move |hash, _| {
+				let hash = hash.clone();
+				Box::pin(async move {
+					Ok(solver_types::TransactionReceipt {
+						hash,
+						block_number: 12345,
+						success: true,
+						block_timestamp: None,
+						logs: vec![],
+					})
+				})
+			});
+		let delivery = Arc::new(DeliveryService::new(
+			HashMap::from([(
+				137u64,
+				Arc::new(mock_delivery) as Arc<dyn solver_delivery::DeliveryInterface>,
+			)]),
+			1,
+			20,
+			60,
+		));
+
+		let mut mock_settlement = MockSettlementInterface::new();
+		mock_settlement
+			.expect_recover_post_fill_state()
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(false) }));
+		let settlement = Arc::new(SettlementService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+			)]),
+			String::new(),
+			20,
+		));
+		let event_bus = EventBus::new(100);
+
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine.clone(),
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+		);
+
+		let (repaired_order, result) = recovery_service
+			.reconcile_with_blockchain(&order)
+			.await
+			.unwrap();
+
+		assert!(matches!(result, ReconcileResult::NeedsPostFill));
+		assert_eq!(repaired_order.fill_tx_hash, Some(tx_hash.clone()));
+		let stored = state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.fill_tx_hash, Some(tx_hash));
+	}
+
+	#[tokio::test]
+	async fn recovery_uses_claim_attempt_before_fill_attempt() {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
+
+		let mut order = create_test_order_with_status(OrderStatus::Settled);
+		order.fill_tx_hash = None;
+		order.claim_tx_hash = None;
+		state_machine.store_order(&order).await.unwrap();
+
+		let fill_hash = TransactionHash(vec![0xf1; 32]);
+		let claim_hash = TransactionHash(vec![0xc1; 32]);
+
+		for (tx_type, tx_hash, chain_id) in [
+			(TransactionType::Fill, fill_hash.clone(), 137),
+			(TransactionType::Claim, claim_hash.clone(), 1),
+		] {
+			let attempt = attempt_store
+				.create_planned_attempt(
+					&order.id,
+					Some(Address(vec![9; 20])),
+					tx_type,
+					sample_tx(chain_id),
+				)
+				.await
+				.unwrap();
+			attempt_store
+				.update_attempt_status(
+					&attempt.id,
+					TransactionAttemptStatus::Confirmed,
+					None,
+					|attempt| {
+						attempt.tx_hash = Some(tx_hash);
+					},
+				)
+				.await
+				.unwrap();
+		}
+
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery
+			.expect_get_receipt()
+			.with(eq(claim_hash.clone()), eq(1u64))
+			.times(1)
+			.returning(move |hash, _| {
+				let hash = hash.clone();
+				Box::pin(async move {
+					Ok(solver_types::TransactionReceipt {
+						hash,
+						block_number: 999,
+						success: true,
+						block_timestamp: None,
+						logs: vec![],
+					})
+				})
+			});
+		let delivery = Arc::new(DeliveryService::new(
+			HashMap::from([(
+				1u64,
+				Arc::new(mock_delivery) as Arc<dyn solver_delivery::DeliveryInterface>,
+			)]),
+			1,
+			20,
+			60,
+		));
+
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine.clone(),
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+		);
+
+		let (repaired_order, result) = recovery_service
+			.reconcile_with_blockchain(&order)
+			.await
+			.unwrap();
+
+		assert!(matches!(result, ReconcileResult::Finalized));
+		assert_eq!(repaired_order.claim_tx_hash, Some(claim_hash.clone()));
+		let stored = state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.claim_tx_hash, Some(claim_hash));
+	}
+
+	#[tokio::test]
+	async fn recovery_continues_with_recovered_hash_when_order_writeback_fails() {
+		let mut mock_storage = MockStorageInterface::new();
+		mock_storage
+			.expect_get_bytes()
+			.with(eq("orders:test_order_123"))
+			.times(1)
+			.returning(|_| {
+				Box::pin(async move {
+					Err(solver_storage::StorageError::Backend(
+						"writeback unavailable".to_string(),
+					))
+				})
+			});
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let recovery_service = RecoveryService::new(
+			storage,
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
+
+		let mut order = create_test_order_with_status(OrderStatus::Executed);
+		order.fill_tx_hash = None;
+		let recovered_hash = TransactionHash(vec![0xbb; 32]);
+		let attempts = vec![sample_attempt(
+			"fill",
+			TransactionType::Fill,
+			TransactionAttemptStatus::Broadcast,
+			Some(0xbb),
+			100,
+		)];
+
+		let hash = recovery_service
+			.resolve_and_repair_stage_hash(&mut order, &attempts, TransactionType::Fill)
+			.await;
+
+		assert_eq!(hash, Some(recovered_hash.clone()));
+		assert_eq!(order.fill_tx_hash, Some(recovered_hash));
 	}
 
 	#[tokio::test]
@@ -942,8 +1452,14 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		// Test recovery with no orders
 		let result = recovery_service.recover_state().await;
@@ -990,8 +1506,14 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.load_active_orders().await;
 		assert!(result.is_ok());
@@ -1043,8 +1565,14 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let orders = recovery_service.load_active_orders().await.unwrap();
 		assert!(orders.is_empty());
@@ -1100,8 +1628,14 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.recover_orphaned_intents().await;
 		assert!(result.is_ok());
@@ -1126,13 +1660,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::NeedsExecution => {},
 			_ => panic!("Expected NeedsExecution"),
 		}
@@ -1177,13 +1717,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::NeedsFill => {},
 			_ => panic!("Expected NeedsFill"),
 		}
@@ -1230,13 +1776,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::NeedsClaim { fill_proof } => {
 				assert!(fill_proof.is_some());
 			},
@@ -1291,13 +1843,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::NeedsMonitoring => {},
 			other => panic!("Expected NeedsMonitoring, got {other:?}"),
 		}
@@ -1350,12 +1908,18 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
-		assert!(matches!(result.unwrap(), ReconcileResult::NeedsPostFill));
+		assert!(matches!(result.unwrap().1, ReconcileResult::NeedsPostFill));
 	}
 
 	#[tokio::test]
@@ -1411,8 +1975,14 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_err());
@@ -1457,13 +2027,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::Finalized => {},
 			_ => panic!("Expected Finalized"),
 		}
@@ -1507,13 +2083,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::Failed(TransactionType::Prepare) => {},
 			_ => panic!("Expected Failed(Prepare)"),
 		}
@@ -1558,13 +2140,19 @@ mod tests {
 		let settlement = Arc::new(SettlementService::new(settlement_impls, String::new(), 20));
 		let event_bus = EventBus::new(100);
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let result = recovery_service.reconcile_with_blockchain(&order).await;
 		assert!(result.is_ok());
 
-		match result.unwrap() {
+		match result.unwrap().1 {
 			ReconcileResult::Unknown => {},
 			other => panic!("Expected Unknown for RPC error, got {other:?}"),
 		}
@@ -1612,8 +2200,14 @@ mod tests {
 		// Subscribe to events
 		let mut receiver = event_bus.subscribe();
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		recovery_service
 			.publish_recovery_event(
@@ -1671,8 +2265,14 @@ mod tests {
 		// Subscribe to events
 		let mut receiver = event_bus.subscribe();
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		let order = create_test_order_with_status(OrderStatus::Created);
 		recovery_service
@@ -1728,8 +2328,14 @@ mod tests {
 		let event_bus = EventBus::new(100);
 		let mut receiver = event_bus.subscribe();
 
-		let recovery_service =
-			RecoveryService::new(storage, state_machine, delivery, settlement, event_bus);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			empty_attempt_store(),
+		);
 
 		recovery_service
 			.publish_recovery_event(
@@ -1793,6 +2399,7 @@ mod tests {
 			delivery,
 			settlement,
 			event_bus,
+			empty_attempt_store(),
 		);
 
 		recovery_service

--- a/crates/solver-core/src/state/mod.rs
+++ b/crates/solver-core/src/state/mod.rs
@@ -5,5 +5,6 @@
 //! maintaining data consistency.
 
 pub mod order;
+pub mod transaction_attempt;
 
 pub use order::{OrderStateError, OrderStateMachine};

--- a/crates/solver-core/src/state/transaction_attempt.rs
+++ b/crates/solver-core/src/state/transaction_attempt.rs
@@ -27,6 +27,8 @@ pub enum TransactionAttemptStoreError {
 	NotFound(String),
 	#[error("transaction attempt is terminal and cannot be updated: {0}")]
 	TerminalAttempt(String),
+	#[error("transaction attempt changed concurrently: {0}")]
+	ConcurrentModification(String),
 }
 
 impl From<StorageError> for TransactionAttemptStoreError {
@@ -150,7 +152,11 @@ impl TransactionAttemptStore {
 	where
 		F: FnOnce(&mut TransactionAttempt),
 	{
-		let mut attempt = self.get_attempt(attempt_id).await?;
+		let namespace = StorageKey::TransactionAttempts.as_str();
+		let current_bytes = self.storage.retrieve_bytes(namespace, attempt_id).await?;
+		let mut attempt: TransactionAttempt = serde_json::from_slice(&current_bytes)
+			.map_err(|e| TransactionAttemptStoreError::Storage(e.to_string()))?;
+
 		if attempt.is_terminal() {
 			return Err(TransactionAttemptStoreError::TerminalAttempt(
 				attempt_id.to_string(),
@@ -162,16 +168,38 @@ impl TransactionAttemptStore {
 		attempt.error = error;
 		attempt.updated_at = current_timestamp();
 
-		self.storage
-			.update(
-				StorageKey::TransactionAttempts.as_str(),
+		let updated_bytes = serde_json::to_vec(&attempt)
+			.map_err(|e| TransactionAttemptStoreError::Storage(e.to_string()))?;
+
+		let swapped = self
+			.storage
+			.compare_and_swap_bytes(
+				namespace,
 				&attempt.id,
-				&attempt,
+				&current_bytes,
+				updated_bytes,
 				Some(transaction_attempt_indexes(&attempt)),
+				None,
 			)
 			.await?;
 
-		Ok(attempt)
+		if swapped {
+			return Ok(attempt);
+		}
+
+		let latest_bytes = self.storage.retrieve_bytes(namespace, attempt_id).await?;
+		let latest: TransactionAttempt = serde_json::from_slice(&latest_bytes)
+			.map_err(|e| TransactionAttemptStoreError::Storage(e.to_string()))?;
+
+		if latest.is_terminal() {
+			return Err(TransactionAttemptStoreError::TerminalAttempt(
+				attempt_id.to_string(),
+			));
+		}
+
+		Err(TransactionAttemptStoreError::ConcurrentModification(
+			attempt_id.to_string(),
+		))
 	}
 }
 

--- a/crates/solver-core/src/state/transaction_attempt.rs
+++ b/crates/solver-core/src/state/transaction_attempt.rs
@@ -10,7 +10,7 @@ use solver_delivery::{TransactionAttemptRecorder, TransactionAttemptRecorderErro
 use solver_storage::{QueryFilter, StorageError, StorageIndexes, StorageService};
 use solver_types::{
 	current_timestamp, Address, StorageKey, Transaction, TransactionAttempt,
-	TransactionAttemptStatus, TransactionHash, TransactionType,
+	TransactionAttemptStatus, TransactionHash, TransactionReceipt, TransactionType,
 };
 use thiserror::Error;
 use uuid::Uuid;
@@ -189,15 +189,24 @@ impl TransactionAttemptRecorder for TransactionAttemptStore {
 			.map_err(|e| TransactionAttemptRecorderError::Storage(e.to_string()))
 	}
 
-	async fn record_attempt_status(
+	async fn record_attempt_update(
 		&self,
 		attempt_id: &str,
 		status: TransactionAttemptStatus,
+		tx_hash: Option<TransactionHash>,
+		receipt: Option<TransactionReceipt>,
 		error: Option<String>,
 	) -> Result<(), TransactionAttemptRecorderError> {
-		self.update_attempt_status(attempt_id, status, error, |_| {})
-			.await
-			.map_err(|e| TransactionAttemptRecorderError::Storage(e.to_string()))?;
+		self.update_attempt_status(attempt_id, status, error, |attempt| {
+			if let Some(tx_hash) = tx_hash {
+				attempt.tx_hash = Some(tx_hash);
+			}
+			if let Some(receipt) = receipt {
+				attempt.receipt = Some(receipt);
+			}
+		})
+		.await
+		.map_err(|e| TransactionAttemptRecorderError::Storage(e.to_string()))?;
 		Ok(())
 	}
 }

--- a/crates/solver-core/src/state/transaction_attempt.rs
+++ b/crates/solver-core/src/state/transaction_attempt.rs
@@ -1,0 +1,203 @@
+//! Durable transaction attempt storage.
+//!
+//! This ledger tracks delivery attempts separately from the order lifecycle so
+//! recovery can reason about what was broadcast without adding transport states
+//! to `OrderStatus`.
+
+use std::sync::Arc;
+
+use solver_delivery::{TransactionAttemptRecorder, TransactionAttemptRecorderError};
+use solver_storage::{QueryFilter, StorageError, StorageIndexes, StorageService};
+use solver_types::{
+	current_timestamp, Address, StorageKey, Transaction, TransactionAttempt,
+	TransactionAttemptStatus, TransactionHash, TransactionType,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+const ORDER_ID_INDEX_FIELD: &str = "order_id";
+const TX_HASH_INDEX_FIELD: &str = "tx_hash";
+const IS_TERMINAL_INDEX_FIELD: &str = "is_terminal";
+
+#[derive(Debug, Error)]
+pub enum TransactionAttemptStoreError {
+	#[error("storage error: {0}")]
+	Storage(String),
+	#[error("transaction attempt not found: {0}")]
+	NotFound(String),
+	#[error("transaction attempt is terminal and cannot be updated: {0}")]
+	TerminalAttempt(String),
+}
+
+impl From<StorageError> for TransactionAttemptStoreError {
+	fn from(value: StorageError) -> Self {
+		match value {
+			StorageError::NotFound(id) => Self::NotFound(id),
+			other => Self::Storage(other.to_string()),
+		}
+	}
+}
+
+pub struct TransactionAttemptStore {
+	storage: Arc<StorageService>,
+}
+
+fn tx_hash_index_value(tx_hash: &TransactionHash) -> String {
+	hex::encode(&tx_hash.0)
+}
+
+fn transaction_attempt_indexes(attempt: &TransactionAttempt) -> StorageIndexes {
+	let mut indexes = StorageIndexes::new()
+		.with_field(ORDER_ID_INDEX_FIELD, &attempt.order_id)
+		.with_field(IS_TERMINAL_INDEX_FIELD, attempt.is_terminal());
+
+	if let Some(tx_hash) = &attempt.tx_hash {
+		indexes = indexes.with_field(TX_HASH_INDEX_FIELD, tx_hash_index_value(tx_hash));
+	}
+
+	indexes
+}
+
+impl TransactionAttemptStore {
+	pub fn new(storage: Arc<StorageService>) -> Self {
+		Self { storage }
+	}
+
+	pub async fn create_planned_attempt(
+		&self,
+		order_id: &str,
+		signer: Option<Address>,
+		tx_type: TransactionType,
+		tx: Transaction,
+	) -> Result<TransactionAttempt, TransactionAttemptStoreError> {
+		let attempt = TransactionAttempt::planned(
+			Uuid::new_v4().hyphenated().to_string(),
+			order_id.to_string(),
+			signer,
+			tx_type,
+			tx,
+		);
+		self.save_attempt(&attempt).await?;
+		Ok(attempt)
+	}
+
+	pub async fn save_attempt(
+		&self,
+		attempt: &TransactionAttempt,
+	) -> Result<(), TransactionAttemptStoreError> {
+		self.storage
+			.store(
+				StorageKey::TransactionAttempts.as_str(),
+				&attempt.id,
+				attempt,
+				Some(transaction_attempt_indexes(attempt)),
+			)
+			.await?;
+		Ok(())
+	}
+
+	pub async fn get_attempt(
+		&self,
+		attempt_id: &str,
+	) -> Result<TransactionAttempt, TransactionAttemptStoreError> {
+		Ok(self
+			.storage
+			.retrieve(StorageKey::TransactionAttempts.as_str(), attempt_id)
+			.await?)
+	}
+
+	pub async fn attempts_for_order(
+		&self,
+		order_id: &str,
+	) -> Result<Vec<TransactionAttempt>, TransactionAttemptStoreError> {
+		let rows = self
+			.storage
+			.query(
+				StorageKey::TransactionAttempts.as_str(),
+				QueryFilter::Equals(
+					ORDER_ID_INDEX_FIELD.to_string(),
+					serde_json::json!(order_id),
+				),
+			)
+			.await?;
+		Ok(rows.into_iter().map(|(_, attempt)| attempt).collect())
+	}
+
+	pub async fn attempt_by_hash(
+		&self,
+		tx_hash: &TransactionHash,
+	) -> Result<Option<TransactionAttempt>, TransactionAttemptStoreError> {
+		let rows = self
+			.storage
+			.query(
+				StorageKey::TransactionAttempts.as_str(),
+				QueryFilter::Equals(
+					TX_HASH_INDEX_FIELD.to_string(),
+					serde_json::json!(tx_hash_index_value(tx_hash)),
+				),
+			)
+			.await?;
+		Ok(rows.into_iter().map(|(_, attempt)| attempt).next())
+	}
+
+	pub async fn update_attempt_status<F>(
+		&self,
+		attempt_id: &str,
+		status: TransactionAttemptStatus,
+		error: Option<String>,
+		mutate: F,
+	) -> Result<TransactionAttempt, TransactionAttemptStoreError>
+	where
+		F: FnOnce(&mut TransactionAttempt),
+	{
+		let mut attempt = self.get_attempt(attempt_id).await?;
+		if attempt.is_terminal() {
+			return Err(TransactionAttemptStoreError::TerminalAttempt(
+				attempt_id.to_string(),
+			));
+		}
+
+		mutate(&mut attempt);
+		attempt.status = status;
+		attempt.error = error;
+		attempt.updated_at = current_timestamp();
+
+		self.storage
+			.update(
+				StorageKey::TransactionAttempts.as_str(),
+				&attempt.id,
+				&attempt,
+				Some(transaction_attempt_indexes(&attempt)),
+			)
+			.await?;
+
+		Ok(attempt)
+	}
+}
+
+#[async_trait::async_trait]
+impl TransactionAttemptRecorder for TransactionAttemptStore {
+	async fn record_planned_attempt(
+		&self,
+		order_id: &str,
+		signer: Option<Address>,
+		tx_type: TransactionType,
+		tx: Transaction,
+	) -> Result<TransactionAttempt, TransactionAttemptRecorderError> {
+		self.create_planned_attempt(order_id, signer, tx_type, tx)
+			.await
+			.map_err(|e| TransactionAttemptRecorderError::Storage(e.to_string()))
+	}
+
+	async fn record_attempt_status(
+		&self,
+		attempt_id: &str,
+		status: TransactionAttemptStatus,
+		error: Option<String>,
+	) -> Result<(), TransactionAttemptRecorderError> {
+		self.update_attempt_status(attempt_id, status, error, |_| {})
+			.await
+			.map_err(|e| TransactionAttemptRecorderError::Storage(e.to_string()))?;
+		Ok(())
+	}
+}

--- a/crates/solver-core/tests/transaction_attempt_store.rs
+++ b/crates/solver-core/tests/transaction_attempt_store.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use alloy_primitives::U256;
+use solver_core::state::transaction_attempt::TransactionAttemptStore;
+use solver_storage::{
+	implementations::file::{FileStorage, TtlConfig},
+	StorageService,
+};
+use solver_types::{
+	Address, Transaction, TransactionAttemptStatus, TransactionHash, TransactionType,
+};
+use tempfile::TempDir;
+
+fn make_store() -> (TransactionAttemptStore, TempDir) {
+	let temp_dir = tempfile::tempdir().unwrap();
+	let path = temp_dir.path().to_path_buf();
+	let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+		path,
+		TtlConfig::default(),
+	))));
+	(TransactionAttemptStore::new(storage), temp_dir)
+}
+
+fn sample_tx(chain_id: u64, nonce: Option<u64>) -> Transaction {
+	Transaction {
+		to: Some(Address(vec![3; 20])),
+		data: vec![0xde, 0xad, 0xbe, 0xef],
+		value: U256::ZERO,
+		chain_id,
+		nonce,
+		gas_limit: Some(120000),
+		gas_price: None,
+		max_fee_per_gas: Some(2000),
+		max_priority_fee_per_gas: Some(20),
+	}
+}
+
+fn sample_hash(byte: u8) -> TransactionHash {
+	TransactionHash(vec![byte; 32])
+}
+
+#[tokio::test]
+async fn create_planned_attempt_persists_with_v4_id() {
+	let (store, _temp_dir) = make_store();
+
+	let attempt = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(7)),
+		)
+		.await
+		.unwrap();
+
+	let parsed_id = uuid::Uuid::parse_str(&attempt.id).unwrap();
+	assert_eq!(parsed_id.get_version_num(), 4);
+	assert_eq!(attempt.order_id, "order-1");
+	assert_eq!(attempt.signer, Some(Address(vec![9; 20])));
+	assert_eq!(attempt.tx_type, TransactionType::Fill);
+	assert_eq!(attempt.chain_id, 10);
+	assert_eq!(attempt.nonce, Some(7));
+	assert_eq!(attempt.status, TransactionAttemptStatus::Planned);
+
+	let loaded = store.get_attempt(&attempt.id).await.unwrap();
+	assert_eq!(loaded.id, attempt.id);
+	assert_eq!(loaded.order_id, attempt.order_id);
+	assert_eq!(loaded.signer, attempt.signer);
+	assert_eq!(loaded.tx_type, attempt.tx_type);
+	assert_eq!(loaded.chain_id, attempt.chain_id);
+	assert_eq!(loaded.nonce, attempt.nonce);
+	assert_eq!(loaded.tx_hash, attempt.tx_hash);
+	assert_eq!(loaded.receipt, attempt.receipt);
+	assert_eq!(loaded.status, attempt.status);
+	assert_eq!(loaded.error, attempt.error);
+	assert_eq!(loaded.created_at, attempt.created_at);
+	assert_eq!(loaded.updated_at, attempt.updated_at);
+	assert_eq!(loaded.tx.chain_id, attempt.tx.chain_id);
+	assert_eq!(loaded.tx.nonce, attempt.tx.nonce);
+	assert_eq!(loaded.tx.data, attempt.tx.data);
+}
+
+#[tokio::test]
+async fn attempts_for_order_returns_only_matching_order_attempts() {
+	let (store, _temp_dir) = make_store();
+
+	let first = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(1)),
+		)
+		.await
+		.unwrap();
+	let second = store
+		.create_planned_attempt(
+			"order-2",
+			Some(Address(vec![8; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(2)),
+		)
+		.await
+		.unwrap();
+
+	let order_one_attempts = store.attempts_for_order("order-1").await.unwrap();
+
+	assert_eq!(order_one_attempts.len(), 1);
+	assert_eq!(order_one_attempts[0].id, first.id);
+	assert_ne!(order_one_attempts[0].id, second.id);
+}
+
+#[tokio::test]
+async fn update_attempt_status_sets_hash_and_hash_lookup_finds_it() {
+	let (store, _temp_dir) = make_store();
+	let attempt = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(7)),
+		)
+		.await
+		.unwrap();
+	let tx_hash = sample_hash(9);
+
+	let updated = store
+		.update_attempt_status(
+			&attempt.id,
+			TransactionAttemptStatus::Broadcast,
+			None,
+			|attempt| {
+				attempt.tx_hash = Some(tx_hash.clone());
+			},
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(updated.status, TransactionAttemptStatus::Broadcast);
+	assert_eq!(updated.tx_hash, Some(tx_hash.clone()));
+	assert!(updated.updated_at >= updated.created_at);
+
+	let by_hash = store.attempt_by_hash(&tx_hash).await.unwrap().unwrap();
+	assert_eq!(by_hash.id, attempt.id);
+}
+
+#[tokio::test]
+async fn terminal_attempt_cannot_be_mutated() {
+	let (store, _temp_dir) = make_store();
+	let attempt = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(7)),
+		)
+		.await
+		.unwrap();
+
+	store
+		.update_attempt_status(
+			&attempt.id,
+			TransactionAttemptStatus::Confirmed,
+			None,
+			|attempt| {
+				attempt.tx_hash = Some(sample_hash(1));
+			},
+		)
+		.await
+		.unwrap();
+
+	let err = store
+		.update_attempt_status(
+			&attempt.id,
+			TransactionAttemptStatus::Reverted,
+			Some("late revert".to_string()),
+			|_| {},
+		)
+		.await
+		.unwrap_err();
+
+	assert!(err.to_string().contains("terminal"));
+	let loaded = store.get_attempt(&attempt.id).await.unwrap();
+	assert_eq!(loaded.status, TransactionAttemptStatus::Confirmed);
+	assert_eq!(loaded.error, None);
+}

--- a/crates/solver-core/tests/transaction_attempt_store.rs
+++ b/crates/solver-core/tests/transaction_attempt_store.rs
@@ -1,15 +1,20 @@
-use std::sync::Arc;
+use std::sync::{
+	atomic::{AtomicUsize, Ordering},
+	Arc,
+};
 
 use alloy_primitives::U256;
-use solver_core::state::transaction_attempt::TransactionAttemptStore;
+use solver_core::state::transaction_attempt::{
+	TransactionAttemptStore, TransactionAttemptStoreError,
+};
 use solver_delivery::TransactionAttemptRecorder;
 use solver_storage::{
 	implementations::file::{FileStorage, TtlConfig},
-	StorageService,
+	MockStorageInterface, StorageService,
 };
 use solver_types::{
-	Address, Transaction, TransactionAttemptStatus, TransactionHash, TransactionReceipt,
-	TransactionType,
+	Address, StorageKey, Transaction, TransactionAttempt, TransactionAttemptStatus,
+	TransactionHash, TransactionReceipt, TransactionType,
 };
 use tempfile::TempDir;
 
@@ -49,6 +54,21 @@ fn sample_receipt(hash: TransactionHash, success: bool) -> TransactionReceipt {
 		logs: vec![],
 		block_timestamp: Some(456),
 	}
+}
+
+fn sample_attempt_with_id_and_status(
+	id: &str,
+	status: TransactionAttemptStatus,
+) -> TransactionAttempt {
+	let mut attempt = TransactionAttempt::planned(
+		id.to_string(),
+		"order-1".to_string(),
+		Some(Address(vec![9; 20])),
+		TransactionType::Fill,
+		sample_tx(10, Some(7)),
+	);
+	attempt.status = status;
+	attempt
 }
 
 #[tokio::test]
@@ -267,4 +287,115 @@ async fn terminal_attempt_cannot_be_mutated() {
 	let loaded = store.get_attempt(&attempt.id).await.unwrap();
 	assert_eq!(loaded.status, TransactionAttemptStatus::Confirmed);
 	assert_eq!(loaded.error, None);
+}
+
+#[tokio::test]
+async fn update_attempt_status_rejects_when_cas_loser_sees_terminal_attempt() {
+	let attempt_id = "attempt-race-terminal";
+	let key = format!("{}:{attempt_id}", StorageKey::TransactionAttempts.as_str());
+
+	let non_terminal =
+		sample_attempt_with_id_and_status(attempt_id, TransactionAttemptStatus::Broadcast);
+	let terminal =
+		sample_attempt_with_id_and_status(attempt_id, TransactionAttemptStatus::Confirmed);
+	let non_terminal_bytes = serde_json::to_vec(&non_terminal).unwrap();
+	let terminal_bytes = serde_json::to_vec(&terminal).unwrap();
+	let read_count = Arc::new(AtomicUsize::new(0));
+
+	let mut backend = MockStorageInterface::new();
+	{
+		let key = key.clone();
+		let read_count = read_count.clone();
+		let non_terminal_bytes = non_terminal_bytes.clone();
+		let terminal_bytes = terminal_bytes.clone();
+		backend
+			.expect_get_bytes()
+			.withf(move |actual| actual == key.as_str())
+			.times(2)
+			.returning(move |_| {
+				let call = read_count.fetch_add(1, Ordering::SeqCst);
+				let bytes = if call == 0 {
+					non_terminal_bytes.clone()
+				} else {
+					terminal_bytes.clone()
+				};
+				Box::pin(async move { Ok(bytes) })
+			});
+	}
+
+	backend
+		.expect_compare_and_swap_with_indexes()
+		.times(1)
+		.returning(|_, _, _, _, _| Box::pin(async move { Ok(false) }));
+
+	let store = TransactionAttemptStore::new(Arc::new(StorageService::new(Box::new(backend))));
+
+	let result = store
+		.update_attempt_status(
+			attempt_id,
+			TransactionAttemptStatus::Indeterminate,
+			Some("monitor timeout".to_string()),
+			|_| {},
+		)
+		.await;
+
+	assert!(matches!(
+		result,
+		Err(TransactionAttemptStoreError::TerminalAttempt(id)) if id == attempt_id
+	));
+}
+
+#[tokio::test]
+async fn update_attempt_status_returns_conflict_when_cas_loser_sees_non_terminal_attempt() {
+	let attempt_id = "attempt-race-active";
+	let key = format!("{}:{attempt_id}", StorageKey::TransactionAttempts.as_str());
+
+	let first = sample_attempt_with_id_and_status(attempt_id, TransactionAttemptStatus::Broadcast);
+	let second =
+		sample_attempt_with_id_and_status(attempt_id, TransactionAttemptStatus::Indeterminate);
+	let first_bytes = serde_json::to_vec(&first).unwrap();
+	let second_bytes = serde_json::to_vec(&second).unwrap();
+	let read_count = Arc::new(AtomicUsize::new(0));
+
+	let mut backend = MockStorageInterface::new();
+	{
+		let key = key.clone();
+		let read_count = read_count.clone();
+		let first_bytes = first_bytes.clone();
+		let second_bytes = second_bytes.clone();
+		backend
+			.expect_get_bytes()
+			.withf(move |actual| actual == key.as_str())
+			.times(2)
+			.returning(move |_| {
+				let call = read_count.fetch_add(1, Ordering::SeqCst);
+				let bytes = if call == 0 {
+					first_bytes.clone()
+				} else {
+					second_bytes.clone()
+				};
+				Box::pin(async move { Ok(bytes) })
+			});
+	}
+
+	backend
+		.expect_compare_and_swap_with_indexes()
+		.times(1)
+		.returning(|_, _, _, _, _| Box::pin(async move { Ok(false) }));
+
+	let store = TransactionAttemptStore::new(Arc::new(StorageService::new(Box::new(backend))));
+
+	let result = store
+		.update_attempt_status(
+			attempt_id,
+			TransactionAttemptStatus::Confirmed,
+			None,
+			|_| {},
+		)
+		.await;
+
+	assert!(matches!(
+		result,
+		Err(TransactionAttemptStoreError::ConcurrentModification(id)) if id == attempt_id
+	));
 }

--- a/crates/solver-core/tests/transaction_attempt_store.rs
+++ b/crates/solver-core/tests/transaction_attempt_store.rs
@@ -2,12 +2,14 @@ use std::sync::Arc;
 
 use alloy_primitives::U256;
 use solver_core::state::transaction_attempt::TransactionAttemptStore;
+use solver_delivery::TransactionAttemptRecorder;
 use solver_storage::{
 	implementations::file::{FileStorage, TtlConfig},
 	StorageService,
 };
 use solver_types::{
-	Address, Transaction, TransactionAttemptStatus, TransactionHash, TransactionType,
+	Address, Transaction, TransactionAttemptStatus, TransactionHash, TransactionReceipt,
+	TransactionType,
 };
 use tempfile::TempDir;
 
@@ -37,6 +39,16 @@ fn sample_tx(chain_id: u64, nonce: Option<u64>) -> Transaction {
 
 fn sample_hash(byte: u8) -> TransactionHash {
 	TransactionHash(vec![byte; 32])
+}
+
+fn sample_receipt(hash: TransactionHash, success: bool) -> TransactionReceipt {
+	TransactionReceipt {
+		hash,
+		block_number: 123,
+		success,
+		logs: vec![],
+		block_timestamp: Some(456),
+	}
 }
 
 #[tokio::test]
@@ -142,6 +154,78 @@ async fn update_attempt_status_sets_hash_and_hash_lookup_finds_it() {
 
 	let by_hash = store.attempt_by_hash(&tx_hash).await.unwrap().unwrap();
 	assert_eq!(by_hash.id, attempt.id);
+}
+
+#[tokio::test]
+async fn recorder_update_persists_broadcast_hash_index() {
+	let (store, _temp_dir) = make_store();
+	let tx_hash = sample_hash(7);
+	let attempt = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(10, Some(7)),
+		)
+		.await
+		.unwrap();
+
+	store
+		.record_attempt_update(
+			&attempt.id,
+			TransactionAttemptStatus::Broadcast,
+			Some(tx_hash.clone()),
+			None,
+			None,
+		)
+		.await
+		.unwrap();
+
+	let stored = store.get_attempt(&attempt.id).await.unwrap();
+	assert_eq!(stored.status, TransactionAttemptStatus::Broadcast);
+	assert_eq!(stored.tx_hash, Some(tx_hash.clone()));
+	assert_eq!(stored.receipt, None);
+	assert_eq!(stored.error, None);
+
+	let by_hash = store.attempt_by_hash(&tx_hash).await.unwrap().unwrap();
+	assert_eq!(by_hash.id, attempt.id);
+}
+
+#[tokio::test]
+async fn recorder_update_persists_confirmed_receipt() {
+	let (store, _temp_dir) = make_store();
+	let tx_hash = sample_hash(8);
+	let receipt = sample_receipt(tx_hash.clone(), true);
+	let attempt = store
+		.create_planned_attempt(
+			"order-1",
+			Some(Address(vec![9; 20])),
+			TransactionType::Claim,
+			sample_tx(10, Some(7)),
+		)
+		.await
+		.unwrap();
+
+	store
+		.record_attempt_update(
+			&attempt.id,
+			TransactionAttemptStatus::Confirmed,
+			Some(tx_hash.clone()),
+			Some(receipt.clone()),
+			None,
+		)
+		.await
+		.unwrap();
+
+	let stored = store.get_attempt(&attempt.id).await.unwrap();
+	assert_eq!(stored.status, TransactionAttemptStatus::Confirmed);
+	assert_eq!(stored.tx_hash, Some(tx_hash));
+	assert_eq!(
+		stored.receipt.as_ref().unwrap().block_number,
+		receipt.block_number
+	);
+	assert_eq!(stored.receipt.as_ref().unwrap().success, true);
+	assert!(stored.is_terminal());
 }
 
 #[tokio::test]

--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -16,7 +16,7 @@ use crate::implementations::evm::nonce::{
 };
 use crate::{
 	DeliveryError, DeliveryInterface, FeeParams, InsufficientNativeGasInfo,
-	TransactionMonitoringEvent, TransactionTrackingWithConfig,
+	TransactionAttemptRecorder, TransactionMonitoringEvent, TransactionTrackingWithConfig,
 };
 use alloy_consensus::BlockHeader;
 use alloy_network::{BlockResponse, EthereumWallet};
@@ -32,7 +32,8 @@ use alloy_transport::TransportError;
 use async_trait::async_trait;
 use solver_account::AccountSigner;
 use solver_types::{
-	ConfigSchema, Field, FieldType, NetworksConfig, Schema, Transaction as SolverTransaction,
+	Address as SolverAddress, ConfigSchema, Field, FieldType, NetworksConfig, Schema,
+	Transaction as SolverTransaction, TransactionAttempt, TransactionAttemptStatus,
 	TransactionHash, TransactionReceipt,
 };
 use std::collections::HashMap;
@@ -219,6 +220,65 @@ fn nonce_action_for_outcome(outcome: SubmissionOutcome) -> NonceCacheAction {
 		SubmissionOutcome::DefinitelyRejected => NonceCacheAction::AttemptRollback,
 		SubmissionOutcome::NonceTooLow => NonceCacheAction::NonceTooLowRetry,
 		SubmissionOutcome::Replacement | SubmissionOutcome::Ambiguous => NonceCacheAction::Keep,
+	}
+}
+
+fn attempt_status_for_submission_outcome(outcome: SubmissionOutcome) -> TransactionAttemptStatus {
+	match outcome {
+		SubmissionOutcome::NonceTooLow | SubmissionOutcome::DefinitelyRejected => {
+			TransactionAttemptStatus::SubmitRejected
+		},
+		SubmissionOutcome::Replacement | SubmissionOutcome::Ambiguous => {
+			TransactionAttemptStatus::Indeterminate
+		},
+	}
+}
+
+fn solver_address_from_alloy(address: Address) -> SolverAddress {
+	SolverAddress(address.as_slice().to_vec())
+}
+
+async fn record_planned_attempt(
+	tracking: &TransactionTrackingWithConfig,
+	signer: SolverAddress,
+	tx: SolverTransaction,
+) -> Result<TransactionAttempt, DeliveryError> {
+	tracking
+		.tracking
+		.attempt_recorder
+		.record_planned_attempt(
+			&tracking.tracking.id,
+			Some(signer),
+			tracking.tracking.tx_type,
+			tx,
+		)
+		.await
+		.map_err(|e| {
+			DeliveryError::Network(format!(
+				"Failed to persist planned transaction attempt before broadcast: {e}"
+			))
+		})
+}
+
+async fn record_attempt_update_best_effort(
+	recorder: Arc<dyn TransactionAttemptRecorder>,
+	attempt_id: String,
+	status: TransactionAttemptStatus,
+	tx_hash: Option<TransactionHash>,
+	receipt: Option<TransactionReceipt>,
+	error: Option<String>,
+	context: &'static str,
+) {
+	if let Err(err) = recorder
+		.record_attempt_update(&attempt_id, status, tx_hash, receipt, error)
+		.await
+	{
+		tracing::error!(
+			attempt_id,
+			%err,
+			context,
+			"Failed to update transaction attempt ledger"
+		);
 	}
 }
 
@@ -853,6 +913,20 @@ impl DeliveryInterface for AlloyDelivery {
 		// (NonceTooLow / DefinitelyRejected / Replacement / Ambiguous) and act
 		// on the local nonce cache accordingly. See `nonce_action_for_outcome`
 		// and `apply_nonce_cache_action`.
+		let mut broadcast_attempt_id: Option<String> = None;
+		let first_attempt = if let Some(tracking) = tracking.as_ref() {
+			Some(
+				record_planned_attempt(
+					tracking,
+					solver_address_from_alloy(from),
+					tx_attempt.clone(),
+				)
+				.await?,
+			)
+		} else {
+			None
+		};
+
 		let pending_tx = match provider.send_transaction(request).await {
 			Ok(p) => {
 				tracing::debug!(
@@ -862,11 +936,38 @@ impl DeliveryInterface for AlloyDelivery {
 					tx_hash = %p.tx_hash(),
 					"tx submitted; nonce committed"
 				);
+				if let (Some(tracking), Some(attempt)) = (tracking.as_ref(), first_attempt.as_ref())
+				{
+					record_attempt_update_best_effort(
+						tracking.tracking.attempt_recorder.clone(),
+						attempt.id.clone(),
+						TransactionAttemptStatus::Broadcast,
+						Some(TransactionHash(p.tx_hash().0.to_vec())),
+						None,
+						None,
+						"first_broadcast",
+					)
+					.await;
+					broadcast_attempt_id = Some(attempt.id.clone());
+				}
 				p
 			},
 			Err(first_err) => {
 				let first_err_str = first_err.to_string();
 				let outcome = classify_submission_outcome(&first_err_str);
+				if let (Some(tracking), Some(attempt)) = (tracking.as_ref(), first_attempt.as_ref())
+				{
+					record_attempt_update_best_effort(
+						tracking.tracking.attempt_recorder.clone(),
+						attempt.id.clone(),
+						attempt_status_for_submission_outcome(outcome),
+						None,
+						None,
+						Some(first_err_str.clone()),
+						"first_submit_error",
+					)
+					.await;
+				}
 				match nonce_action_for_outcome(outcome) {
 					NonceCacheAction::NonceTooLowRetry => {
 						// EXISTING path — resync local cache from chain
@@ -882,6 +983,18 @@ impl DeliveryInterface for AlloyDelivery {
 						let retry_nonce = self.resync_nonce_for(chain_id, from).await?;
 						let mut retry_tx = tx_attempt.clone();
 						retry_tx.nonce = Some(retry_nonce);
+						let retry_attempt = if let Some(tracking) = tracking.as_ref() {
+							Some(
+								record_planned_attempt(
+									tracking,
+									solver_address_from_alloy(from),
+									retry_tx.clone(),
+								)
+								.await?,
+							)
+						} else {
+							None
+						};
 						let retry_request: TransactionRequest = retry_tx.into();
 
 						match provider.send_transaction(retry_request).await {
@@ -891,11 +1004,40 @@ impl DeliveryInterface for AlloyDelivery {
 									retry_nonce,
 									"Resynced nonce retry succeeded"
 								);
+								if let (Some(tracking), Some(attempt)) =
+									(tracking.as_ref(), retry_attempt.as_ref())
+								{
+									record_attempt_update_best_effort(
+										tracking.tracking.attempt_recorder.clone(),
+										attempt.id.clone(),
+										TransactionAttemptStatus::Broadcast,
+										Some(TransactionHash(p.tx_hash().0.to_vec())),
+										None,
+										None,
+										"retry_broadcast",
+									)
+									.await;
+									broadcast_attempt_id = Some(attempt.id.clone());
+								}
 								p
 							},
 							Err(retry_err) => {
 								let retry_err_str = retry_err.to_string();
 								let retry_outcome = classify_submission_outcome(&retry_err_str);
+								if let (Some(tracking), Some(attempt)) =
+									(tracking.as_ref(), retry_attempt.as_ref())
+								{
+									record_attempt_update_best_effort(
+										tracking.tracking.attempt_recorder.clone(),
+										attempt.id.clone(),
+										attempt_status_for_submission_outcome(retry_outcome),
+										None,
+										None,
+										Some(retry_err_str.clone()),
+										"retry_submit_error",
+									)
+									.await;
+								}
 								match nonce_action_for_outcome(retry_outcome) {
 									NonceCacheAction::NonceTooLowRetry => {
 										tracing::error!(
@@ -1089,6 +1231,8 @@ impl DeliveryInterface for AlloyDelivery {
 		// If tracking is provided, set up monitoring
 		if let Some(tracking) = tracking {
 			let tx_hash_clone = tx_hash_obj.clone();
+			let monitor_attempt_id = broadcast_attempt_id.clone();
+			let monitor_attempt_recorder = tracking.tracking.attempt_recorder.clone();
 			// Erase the root provider to a `DynProvider` so it matches
 			// `monitor_transaction`'s signature (and `ProviderProbe` inside it).
 			let provider_clone = pending_tx.provider().clone().erased();
@@ -1103,6 +1247,18 @@ impl DeliveryInterface for AlloyDelivery {
 
 				match result {
 					PollOutcome::Confirmed(receipt) => {
+						if let Some(attempt_id) = monitor_attempt_id.clone() {
+							record_attempt_update_best_effort(
+								monitor_attempt_recorder.clone(),
+								attempt_id,
+								TransactionAttemptStatus::Confirmed,
+								Some(tx_hash_clone.clone()),
+								Some(receipt.clone()),
+								None,
+								"monitor_confirmed",
+							)
+							.await;
+						}
 						(tracking.tracking.callback)(TransactionMonitoringEvent::Confirmed {
 							id: tracking.tracking.id,
 							tx_hash: tx_hash_clone,
@@ -1111,6 +1267,18 @@ impl DeliveryInterface for AlloyDelivery {
 						});
 					},
 					PollOutcome::Reverted(error) => {
+						if let Some(attempt_id) = monitor_attempt_id.clone() {
+							record_attempt_update_best_effort(
+								monitor_attempt_recorder.clone(),
+								attempt_id,
+								TransactionAttemptStatus::Reverted,
+								Some(tx_hash_clone.clone()),
+								None,
+								Some(error.clone()),
+								"monitor_reverted",
+							)
+							.await;
+						}
 						(tracking.tracking.callback)(TransactionMonitoringEvent::Failed {
 							id: tracking.tracking.id,
 							tx_hash: tx_hash_clone,
@@ -1119,6 +1287,18 @@ impl DeliveryInterface for AlloyDelivery {
 						});
 					},
 					PollOutcome::Indeterminate(reason) => {
+						if let Some(attempt_id) = monitor_attempt_id.clone() {
+							record_attempt_update_best_effort(
+								monitor_attempt_recorder.clone(),
+								attempt_id,
+								TransactionAttemptStatus::Indeterminate,
+								Some(tx_hash_clone.clone()),
+								None,
+								Some(reason.clone()),
+								"monitor_indeterminate",
+							)
+							.await;
+						}
 						(tracking.tracking.callback)(TransactionMonitoringEvent::Indeterminate {
 							id: tracking.tracking.id,
 							tx_hash: tx_hash_clone,
@@ -2127,6 +2307,28 @@ mod tests {
 	}
 
 	#[test]
+	fn submission_outcome_maps_to_attempt_status() {
+		use SubmissionOutcome::*;
+
+		assert_eq!(
+			attempt_status_for_submission_outcome(NonceTooLow),
+			TransactionAttemptStatus::SubmitRejected
+		);
+		assert_eq!(
+			attempt_status_for_submission_outcome(DefinitelyRejected),
+			TransactionAttemptStatus::SubmitRejected
+		);
+		assert_eq!(
+			attempt_status_for_submission_outcome(Replacement),
+			TransactionAttemptStatus::Indeterminate
+		);
+		assert_eq!(
+			attempt_status_for_submission_outcome(Ambiguous),
+			TransactionAttemptStatus::Indeterminate
+		);
+	}
+
+	#[test]
 	fn apply_nonce_cache_action_rollback_with_pending_resets_cache() {
 		use NonceCacheAction::*;
 		let mgr = ResettableNonceManager::new();
@@ -2979,8 +3181,11 @@ mod tests {
 	// ========================================================================
 
 	mod tracking_config_tests {
-		use crate::{TransactionTracking, TransactionTrackingWithConfig};
+		use crate::{
+			NoopTransactionAttemptRecorder, TransactionTracking, TransactionTrackingWithConfig,
+		};
 		use solver_types::TransactionType;
+		use std::sync::Arc;
 
 		#[test]
 		fn test_tracking_with_config_creation() {
@@ -2989,6 +3194,7 @@ mod tests {
 			let tracking = TransactionTracking {
 				id: "test-order-123".to_string(),
 				tx_type: TransactionType::Fill,
+				attempt_recorder: Arc::new(NoopTransactionAttemptRecorder),
 				callback,
 			};
 
@@ -3020,6 +3226,7 @@ mod tests {
 				let tracking = TransactionTracking {
 					id: format!("order-{tx_type:?}"),
 					tx_type,
+					attempt_recorder: Arc::new(NoopTransactionAttemptRecorder),
 					callback,
 				};
 

--- a/crates/solver-delivery/src/lib.rs
+++ b/crates/solver-delivery/src/lib.rs
@@ -69,9 +69,11 @@ mod transaction_attempt_recorder_tests {
 		let recorder = NoopTransactionAttemptRecorder;
 
 		recorder
-			.record_attempt_status(
+			.record_attempt_update(
 				"attempt-1",
 				TransactionAttemptStatus::SubmitRejected,
+				None,
+				None,
 				Some("nonce too low".to_string()),
 			)
 			.await
@@ -161,10 +163,12 @@ pub trait TransactionAttemptRecorder: Send + Sync {
 		tx: Transaction,
 	) -> Result<TransactionAttempt, TransactionAttemptRecorderError>;
 
-	async fn record_attempt_status(
+	async fn record_attempt_update(
 		&self,
 		attempt_id: &str,
 		status: TransactionAttemptStatus,
+		tx_hash: Option<TransactionHash>,
+		receipt: Option<TransactionReceipt>,
 		error: Option<String>,
 	) -> Result<(), TransactionAttemptRecorderError>;
 }
@@ -190,13 +194,15 @@ impl TransactionAttemptRecorder for NoopTransactionAttemptRecorder {
 		))
 	}
 
-	async fn record_attempt_status(
+	async fn record_attempt_update(
 		&self,
 		attempt_id: &str,
 		status: TransactionAttemptStatus,
+		tx_hash: Option<TransactionHash>,
+		receipt: Option<TransactionReceipt>,
 		error: Option<String>,
 	) -> Result<(), TransactionAttemptRecorderError> {
-		let _ = (attempt_id, status, error);
+		let _ = (attempt_id, status, tx_hash, receipt, error);
 		Ok(())
 	}
 }
@@ -365,6 +371,8 @@ pub struct TransactionTracking {
 	pub id: String,
 	/// Type of transaction being submitted
 	pub tx_type: TransactionType,
+	/// Records durable delivery attempts for this tracked transaction.
+	pub attempt_recorder: Arc<dyn TransactionAttemptRecorder>,
 	/// Callback to invoke when transaction state changes
 	pub callback: TransactionCallback,
 }
@@ -390,6 +398,43 @@ pub struct TransactionTrackingWithConfig {
 	/// Timeout in seconds for live tx-confirmation polling (short window).
 	/// Distinct from `monitoring_timeout_seconds`; see `DeliveryConfig`.
 	pub tx_confirmation_timeout_seconds: u64,
+}
+
+#[cfg(test)]
+mod tracking_config_tests {
+	use super::{
+		NoopTransactionAttemptRecorder, TransactionMonitoringEvent, TransactionTracking,
+		TransactionTrackingWithConfig,
+	};
+	use solver_types::TransactionType;
+	use std::sync::Arc;
+
+	#[test]
+	fn tracking_debug_omits_attempt_recorder() {
+		let tracking = TransactionTracking {
+			id: "test-order-123".to_string(),
+			tx_type: TransactionType::Fill,
+			attempt_recorder: Arc::new(NoopTransactionAttemptRecorder),
+			callback: Box::new(|_: TransactionMonitoringEvent| {}),
+		};
+
+		let config = TransactionTrackingWithConfig {
+			tracking,
+			min_confirmations: 3,
+			monitoring_timeout_seconds: 300,
+			tx_confirmation_timeout_seconds: 600,
+		};
+
+		assert_eq!(config.min_confirmations, 3);
+		assert_eq!(config.monitoring_timeout_seconds, 300);
+		assert_eq!(config.tx_confirmation_timeout_seconds, 600);
+		assert_eq!(config.tracking.id, "test-order-123");
+
+		let debug = format!("{:?}", config.tracking);
+		assert!(debug.contains("test-order-123"));
+		assert!(debug.contains("Fill"));
+		assert!(!debug.contains("attempt_recorder"));
+	}
 }
 
 /// Trait defining the interface for transaction delivery implementations.

--- a/crates/solver-delivery/src/lib.rs
+++ b/crates/solver-delivery/src/lib.rs
@@ -8,8 +8,8 @@ use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use solver_types::events::TransactionType;
 use solver_types::{
-	ChainData, ConfigSchema, ImplementationRegistry, Log, LogFilter, NetworksConfig, Transaction,
-	TransactionHash, TransactionReceipt,
+	Address, ChainData, ConfigSchema, ImplementationRegistry, Log, LogFilter, NetworksConfig,
+	Transaction, TransactionAttempt, TransactionAttemptStatus, TransactionHash, TransactionReceipt,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -21,6 +21,79 @@ pub mod implementations {
 		pub mod alloy;
 		pub mod fees;
 		pub mod nonce;
+	}
+}
+
+#[cfg(test)]
+mod transaction_attempt_recorder_tests {
+	use super::*;
+	use alloy_primitives::U256;
+	use solver_types::{Address, TransactionAttemptStatus, TransactionType};
+	use std::sync::Arc;
+
+	fn sample_tx() -> Transaction {
+		Transaction {
+			to: Some(Address(vec![2; 20])),
+			data: vec![1, 2, 3],
+			value: U256::ZERO,
+			chain_id: 8453,
+			nonce: Some(11),
+			gas_limit: Some(100000),
+			gas_price: None,
+			max_fee_per_gas: Some(1000),
+			max_priority_fee_per_gas: Some(10),
+		}
+	}
+
+	#[tokio::test]
+	async fn noop_recorder_returns_planned_attempt() {
+		let recorder = NoopTransactionAttemptRecorder;
+		let attempt = recorder
+			.record_planned_attempt(
+				"order-1",
+				Some(Address(vec![9; 20])),
+				TransactionType::Fill,
+				sample_tx(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(attempt.order_id, "order-1");
+		assert_eq!(attempt.signer, Some(Address(vec![9; 20])));
+		assert_eq!(attempt.tx_type, TransactionType::Fill);
+		assert_eq!(attempt.status, TransactionAttemptStatus::Planned);
+	}
+
+	#[tokio::test]
+	async fn noop_status_update_is_record_and_forget() {
+		let recorder = NoopTransactionAttemptRecorder;
+
+		recorder
+			.record_attempt_status(
+				"attempt-1",
+				TransactionAttemptStatus::SubmitRejected,
+				Some("nonce too low".to_string()),
+			)
+			.await
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn recorder_trait_is_dyn_safe() {
+		let recorder: Arc<dyn TransactionAttemptRecorder> =
+			Arc::new(NoopTransactionAttemptRecorder);
+
+		let attempt = recorder
+			.record_planned_attempt(
+				"order-1",
+				Some(Address(vec![9; 20])),
+				TransactionType::Fill,
+				sample_tx(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(attempt.order_id, "order-1");
 	}
 }
 
@@ -67,6 +140,65 @@ pub struct InsufficientNativeGasInfo {
 	pub max_fee_per_gas: Option<u128>,
 	pub gas_price: Option<u128>,
 	pub value_wei: String,
+}
+
+/// Errors that can occur while recording transaction attempt ledger rows.
+#[derive(Debug, Error)]
+pub enum TransactionAttemptRecorderError {
+	/// Storage or persistence failure from the recorder implementation.
+	#[error("transaction attempt recorder storage error: {0}")]
+	Storage(String),
+}
+
+/// Records transaction delivery attempts independently from order lifecycle state.
+#[async_trait]
+pub trait TransactionAttemptRecorder: Send + Sync {
+	async fn record_planned_attempt(
+		&self,
+		order_id: &str,
+		signer: Option<Address>,
+		tx_type: TransactionType,
+		tx: Transaction,
+	) -> Result<TransactionAttempt, TransactionAttemptRecorderError>;
+
+	async fn record_attempt_status(
+		&self,
+		attempt_id: &str,
+		status: TransactionAttemptStatus,
+		error: Option<String>,
+	) -> Result<(), TransactionAttemptRecorderError>;
+}
+
+#[derive(Debug, Default)]
+pub struct NoopTransactionAttemptRecorder;
+
+#[async_trait]
+impl TransactionAttemptRecorder for NoopTransactionAttemptRecorder {
+	async fn record_planned_attempt(
+		&self,
+		order_id: &str,
+		signer: Option<Address>,
+		tx_type: TransactionType,
+		tx: Transaction,
+	) -> Result<TransactionAttempt, TransactionAttemptRecorderError> {
+		Ok(TransactionAttempt::planned(
+			"noop-attempt".to_string(),
+			order_id.to_string(),
+			signer,
+			tx_type,
+			tx,
+		))
+	}
+
+	async fn record_attempt_status(
+		&self,
+		attempt_id: &str,
+		status: TransactionAttemptStatus,
+		error: Option<String>,
+	) -> Result<(), TransactionAttemptRecorderError> {
+		let _ = (attempt_id, status, error);
+		Ok(())
+	}
 }
 
 /// Fee model used by a chain at transaction submission time.

--- a/crates/solver-e2e-tests/Cargo.toml
+++ b/crates/solver-e2e-tests/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 reqwest = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 solver-core = { path = "../solver-core" }
 solver-delivery = { path = "../solver-delivery" }
 solver-settlement = { path = "../solver-settlement" }

--- a/crates/solver-e2e-tests/tests/recovery_indexing_e2e.rs
+++ b/crates/solver-e2e-tests/tests/recovery_indexing_e2e.rs
@@ -5,7 +5,11 @@
 //! catch mismatches between indexes written by `OrderStateMachine` and indexes
 //! queried by `RecoveryService`.
 
-use solver_core::{recovery::RecoveryService, state::OrderStateMachine, EventBus};
+use solver_core::{
+	recovery::RecoveryService,
+	state::{transaction_attempt::TransactionAttemptStore, OrderStateMachine},
+	EventBus,
+};
 use solver_delivery::DeliveryService;
 use solver_settlement::SettlementService;
 use solver_storage::{
@@ -28,8 +32,16 @@ fn recovery_service(storage: Arc<StorageService>) -> RecoveryService {
 	let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
 	let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
 	let event_bus = EventBus::new(100);
+	let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
 
-	RecoveryService::new(storage, state_machine, delivery, settlement, event_bus)
+	RecoveryService::new(
+		storage,
+		state_machine,
+		delivery,
+		settlement,
+		event_bus,
+		attempt_store,
+	)
 }
 
 #[tokio::test]

--- a/crates/solver-e2e-tests/tests/transaction_attempt_delivery_e2e.rs
+++ b/crates/solver-e2e-tests/tests/transaction_attempt_delivery_e2e.rs
@@ -1,0 +1,220 @@
+use std::{collections::HashMap, sync::Arc};
+
+use alloy_primitives::{Bytes, U256};
+use async_trait::async_trait;
+use solver_core::state::transaction_attempt::TransactionAttemptStore;
+use solver_delivery::{
+	DeliveryError, DeliveryInterface, DeliveryService, FeeParams, TransactionAttemptRecorder,
+	TransactionTracking,
+};
+use solver_storage::{
+	implementations::file::{FileStorage, TtlConfig},
+	StorageService,
+};
+use solver_types::validation::{ConfigSchema, ValidationError};
+use solver_types::{
+	Address, Log, LogFilter, Transaction, TransactionAttemptStatus, TransactionHash,
+	TransactionReceipt, TransactionType,
+};
+use tempfile::TempDir;
+
+struct EmptyConfigSchema;
+
+impl ConfigSchema for EmptyConfigSchema {
+	fn validate(&self, _config: &serde_json::Value) -> Result<(), ValidationError> {
+		Ok(())
+	}
+}
+
+#[derive(Clone)]
+struct RecordingDelivery {
+	tx_hash: TransactionHash,
+	signer: Address,
+}
+
+#[async_trait]
+impl DeliveryInterface for RecordingDelivery {
+	fn config_schema(&self) -> Box<dyn ConfigSchema> {
+		Box::new(EmptyConfigSchema)
+	}
+
+	async fn submit(
+		&self,
+		tx: Transaction,
+		tracking: Option<solver_delivery::TransactionTrackingWithConfig>,
+	) -> Result<TransactionHash, DeliveryError> {
+		let tracking = tracking.expect("test must pass tracking");
+		let attempt = tracking
+			.tracking
+			.attempt_recorder
+			.record_planned_attempt(
+				&tracking.tracking.id,
+				Some(self.signer.clone()),
+				tracking.tracking.tx_type,
+				tx,
+			)
+			.await
+			.map_err(|e| DeliveryError::Network(e.to_string()))?;
+
+		tracking
+			.tracking
+			.attempt_recorder
+			.record_attempt_update(
+				&attempt.id,
+				TransactionAttemptStatus::Broadcast,
+				Some(self.tx_hash.clone()),
+				None,
+				None,
+			)
+			.await
+			.map_err(|e| DeliveryError::Network(e.to_string()))?;
+
+		Ok(self.tx_hash.clone())
+	}
+
+	async fn get_receipt(
+		&self,
+		_hash: &TransactionHash,
+		_chain_id: u64,
+	) -> Result<TransactionReceipt, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn get_fee_params(&self, chain_id: u64) -> Result<FeeParams, DeliveryError> {
+		Ok(FeeParams::legacy(chain_id, 1))
+	}
+
+	async fn get_balance(
+		&self,
+		_address: &str,
+		_token: Option<&str>,
+		_chain_id: u64,
+	) -> Result<String, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn get_allowance(
+		&self,
+		_owner: &str,
+		_spender: &str,
+		_token_address: &str,
+		_chain_id: u64,
+	) -> Result<String, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn get_nonce(&self, _address: &str, _chain_id: u64) -> Result<u64, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn get_block_number(&self, _chain_id: u64) -> Result<u64, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn estimate_gas(&self, _tx: Transaction) -> Result<u64, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn estimate_gas_with_overrides(
+		&self,
+		_tx: Transaction,
+		_state_override: alloy_rpc_types::state::StateOverride,
+	) -> Result<u64, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn eth_call(&self, _tx: Transaction) -> Result<Bytes, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn tx_exists(
+		&self,
+		_hash: &TransactionHash,
+		_chain_id: u64,
+	) -> Result<bool, DeliveryError> {
+		unimplemented!()
+	}
+
+	async fn get_logs(
+		&self,
+		_chain_id: u64,
+		_filter: LogFilter,
+	) -> Result<Vec<Log>, DeliveryError> {
+		unimplemented!()
+	}
+}
+
+fn make_storage() -> (Arc<StorageService>, TempDir) {
+	let temp_dir = TempDir::new().unwrap();
+	let file_storage = FileStorage::new(temp_dir.path().to_path_buf(), TtlConfig::default());
+	(
+		Arc::new(StorageService::new(Box::new(file_storage))),
+		temp_dir,
+	)
+}
+
+fn sample_tx() -> Transaction {
+	Transaction {
+		to: Some(Address(vec![1; 20])),
+		data: vec![0xab, 0xcd],
+		value: U256::from(5u64),
+		chain_id: 10,
+		nonce: Some(7),
+		gas_limit: Some(21000),
+		gas_price: None,
+		max_fee_per_gas: Some(100),
+		max_priority_fee_per_gas: Some(2),
+	}
+}
+
+#[tokio::test]
+async fn delivery_service_persists_attempt_ledger_through_tracking() {
+	let (storage, _temp_dir) = make_storage();
+	let attempt_store = Arc::new(TransactionAttemptStore::new(storage));
+	let tx_hash = TransactionHash(vec![3; 32]);
+	let signer = Address(vec![9; 20]);
+
+	let mut implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+	implementations.insert(
+		10,
+		Arc::new(RecordingDelivery {
+			tx_hash: tx_hash.clone(),
+			signer: signer.clone(),
+		}),
+	);
+
+	let service = DeliveryService::new(implementations, 1, 60, 60);
+
+	let tracking = TransactionTracking {
+		id: "order-delivery-e2e".to_string(),
+		tx_type: TransactionType::Fill,
+		attempt_recorder: attempt_store.clone() as Arc<dyn TransactionAttemptRecorder>,
+		callback: Box::new(|_| {}),
+	};
+
+	let returned_hash = service.deliver(sample_tx(), Some(tracking)).await.unwrap();
+	assert_eq!(returned_hash, tx_hash);
+
+	let attempts = attempt_store
+		.attempts_for_order("order-delivery-e2e")
+		.await
+		.unwrap();
+	assert_eq!(attempts.len(), 1);
+
+	let attempt = &attempts[0];
+	assert_eq!(attempt.order_id, "order-delivery-e2e");
+	assert_eq!(attempt.signer, Some(signer));
+	assert_eq!(attempt.tx_type, TransactionType::Fill);
+	assert_eq!(attempt.chain_id, 10);
+	assert_eq!(attempt.nonce, Some(7));
+	assert_eq!(attempt.status, TransactionAttemptStatus::Broadcast);
+	assert_eq!(attempt.tx_hash, Some(tx_hash.clone()));
+	assert_eq!(attempt.receipt, None);
+
+	let by_hash = attempt_store
+		.attempt_by_hash(&tx_hash)
+		.await
+		.unwrap()
+		.unwrap();
+	assert_eq!(by_hash.id, attempt.id);
+}

--- a/crates/solver-storage/src/implementations/file.rs
+++ b/crates/solver-storage/src/implementations/file.rs
@@ -501,6 +501,66 @@ impl FileStorage {
 		}
 		Ok(removed)
 	}
+
+	async fn compare_and_swap_internal(
+		&self,
+		key: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		let path = self.get_file_path(key);
+
+		let current_data = match fs::read(&path).await {
+			Ok(data) => data,
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+				return Err(StorageError::NotFound(key.to_string()));
+			},
+			Err(e) => return Err(StorageError::Backend(e.to_string())),
+		};
+
+		let current_value = if let Ok(header) = FileHeader::deserialize(&current_data) {
+			if header.is_expired() {
+				return Err(StorageError::NotFound(key.to_string()));
+			}
+			if current_data.len() > FileHeader::SIZE {
+				&current_data[FileHeader::SIZE..]
+			} else {
+				&[]
+			}
+		} else {
+			&current_data[..]
+		};
+
+		if current_value != expected {
+			return Ok(false);
+		}
+
+		let ttl = ttl.unwrap_or_else(|| self.get_ttl_for_key(key));
+		let header = FileHeader::new(ttl);
+		let header_bytes = header.serialize();
+
+		let mut file_data = Vec::with_capacity(FileHeader::SIZE + new_value.len());
+		file_data.extend_from_slice(&header_bytes);
+		file_data.extend_from_slice(&new_value);
+
+		let temp_path = path.with_extension("tmp");
+		fs::write(&temp_path, file_data)
+			.await
+			.map_err(|e| StorageError::Backend(e.to_string()))?;
+
+		fs::rename(&temp_path, &path)
+			.await
+			.map_err(|e| StorageError::Backend(e.to_string()))?;
+
+		if let Some(indexes) = indexes {
+			let namespace = key.split(':').next().unwrap_or("");
+			self.update_indexes(namespace, key, &indexes).await?;
+		}
+
+		Ok(true)
+	}
 }
 
 #[async_trait]
@@ -789,56 +849,20 @@ impl StorageInterface for FileStorage {
 		new_value: Vec<u8>,
 		ttl: Option<Duration>,
 	) -> Result<bool, StorageError> {
-		let path = self.get_file_path(key);
-
-		// Read current value
-		let current_data = match fs::read(&path).await {
-			Ok(data) => data,
-			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-				return Err(StorageError::NotFound(key.to_string()));
-			},
-			Err(e) => return Err(StorageError::Backend(e.to_string())),
-		};
-
-		// Parse header and get current value
-		let current_value = if let Ok(header) = FileHeader::deserialize(&current_data) {
-			if header.is_expired() {
-				return Err(StorageError::NotFound(key.to_string()));
-			}
-			if current_data.len() > FileHeader::SIZE {
-				&current_data[FileHeader::SIZE..]
-			} else {
-				&[]
-			}
-		} else {
-			// Legacy file without header
-			&current_data[..]
-		};
-
-		// Compare
-		if current_value != expected {
-			return Ok(false);
-		}
-
-		// Match - write new value
-		let ttl = ttl.unwrap_or_else(|| self.get_ttl_for_key(key));
-		let header = FileHeader::new(ttl);
-		let header_bytes = header.serialize();
-
-		let mut file_data = Vec::with_capacity(FileHeader::SIZE + new_value.len());
-		file_data.extend_from_slice(&header_bytes);
-		file_data.extend_from_slice(&new_value);
-
-		let temp_path = path.with_extension("tmp");
-		fs::write(&temp_path, file_data)
+		self.compare_and_swap_internal(key, expected, new_value, None, ttl)
 			.await
-			.map_err(|e| StorageError::Backend(e.to_string()))?;
+	}
 
-		fs::rename(&temp_path, &path)
+	async fn compare_and_swap_with_indexes(
+		&self,
+		key: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		self.compare_and_swap_internal(key, expected, new_value, indexes, ttl)
 			.await
-			.map_err(|e| StorageError::Backend(e.to_string()))?;
-
-		Ok(true)
 	}
 
 	async fn delete_if_exists(&self, key: &str) -> Result<bool, StorageError> {

--- a/crates/solver-storage/src/implementations/memory.rs
+++ b/crates/solver-storage/src/implementations/memory.rs
@@ -204,6 +204,17 @@ impl StorageInterface for MemoryStorage {
 		}
 	}
 
+	async fn compare_and_swap_with_indexes(
+		&self,
+		key: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		_indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		self.compare_and_swap(key, expected, new_value, ttl).await
+	}
+
 	async fn delete_if_exists(&self, key: &str) -> Result<bool, StorageError> {
 		let mut store = self.store.write().await;
 

--- a/crates/solver-storage/src/implementations/redis.rs
+++ b/crates/solver-storage/src/implementations/redis.rs
@@ -917,6 +917,30 @@ impl StorageInterface for RedisStorage {
 		}
 	}
 
+	async fn compare_and_swap_with_indexes(
+		&self,
+		key: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		let effective_ttl = ttl.or_else(|| self.get_ttl_for_key(key));
+		let swapped = self
+			.compare_and_swap(key, expected, new_value, effective_ttl)
+			.await?;
+
+		if swapped {
+			if let Some(indexes) = indexes {
+				let namespace = key.split(':').next().unwrap_or("");
+				self.update_indexes(key, namespace, &indexes, effective_ttl)
+					.await?;
+			}
+		}
+
+		Ok(swapped)
+	}
+
 	async fn delete_if_exists(&self, key: &str) -> Result<bool, StorageError> {
 		let client = self.get_connection().await?;
 		let mut conn = client.as_ref().clone();

--- a/crates/solver-storage/src/lib.rs
+++ b/crates/solver-storage/src/lib.rs
@@ -234,6 +234,22 @@ pub trait StorageInterface: Send + Sync {
 		ttl: Option<Duration>,
 	) -> Result<bool, StorageError>;
 
+	/// Atomic compare-and-swap on raw bytes, with index refresh after success.
+	///
+	/// The value replacement is conditional on `current == expected`. If the
+	/// swap succeeds and `indexes` is provided, implementations must refresh
+	/// the key's secondary indexes to match the new value. The value CAS is the
+	/// hard atomic boundary; index refresh follows each backend's existing
+	/// indexing guarantees.
+	async fn compare_and_swap_with_indexes(
+		&self,
+		key: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError>;
+
 	/// Delete a key and return whether it existed.
 	///
 	/// Useful for single-use tokens like nonces where you need to
@@ -515,6 +531,14 @@ impl StorageService {
 		serde_json::from_slice(&bytes).map_err(|e| StorageError::Serialization(e.to_string()))
 	}
 
+	/// Retrieves raw bytes from storage.
+	///
+	/// The namespace and id are combined to form the lookup key.
+	pub async fn retrieve_bytes(&self, namespace: &str, id: &str) -> Result<Vec<u8>, StorageError> {
+		let key = format!("{namespace}:{id}");
+		self.backend.get_bytes(&key).await
+	}
+
 	/// Removes a value from storage.
 	///
 	/// The namespace and id are combined to form the key to delete.
@@ -545,6 +569,22 @@ impl StorageService {
 		let bytes =
 			serde_json::to_vec(data).map_err(|e| StorageError::Serialization(e.to_string()))?;
 		self.backend.set_bytes(&key, bytes, indexes, None).await
+	}
+
+	/// Atomically replaces raw bytes if the current bytes still match `expected`.
+	pub async fn compare_and_swap_bytes(
+		&self,
+		namespace: &str,
+		id: &str,
+		expected: &[u8],
+		new_value: Vec<u8>,
+		indexes: Option<StorageIndexes>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		let key = format!("{namespace}:{id}");
+		self.backend
+			.compare_and_swap_with_indexes(&key, expected, new_value, indexes, ttl)
+			.await
 	}
 
 	/// Checks if a value exists in storage.
@@ -924,5 +964,64 @@ mod tests {
 		assert_eq!(indexes.fields.len(), 2);
 		assert!(indexes.fields.contains_key("status"));
 		assert!(indexes.fields.contains_key("amount"));
+	}
+
+	#[tokio::test]
+	async fn compare_and_swap_bytes_updates_value_and_indexes() {
+		use crate::implementations::file::{FileStorage, TtlConfig};
+
+		let temp_dir = tempfile::TempDir::new().unwrap();
+		let storage = StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		)));
+
+		let namespace = "cas_test";
+		let id = "attempt-1";
+
+		storage
+			.store(
+				namespace,
+				id,
+				&serde_json::json!({ "status": "broadcast" }),
+				Some(StorageIndexes::new().with_field("status", "broadcast")),
+			)
+			.await
+			.unwrap();
+
+		let expected = storage.retrieve_bytes(namespace, id).await.unwrap();
+		let new_value = serde_json::to_vec(&serde_json::json!({ "status": "confirmed" })).unwrap();
+
+		let swapped = storage
+			.compare_and_swap_bytes(
+				namespace,
+				id,
+				&expected,
+				new_value,
+				Some(StorageIndexes::new().with_field("status", "confirmed")),
+				None,
+			)
+			.await
+			.unwrap();
+
+		assert!(swapped);
+
+		let terminal_rows = storage
+			.query::<serde_json::Value>(
+				namespace,
+				QueryFilter::Equals("status".to_string(), serde_json::json!("confirmed")),
+			)
+			.await
+			.unwrap();
+		assert_eq!(terminal_rows.len(), 1);
+
+		let active_rows = storage
+			.query::<serde_json::Value>(
+				namespace,
+				QueryFilter::Equals("status".to_string(), serde_json::json!("broadcast")),
+			)
+			.await
+			.unwrap();
+		assert!(active_rows.is_empty());
 	}
 }

--- a/crates/solver-types/src/lib.rs
+++ b/crates/solver-types/src/lib.rs
@@ -38,6 +38,8 @@ pub mod seed_overrides;
 pub mod standards;
 /// Storage types for managing persistent data.
 pub mod storage;
+/// Transaction attempt ledger types.
+pub mod transaction_attempt;
 /// Utility functions for common type conversions.
 pub mod utils;
 /// Configuration validation types for ensuring type-safe configurations.
@@ -91,6 +93,7 @@ pub use standards::{
 	eip7930::{InteropAddress, InteropAddressError},
 };
 pub use storage::*;
+pub use transaction_attempt::{TransactionAttempt, TransactionAttemptStatus};
 pub use utils::{
 	bytes32_to_address, current_timestamp, format_token_amount, normalize_bytes32_address,
 	parse_address, truncate_id, wei_string_to_eth_string, with_0x_prefix, without_0x_prefix,

--- a/crates/solver-types/src/storage.rs
+++ b/crates/solver-types/src/storage.rs
@@ -35,6 +35,8 @@ pub enum StorageKey {
 	Quotes,
 	/// Key for storing settlement message data (per implementation)
 	SettlementMessages,
+	/// Key for storing transaction delivery attempt data
+	TransactionAttempts,
 }
 
 impl StorageKey {
@@ -46,6 +48,7 @@ impl StorageKey {
 			StorageKey::OrderByTxHash => "order_by_tx_hash",
 			StorageKey::Quotes => "quotes",
 			StorageKey::SettlementMessages => "settlement_messages",
+			StorageKey::TransactionAttempts => "transaction_attempts",
 		}
 	}
 
@@ -57,6 +60,7 @@ impl StorageKey {
 			Self::OrderByTxHash,
 			Self::Quotes,
 			Self::SettlementMessages,
+			Self::TransactionAttempts,
 		]
 		.into_iter()
 	}
@@ -72,6 +76,7 @@ impl FromStr for StorageKey {
 			"order_by_tx_hash" => Ok(Self::OrderByTxHash),
 			"quotes" => Ok(Self::Quotes),
 			"settlement_messages" => Ok(Self::SettlementMessages),
+			"transaction_attempts" => Ok(Self::TransactionAttempts),
 			_ => Err(()),
 		}
 	}
@@ -97,6 +102,10 @@ mod tests {
 			StorageKey::SettlementMessages.as_str(),
 			"settlement_messages"
 		);
+		assert_eq!(
+			StorageKey::TransactionAttempts.as_str(),
+			"transaction_attempts"
+		);
 	}
 
 	#[test]
@@ -116,6 +125,10 @@ mod tests {
 			"settlement_messages".parse::<StorageKey>().unwrap(),
 			StorageKey::SettlementMessages
 		);
+		assert_eq!(
+			"transaction_attempts".parse::<StorageKey>().unwrap(),
+			StorageKey::TransactionAttempts
+		);
 
 		// Invalid cases
 		assert!("invalid".parse::<StorageKey>().is_err());
@@ -133,6 +146,7 @@ mod tests {
 			StorageKey::OrderByTxHash,
 			StorageKey::Quotes,
 			StorageKey::SettlementMessages,
+			StorageKey::TransactionAttempts,
 		];
 
 		assert_eq!(all_keys, expected);
@@ -155,6 +169,9 @@ mod tests {
 
 		let settlement_str: &'static str = StorageKey::SettlementMessages.into();
 		assert_eq!(settlement_str, "settlement_messages");
+
+		let transaction_attempts_str: &'static str = StorageKey::TransactionAttempts.into();
+		assert_eq!(transaction_attempts_str, "transaction_attempts");
 	}
 
 	#[test]
@@ -171,7 +188,7 @@ mod tests {
 		use std::collections::HashSet;
 
 		let strings: HashSet<&str> = StorageKey::all().map(|k| k.as_str()).collect();
-		assert_eq!(strings.len(), 5, "String representations should be unique");
+		assert_eq!(strings.len(), 6, "String representations should be unique");
 	}
 
 	#[test]
@@ -182,7 +199,7 @@ mod tests {
 		for key in StorageKey::all() {
 			assert!(set.insert(key)); // Should be unique
 		}
-		assert_eq!(set.len(), 5);
+		assert_eq!(set.len(), 6);
 
 		// Test equality
 		assert_eq!(StorageKey::Orders, StorageKey::Orders);

--- a/crates/solver-types/src/transaction_attempt.rs
+++ b/crates/solver-types/src/transaction_attempt.rs
@@ -1,0 +1,176 @@
+use crate::{
+	current_timestamp, Address, Transaction, TransactionHash, TransactionReceipt, TransactionType,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionAttemptStatus {
+	Planned,
+	Broadcast,
+	Confirmed,
+	SubmitRejected,
+	Reverted,
+	Indeterminate,
+}
+
+impl TransactionAttemptStatus {
+	pub fn is_terminal(self) -> bool {
+		matches!(
+			self,
+			Self::Confirmed | Self::SubmitRejected | Self::Reverted
+		)
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionAttempt {
+	pub id: String,
+	pub order_id: String,
+	pub signer: Option<Address>,
+	pub tx_type: TransactionType,
+	pub chain_id: u64,
+	pub nonce: Option<u64>,
+	pub tx_hash: Option<TransactionHash>,
+	pub receipt: Option<TransactionReceipt>,
+	pub tx: Transaction,
+	pub status: TransactionAttemptStatus,
+	pub error: Option<String>,
+	pub created_at: u64,
+	pub updated_at: u64,
+}
+
+impl TransactionAttempt {
+	pub fn planned(
+		id: String,
+		order_id: String,
+		signer: Option<Address>,
+		tx_type: TransactionType,
+		tx: Transaction,
+	) -> Self {
+		let now = current_timestamp();
+		Self {
+			id,
+			order_id,
+			signer,
+			tx_type,
+			chain_id: tx.chain_id,
+			nonce: tx.nonce,
+			tx_hash: None,
+			receipt: None,
+			tx,
+			status: TransactionAttemptStatus::Planned,
+			error: None,
+			created_at: now,
+			updated_at: now,
+		}
+	}
+
+	pub fn is_terminal(&self) -> bool {
+		self.status.is_terminal()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{Address, Log, TransactionHash, TransactionReceipt};
+	use alloy_primitives::U256;
+
+	fn sample_tx() -> Transaction {
+		Transaction {
+			to: Some(Address(vec![1; 20])),
+			data: vec![0xab, 0xcd],
+			value: U256::from(5u64),
+			chain_id: 10,
+			nonce: Some(7),
+			gas_limit: Some(21000),
+			gas_price: None,
+			max_fee_per_gas: Some(100),
+			max_priority_fee_per_gas: Some(2),
+		}
+	}
+
+	#[test]
+	fn planned_attempt_copies_tx_metadata() {
+		let attempt = TransactionAttempt::planned(
+			"attempt-1".to_string(),
+			"order-1".to_string(),
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(),
+		);
+
+		assert_eq!(attempt.id, "attempt-1");
+		assert_eq!(attempt.order_id, "order-1");
+		assert_eq!(attempt.signer, Some(Address(vec![9; 20])));
+		assert_eq!(attempt.tx_type, TransactionType::Fill);
+		assert_eq!(attempt.chain_id, 10);
+		assert_eq!(attempt.nonce, Some(7));
+		assert_eq!(attempt.tx_hash, None);
+		assert_eq!(attempt.receipt, None);
+		assert_eq!(attempt.status, TransactionAttemptStatus::Planned);
+		assert_eq!(attempt.error, None);
+		assert!(!attempt.is_terminal());
+		assert!(attempt.created_at > 0);
+		assert_eq!(attempt.created_at, attempt.updated_at);
+	}
+
+	#[test]
+	fn terminal_statuses_are_explicit() {
+		assert!(!TransactionAttemptStatus::Planned.is_terminal());
+		assert!(!TransactionAttemptStatus::Broadcast.is_terminal());
+		assert!(!TransactionAttemptStatus::Indeterminate.is_terminal());
+		assert!(TransactionAttemptStatus::Confirmed.is_terminal());
+		assert!(TransactionAttemptStatus::SubmitRejected.is_terminal());
+		assert!(TransactionAttemptStatus::Reverted.is_terminal());
+	}
+
+	#[test]
+	fn status_serializes_as_camel_case() {
+		let json = serde_json::to_string(&TransactionAttemptStatus::SubmitRejected).unwrap();
+		assert_eq!(json, "\"submitRejected\"");
+	}
+
+	#[test]
+	fn attempt_round_trips_through_json() {
+		let mut attempt = TransactionAttempt::planned(
+			"attempt-1".to_string(),
+			"order-1".to_string(),
+			Some(Address(vec![9; 20])),
+			TransactionType::Fill,
+			sample_tx(),
+		);
+		attempt.tx_hash = Some(TransactionHash(vec![4; 32]));
+		attempt.receipt = Some(TransactionReceipt {
+			hash: TransactionHash(vec![4; 32]),
+			block_number: 123,
+			success: true,
+			logs: vec![Log {
+				address: Address(vec![8; 20]),
+				topics: vec![],
+				data: vec![0xaa],
+			}],
+			block_timestamp: Some(456),
+		});
+		attempt.status = TransactionAttemptStatus::Broadcast;
+		attempt.error = Some("temporary rpc timeout".to_string());
+
+		let json = serde_json::to_string(&attempt).unwrap();
+		let decoded: TransactionAttempt = serde_json::from_str(&json).unwrap();
+
+		assert_eq!(decoded.id, attempt.id);
+		assert_eq!(decoded.order_id, attempt.order_id);
+		assert_eq!(decoded.signer, attempt.signer);
+		assert_eq!(decoded.tx_type, attempt.tx_type);
+		assert_eq!(decoded.chain_id, attempt.chain_id);
+		assert_eq!(decoded.nonce, attempt.nonce);
+		assert_eq!(decoded.tx_hash.as_ref().unwrap().0, vec![4; 32]);
+		assert_eq!(decoded.receipt.as_ref().unwrap().block_number, 123);
+		assert!(decoded.receipt.as_ref().unwrap().success);
+		assert_eq!(decoded.status, attempt.status);
+		assert_eq!(decoded.error, attempt.error);
+		assert_eq!(decoded.tx.data, attempt.tx.data);
+		assert_eq!(decoded.tx.chain_id, attempt.tx.chain_id);
+	}
+}


### PR DESCRIPTION
…vice

- Added TransactionAttemptStore to RecoveryService for enhanced transaction recovery.
- Implemented methods for retrieving and resolving transaction attempts during recovery.
- Updated the storage interface to support atomic compare-and-swap operations with index refresh.
- Enhanced tests to cover new transaction attempt functionalities and ensure correct behavior.

# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
