### PR TITLE
Enhance oracle binding security in settlement implementations

### DIFF
--- a/crates/solver-order/src/implementations/standards/_7683.rs
+++ b/crates/solver-order/src/implementations/standards/_7683.rs
@@ -419,8 +419,11 @@ impl OrderInterface for Eip7683OrderImpl {
 		let user_address = hex_to_alloy_address(&order_data.user)
 			.map_err(|e| OrderError::ValidationFailed(format!("Invalid user address: {e}")))?;
 
-		// Parse oracle address
-		let oracle_address = hex_to_alloy_address(&fill_proof.oracle_address)
+		// Security: use the order-bound input oracle from canonical order_data, not
+		// the FillProof's oracle_address. The settlement service's get_attestation
+		// guard enforces that these match, so this preserves the order identity at
+		// claim time even if a future settlement impl regresses.
+		let oracle_address = hex_to_alloy_address(&order_data.input_oracle)
 			.map_err(|e| OrderError::ValidationFailed(format!("Invalid oracle address: {e}")))?;
 
 		// Create inputs array from order data
@@ -1139,6 +1142,66 @@ mod tests {
 		assert_eq!(tx.chain_id, 1); // origin chain
 		assert_eq!(tx.to, Some(Address(vec![0x11; 20])));
 		assert!(!tx.data.is_empty());
+	}
+
+	#[tokio::test]
+	async fn test_generate_claim_transaction_uses_order_bound_oracle() {
+		use alloy_sol_types::SolCall;
+
+		let networks = create_test_networks();
+		let oracle_routes = create_test_oracle_routes();
+		let order_impl = Eip7683OrderImpl::new(networks, oracle_routes).unwrap();
+
+		// Build an order whose canonical input_oracle is the StandardOrder's inputOracle.
+		let standard_order = create_valid_standard_order();
+		let canonical_oracle_bytes: [u8; 20] = standard_order.inputOracle.0 .0;
+		let order_bytes = encode_standard_order(&standard_order);
+		let solver_address = Address(vec![0x99; 20]);
+
+		let order = order_impl
+			.validate_and_create_order(
+				&order_bytes,
+				&None,
+				"permit2_escrow",
+				Box::new(mock_order_id_callback),
+				&solver_address,
+				None,
+			)
+			.await
+			.expect("validate_and_create_order should succeed");
+
+		// FillProof carries a DIFFERENT oracle address (attacker / wrong).
+		let attacker_oracle_hex = "0x".to_string() + &hex::encode([0x99u8; 20]);
+		let fill_proof = FillProof {
+			tx_hash: TransactionHash(vec![0u8; 32]),
+			block_number: 1,
+			attestation_data: None,
+			filled_timestamp: 1_700_000_000,
+			oracle_address: attacker_oracle_hex,
+		};
+
+		let claim_tx = order_impl
+			.generate_claim_transaction(&order, &fill_proof)
+			.await
+			.expect("generate_claim_transaction should succeed");
+
+		// Decode the StandardOrder embedded in the finaliseCall calldata and assert
+		// its inputOracle matches the canonical (signed) value, NOT the FillProof oracle.
+		assert!(claim_tx.data.len() >= 4, "calldata shorter than selector");
+		let decoded =
+			interfaces::IInputSettlerEscrow::finaliseCall::abi_decode_raw(&claim_tx.data[4..])
+				.expect("finaliseCall::abi_decode_raw should succeed");
+		let decoded_input_oracle: [u8; 20] = decoded.order.inputOracle.0 .0;
+
+		assert_eq!(
+			decoded_input_oracle, canonical_oracle_bytes,
+			"claim calldata used FillProof oracle instead of order-bound oracle"
+		);
+		// And explicitly assert the FillProof oracle was NOT used.
+		assert_ne!(
+			decoded_input_oracle, [0x99u8; 20],
+			"FillProof oracle leaked into StandardOrder.inputOracle"
+		);
 	}
 
 	#[test]

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -19,11 +19,12 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use solver_storage::StorageService;
+#[cfg(test)]
+use solver_types::Eip7683OrderData;
 use solver_types::{
-	bytes32_to_address, order_id_to_bytes32, parse_address, with_0x_prefix, ConfigSchema,
-	Eip7683OrderData, Field, FieldType, FillProof, InteropAddress, NetworksConfig, Order,
-	OrderOutput, PusherL2Params, Schema, Transaction, TransactionHash, TransactionReceipt,
-	TransactionType,
+	order_id_to_bytes32, with_0x_prefix, ConfigSchema, Field, FieldType, FillProof, InteropAddress,
+	NetworksConfig, Order, OrderOutput, PusherL2Params, Schema, Transaction, TransactionHash,
+	TransactionReceipt, TransactionType,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -247,53 +248,21 @@ fn compute_message_slot(message: [u8; 32], publisher: &solver_types::Address) ->
 	keccak256(&encoded)
 }
 
+#[cfg(test)]
 fn parse_eip7683_order_data(order: &Order) -> Result<Eip7683OrderData, SettlementError> {
 	if order.standard != "eip7683" {
 		return Err(SettlementError::ValidationFailed(format!(
-			"Broadcaster settlement only supports eip7683 orders, got '{}'",
+			"Settlement only supports eip7683 orders, got '{}'",
 			order.standard
 		)));
 	}
 
 	serde_json::from_value(order.data.clone()).map_err(|e| {
-		SettlementError::ValidationFailed(format!("Failed to parse broadcaster order data: {e}"))
+		SettlementError::ValidationFailed(format!("Failed to parse eip7683 order data: {e}"))
 	})
 }
 
-fn parse_bound_input_oracle(order: &Order) -> Result<solver_types::Address, SettlementError> {
-	let order_data = parse_eip7683_order_data(order)?;
-	parse_address(&order_data.input_oracle).map_err(|e| {
-		SettlementError::ValidationFailed(format!("Invalid order-bound input oracle: {e}"))
-	})
-}
-
-fn parse_bound_output_oracle(
-	order: &Order,
-	destination_chain: u64,
-) -> Result<solver_types::Address, SettlementError> {
-	let order_data = parse_eip7683_order_data(order)?;
-	let output = order_data
-		.outputs
-		.iter()
-		.find(|output| output.chain_id.to::<u64>() == destination_chain)
-		.ok_or_else(|| {
-			SettlementError::ValidationFailed(format!(
-				"No order output found for destination chain {destination_chain}"
-			))
-		})?;
-
-	if output.oracle == [0u8; 32] {
-		return Err(SettlementError::ValidationFailed(format!(
-			"Order output oracle is zero for destination chain {destination_chain}; \
-			 broadcaster requires an order-bound output oracle"
-		)));
-	}
-
-	let oracle_hex = bytes32_to_address(&output.oracle);
-	parse_address(&oracle_hex).map_err(|e| {
-		SettlementError::ValidationFailed(format!("Invalid order-bound output oracle: {e}"))
-	})
-}
+use crate::{parse_bound_input_oracle, parse_bound_output_oracle};
 
 fn parse_hex_bytes(label: &str, value: &str) -> Result<Vec<u8>, SettlementError> {
 	hex::decode(value.trim_start_matches("0x"))

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -968,12 +968,17 @@ impl BroadcasterSettlement {
 			Ok(oracle) => oracle,
 			Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
 		};
-		let output_oracle = submission.remote_oracle.clone();
-		if !self.is_output_oracle_supported(destination_chain, &output_oracle) {
+		let bound_output_oracle =
+			match self.validate_bound_output_oracle(order, destination_chain) {
+				Ok(oracle) => oracle,
+				Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
+			};
+		if submission.remote_oracle != bound_output_oracle {
 			return SettlementReadiness::PermanentFailure(format!(
-				"Stored output oracle is not configured for destination chain {destination_chain}"
+				"Stored output oracle does not match order-bound output oracle for destination chain {destination_chain}"
 			));
 		}
+		let output_oracle = bound_output_oracle;
 
 		let provider = match self.providers.get(&source_chain) {
 			Some(provider) => provider,
@@ -2359,6 +2364,26 @@ mod tests {
 	}
 
 	#[test]
+	fn test_parse_bound_input_oracle_rejects_zero_oracle() {
+		let data = serde_json::json!({
+			"order_id": vec![0u8; 32],
+			"user": "0x1234567890123456789012345678901234567890",
+			"nonce": "1",
+			"origin_chain_id": "1",
+			"expires": 100,
+			"fill_deadline": 50,
+			"input_oracle": "0x0000000000000000000000000000000000000000",
+			"inputs": [],
+			"outputs": [],
+			"gas_limit_overrides": {}
+		});
+		let order = OrderBuilder::new().with_data(data).build();
+
+		let err = parse_bound_input_oracle(&order).unwrap_err();
+		assert!(err.to_string().contains("input oracle is zero"));
+	}
+
+	#[test]
 	fn test_parse_bound_input_oracle_rejects_invalid_address() {
 		let data = serde_json::json!({
 			"order_id": vec![0u8; 32],
@@ -2788,7 +2813,81 @@ mod tests {
 		assert!(matches!(
 			readiness,
 			SettlementReadiness::PermanentFailure(ref msg)
-				if msg.contains("Stored output oracle is not configured")
+				if msg.contains("Stored output oracle does not match order-bound output oracle")
+		));
+	}
+
+	#[tokio::test]
+	async fn test_readiness_internal_rejects_remote_oracle_mismatch() {
+		// Both the configured allow-list and the stored submission.remote_oracle are
+		// in the oracle config, but the stored oracle differs from the order-signed
+		// output oracle. Under the order-bound check, readiness must reject.
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let configured_output_oracle = solver_types::Address(vec![0x44; 20]);
+		let stored_output_oracle = solver_types::Address(vec![0x55; 20]);
+		let order = OrderBuilder::new()
+			.with_id("readiness-bound-mismatch-order")
+			.with_input_chain_ids(vec![421614])
+			.with_output_chain_ids(vec![11155111])
+			.with_data(make_eip7683_order_data(
+				&input_oracle,
+				vec![make_output(
+					11155111,
+					address_to_bytes32(&configured_output_oracle),
+				)],
+			))
+			.build();
+		let settlement = test_settlement(OracleConfig {
+			input_oracles: HashMap::from([(421614u64, vec![input_oracle.clone()])]),
+			// Both oracles are configured – the stored one is in the allow-list,
+			// but does NOT match the order-signed output oracle.
+			output_oracles: HashMap::from([(
+				11155111u64,
+				vec![
+					configured_output_oracle.clone(),
+					stored_output_oracle.clone(),
+				],
+			)]),
+			routes: HashMap::from([(421614u64, vec![11155111u64])]),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		settlement
+			.message_tracker
+			.track_submission(
+				&order.id,
+				BroadcasterSubmission {
+					source_chain: 421614,
+					destination_chain: 11155111,
+					submission_tx_hash: TransactionHash(vec![0x55; 32]),
+					submission_timestamp: 1,
+					submission_block_number: Some(12345),
+					payload_hash: [0x66; 32],
+					message: [0x77; 32],
+					message_data: vec![0x88],
+					application: solver_types::Address(vec![0x99; 20]),
+					remote_oracle: stored_output_oracle,
+				},
+			)
+			.await
+			.unwrap();
+
+		let readiness = settlement
+			.readiness(
+				&order,
+				&FillProof {
+					tx_hash: TransactionHash(vec![0xaa; 32]),
+					block_number: 1,
+					oracle_address: with_0x_prefix(&hex::encode(&input_oracle.0)),
+					attestation_data: None,
+					filled_timestamp: now_seconds(),
+				},
+			)
+			.await;
+
+		assert!(matches!(
+			readiness,
+			SettlementReadiness::PermanentFailure(ref msg)
+				if msg.contains("Stored output oracle does not match order-bound output oracle")
 		));
 	}
 

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -968,11 +968,11 @@ impl BroadcasterSettlement {
 			Ok(oracle) => oracle,
 			Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
 		};
-		let bound_output_oracle =
-			match self.validate_bound_output_oracle(order, destination_chain) {
-				Ok(oracle) => oracle,
-				Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
-			};
+		let bound_output_oracle = match self.validate_bound_output_oracle(order, destination_chain)
+		{
+			Ok(oracle) => oracle,
+			Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
+		};
 		if submission.remote_oracle != bound_output_oracle {
 			return SettlementReadiness::PermanentFailure(format!(
 				"Stored output oracle does not match order-bound output oracle for destination chain {destination_chain}"

--- a/crates/solver-settlement/src/implementations/direct.rs
+++ b/crates/solver-settlement/src/implementations/direct.rs
@@ -56,6 +56,38 @@ impl DirectSettlement {
 			dispute_period_seconds,
 		})
 	}
+
+	/// Validate that the order-bound input oracle is configured for the given
+	/// source chain. Returns the parsed order-bound input oracle on success.
+	fn validate_bound_input_oracle(
+		&self,
+		order: &Order,
+		source_chain: u64,
+	) -> Result<solver_types::Address, SettlementError> {
+		let input_oracle = crate::parse_bound_input_oracle(order)?;
+		if !self.is_input_oracle_supported(source_chain, &input_oracle) {
+			return Err(SettlementError::ValidationFailed(format!(
+				"Order-bound input oracle is not configured for source chain {source_chain}"
+			)));
+		}
+		Ok(input_oracle)
+	}
+
+	/// Validate that the order-bound output oracle is configured for the given
+	/// destination chain. Returns the parsed order-bound output oracle on success.
+	fn validate_bound_output_oracle(
+		&self,
+		order: &Order,
+		destination_chain: u64,
+	) -> Result<solver_types::Address, SettlementError> {
+		let output_oracle = crate::parse_bound_output_oracle(order, destination_chain)?;
+		if !self.is_output_oracle_supported(destination_chain, &output_oracle) {
+			return Err(SettlementError::ValidationFailed(format!(
+				"Order-bound output oracle is not configured for destination chain {destination_chain}"
+			)));
+		}
+		Ok(output_oracle)
+	}
 }
 
 /// Configuration schema for DirectSettlement.
@@ -149,27 +181,10 @@ impl SettlementInterface for DirectSettlement {
 			))
 		})?;
 
-		// Get the oracle address for this chain using the selection strategy
-		let oracle_addresses = self.get_input_oracles(origin_chain_id);
-		if oracle_addresses.is_empty() {
-			return Err(SettlementError::ValidationFailed(format!(
-				"No input oracle configured for chain {origin_chain_id}"
-			)));
-		}
-
-		// Use order ID hash as selection context for deterministic oracle selection
-		// This ensures the same oracle is consistently selected for a given order
-		let order_id_bytes = order.id.as_bytes();
-		let mut hasher = std::collections::hash_map::DefaultHasher::new();
-		std::hash::Hasher::write(&mut hasher, order_id_bytes);
-		let selection_context = std::hash::Hasher::finish(&hasher);
-		let oracle_address = self
-			.select_oracle(&oracle_addresses, Some(selection_context))
-			.ok_or_else(|| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to select oracle for chain {origin_chain_id}"
-				))
-			})?;
+		// Security: use the order-bound input oracle from canonical order_data.
+		// Any mismatch with the configured input oracle set for the source chain
+		// is a security event and surfaces as ValidationFailed.
+		let oracle_address = self.validate_bound_input_oracle(order, origin_chain_id)?;
 
 		// Convert tx hash
 		let hash = FixedBytes::<32>::from_slice(&tx_hash.0);
@@ -266,11 +281,15 @@ impl SettlementInterface for DirectSettlement {
 			.map(|c| c.chain_id)
 			.ok_or_else(|| SettlementError::ValidationFailed("No output chains in order".into()))?;
 
-		let oracle_addresses = self.get_output_oracles(dest_chain);
-		if oracle_addresses.is_empty() {
-			// No oracle configured, no PostFill needed
+		// Preserve "no output oracle configured for this chain = skip post-fill"
+		// semantics for legitimate unconfigured chains.
+		if self.get_output_oracles(dest_chain).is_empty() {
 			return Ok(None);
 		}
+		// At least one output oracle is configured for this chain; require the
+		// order-bound output oracle to be in the supported set. A mismatch is a
+		// security event and surfaces as ValidationFailed (not Ok(None)).
+		let _output_oracle = self.validate_bound_output_oracle(order, dest_chain)?;
 
 		// For testing: send to solver's own address (from the order)
 		// This simulates a PostFill oracle interaction that modifies state
@@ -306,11 +325,15 @@ impl SettlementInterface for DirectSettlement {
 			.map(|c| c.chain_id)
 			.ok_or_else(|| SettlementError::ValidationFailed("No input chains in order".into()))?;
 
-		let oracle_addresses = self.get_input_oracles(origin_chain);
-		if oracle_addresses.is_empty() {
-			// No oracle configured, no PreClaim needed
+		// Preserve "no input oracle configured for this chain = skip pre-claim"
+		// semantics for legitimate unconfigured chains.
+		if self.get_input_oracles(origin_chain).is_empty() {
 			return Ok(None);
 		}
+		// At least one input oracle is configured for this chain; require the
+		// order-bound input oracle to be in the supported set. A mismatch is a
+		// security event and surfaces as ValidationFailed (not Ok(None)).
+		let _input_oracle = self.validate_bound_input_oracle(order, origin_chain)?;
 
 		// For testing: send to solver's own address (from the order)
 		// This simulates a PreClaim oracle interaction that modifies state
@@ -824,6 +847,165 @@ mod tests {
 		if let Err(SettlementError::ValidationFailed(msg)) = result {
 			assert!(msg.contains("No HTTP RPC URL configured"));
 		}
+	}
+
+	// ── helpers for order-bound oracle binding tests ────────────────────────
+
+	fn make_eip7683_order_data_for_binding(
+		input_oracle: &solver_types::Address,
+		outputs: Vec<solver_types::standards::eip7683::MandateOutput>,
+	) -> serde_json::Value {
+		use solver_types::utils::tests::builders::Eip7683OrderDataBuilder;
+		let data = Eip7683OrderDataBuilder::new()
+			.origin_chain_id(U256::from(1u64))
+			.input_oracle(solver_types::with_0x_prefix(&hex::encode(&input_oracle.0)))
+			.outputs(outputs)
+			.build();
+		serde_json::to_value(data).unwrap()
+	}
+
+	fn make_output_for_binding(
+		destination_chain: u64,
+		output_oracle: [u8; 32],
+	) -> solver_types::standards::eip7683::MandateOutput {
+		use solver_types::utils::tests::builders::MandateOutputBuilder;
+		MandateOutputBuilder::new()
+			.oracle(output_oracle)
+			.chain_id(U256::from(destination_chain))
+			.token([0x11; 32])
+			.amount(U256::from(42u64))
+			.recipient([0x22; 32])
+			.build()
+	}
+
+	fn test_direct_settlement(oracle_config: OracleConfig) -> DirectSettlement {
+		DirectSettlement {
+			providers: HashMap::new(),
+			oracle_config,
+			dispute_period_seconds: 300,
+		}
+	}
+
+	#[test]
+	fn test_validate_bound_input_oracle_success() {
+		use solver_types::utils::tests::builders::OrderBuilder;
+
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(137, [0u8; 32])],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::from([(1u64, vec![input_oracle.clone()])]),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_direct_settlement(oracle_config);
+
+		assert_eq!(
+			settlement.validate_bound_input_oracle(&order, 1).unwrap(),
+			input_oracle
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_input_oracle_rejects_unsupported() {
+		use solver_types::utils::tests::builders::OrderBuilder;
+
+		let signed_oracle = solver_types::Address(vec![0x33; 20]);
+		let configured_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&signed_oracle,
+				vec![make_output_for_binding(137, [0u8; 32])],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::from([(1u64, vec![configured_oracle])]),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_direct_settlement(oracle_config);
+
+		let err = settlement
+			.validate_bound_input_oracle(&order, 1)
+			.unwrap_err();
+		assert!(
+			err.to_string()
+				.contains("not configured for source chain 1"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_output_oracle_success() {
+		use crate::utils::address_to_bytes32;
+		use solver_types::utils::tests::builders::OrderBuilder;
+
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(
+					137,
+					address_to_bytes32(&output_oracle),
+				)],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::from([(137u64, vec![output_oracle.clone()])]),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_direct_settlement(oracle_config);
+
+		assert_eq!(
+			settlement
+				.validate_bound_output_oracle(&order, 137)
+				.unwrap(),
+			output_oracle
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_output_oracle_rejects_unsupported() {
+		use crate::utils::address_to_bytes32;
+		use solver_types::utils::tests::builders::OrderBuilder;
+
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let signed_output_oracle = solver_types::Address(vec![0x44; 20]);
+		let configured_output_oracle = solver_types::Address(vec![0x55; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(
+					137,
+					address_to_bytes32(&signed_output_oracle),
+				)],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::from([(137u64, vec![configured_output_oracle])]),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_direct_settlement(oracle_config);
+
+		let err = settlement
+			.validate_bound_output_oracle(&order, 137)
+			.unwrap_err();
+		assert!(
+			err.to_string()
+				.contains("not configured for destination chain 137"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/crates/solver-settlement/src/implementations/hyperlane.rs
+++ b/crates/solver-settlement/src/implementations/hyperlane.rs
@@ -485,6 +485,38 @@ pub struct HyperlaneSettlement {
 }
 
 impl HyperlaneSettlement {
+	/// Validate that the order-bound input oracle is configured for the given
+	/// source chain. Returns the parsed order-bound input oracle on success.
+	fn validate_bound_input_oracle(
+		&self,
+		order: &Order,
+		source_chain: u64,
+	) -> Result<solver_types::Address, SettlementError> {
+		let input_oracle = crate::parse_bound_input_oracle(order)?;
+		if !self.is_input_oracle_supported(source_chain, &input_oracle) {
+			return Err(SettlementError::ValidationFailed(format!(
+				"Order-bound input oracle is not configured for source chain {source_chain}"
+			)));
+		}
+		Ok(input_oracle)
+	}
+
+	/// Validate that the order-bound output oracle is configured for the given
+	/// destination chain. Returns the parsed order-bound output oracle on success.
+	fn validate_bound_output_oracle(
+		&self,
+		order: &Order,
+		destination_chain: u64,
+	) -> Result<solver_types::Address, SettlementError> {
+		let output_oracle = crate::parse_bound_output_oracle(order, destination_chain)?;
+		if !self.is_output_oracle_supported(destination_chain, &output_oracle) {
+			return Err(SettlementError::ValidationFailed(format!(
+				"Order-bound output oracle is not configured for destination chain {destination_chain}"
+			)));
+		}
+		Ok(output_oracle)
+	}
+
 	/// Compute the payload hash that will be checked with isProven
 	fn compute_payload_hash(
 		&self,
@@ -587,15 +619,11 @@ impl HyperlaneSettlement {
 		let payload_hash = submission.payload_hash;
 
 		// Select oracles
-		// We need the input oracle on the destination chain (where we check isProven)
-		let input_oracle = self
-			.select_oracle(&self.get_input_oracles(dest_chain), None)
-			.ok_or_else(|| SettlementError::ValidationFailed("No input oracle".to_string()))?;
-
-		// We need the output oracle on the origin chain (the remote oracle)
-		let output_oracle = self
-			.select_oracle(&self.get_output_oracles(origin_chain), None)
-			.ok_or_else(|| SettlementError::ValidationFailed("No output oracle".to_string()))?;
+		// Security: bind to the order's signed input oracle on the destination chain
+		// (where we check isProven) and the order's signed output oracle on the
+		// origin chain. Reject any divergence from the order-bound oracles.
+		let input_oracle = self.validate_bound_input_oracle(order, dest_chain)?;
+		let output_oracle = self.validate_bound_output_oracle(order, origin_chain)?;
 
 		// Get application address (OutputSettler)
 		let application = order
@@ -902,27 +930,10 @@ impl SettlementInterface for HyperlaneSettlement {
 			))
 		})?;
 
-		// Get the oracle address using selection strategy
-		let oracle_addresses = self.get_input_oracles(origin_chain_id);
-		if oracle_addresses.is_empty() {
-			return Err(SettlementError::ValidationFailed(format!(
-				"No input oracle configured for chain {origin_chain_id}"
-			)));
-		}
-
-		// Use order ID hash for deterministic oracle selection
-		let order_id_hash = keccak256(&order.id);
-		let selection_context =
-			u64::from_be_bytes(order_id_hash[0..8].try_into().map_err(|_| {
-				SettlementError::ValidationFailed("Failed to convert hash bytes".to_string())
-			})?);
-		let oracle_address = self
-			.select_oracle(&oracle_addresses, Some(selection_context))
-			.ok_or_else(|| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to select oracle for chain {origin_chain_id}"
-				))
-			})?;
+		// Security: use the order-bound input oracle from canonical order_data.
+		// Any mismatch with the configured input oracle set for the source chain
+		// is a security event and surfaces as ValidationFailed.
+		let oracle_address = self.validate_bound_input_oracle(order, origin_chain_id)?;
 
 		// Get transaction receipt
 		let hash = FixedBytes::<32>::from_slice(&tx_hash.0);
@@ -1036,25 +1047,19 @@ impl SettlementInterface for HyperlaneSettlement {
 			.map(|c| c.chain_id)
 			.ok_or_else(|| SettlementError::ValidationFailed("No input chains".into()))?;
 
-		// Get output oracle on destination chain
-		let output_oracles = self.get_output_oracles(dest_chain);
-		if output_oracles.is_empty() {
-			return Ok(None); // No oracle configured
-		}
-
-		let oracle_address = self
-			.select_oracle(&output_oracles, None)
-			.ok_or_else(|| SettlementError::ValidationFailed("Failed to select oracle".into()))?;
-
-		// Get input oracle on origin chain (recipient)
-		let input_oracles = self.get_input_oracles(origin_chain);
-		if input_oracles.is_empty() {
+		// Preserve legitimate "no oracle configured for this chain = skip post-fill"
+		// semantics. Any mismatch between the order-bound oracle and the configured
+		// supported set MUST surface as ValidationFailed below, not as Ok(None).
+		if self.get_output_oracles(dest_chain).is_empty() {
 			return Ok(None);
 		}
-
-		let recipient_oracle = self.select_oracle(&input_oracles, None).ok_or_else(|| {
-			SettlementError::ValidationFailed("Failed to select recipient".into())
-		})?;
+		if self.get_input_oracles(origin_chain).is_empty() {
+			return Ok(None);
+		}
+		// Security: bind to the order's signed output oracle (destination) and
+		// signed input oracle (origin / recipient).
+		let oracle_address = self.validate_bound_output_oracle(order, dest_chain)?;
+		let recipient_oracle = self.validate_bound_input_oracle(order, origin_chain)?;
 
 		// Extract fill details from order
 		let output = extract_output_details(order)?;
@@ -1303,3 +1308,164 @@ impl solver_types::ImplementationRegistry for Registry {
 }
 
 impl crate::SettlementRegistry for Registry {}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::OracleSelectionStrategy;
+	use solver_types::standards::eip7683::MandateOutput;
+	use solver_types::utils::tests::builders::{
+		Eip7683OrderDataBuilder, MandateOutputBuilder, OrderBuilder,
+	};
+
+	fn test_storage() -> Arc<StorageService> {
+		Arc::new(StorageService::new(Box::new(
+			solver_storage::implementations::memory::MemoryStorage::new(),
+		)))
+	}
+
+	fn test_hyperlane_settlement(oracle_config: OracleConfig) -> HyperlaneSettlement {
+		HyperlaneSettlement {
+			providers: HashMap::new(),
+			oracle_config,
+			mailbox_addresses: HashMap::new(),
+			igp_addresses: HashMap::new(),
+			message_tracker: Arc::new(MessageTracker::new(test_storage())),
+			default_gas_limit: 500_000,
+		}
+	}
+
+	fn make_eip7683_order_data_for_binding(
+		input_oracle: &solver_types::Address,
+		outputs: Vec<MandateOutput>,
+	) -> serde_json::Value {
+		let data = Eip7683OrderDataBuilder::new()
+			.origin_chain_id(U256::from(1u64))
+			.input_oracle(with_0x_prefix(&hex::encode(&input_oracle.0)))
+			.outputs(outputs)
+			.build();
+		serde_json::to_value(data).unwrap()
+	}
+
+	fn make_output_for_binding(destination_chain: u64, output_oracle: [u8; 32]) -> MandateOutput {
+		MandateOutputBuilder::new()
+			.oracle(output_oracle)
+			.chain_id(U256::from(destination_chain))
+			.token([0x11; 32])
+			.amount(U256::from(42u64))
+			.recipient([0x22; 32])
+			.build()
+	}
+
+	#[test]
+	fn test_validate_bound_input_oracle_success() {
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(137, [0u8; 32])],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::from([(1u64, vec![input_oracle.clone()])]),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_hyperlane_settlement(oracle_config);
+
+		assert_eq!(
+			settlement.validate_bound_input_oracle(&order, 1).unwrap(),
+			input_oracle
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_input_oracle_rejects_unsupported() {
+		let signed_oracle = solver_types::Address(vec![0x33; 20]);
+		let configured_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&signed_oracle,
+				vec![make_output_for_binding(137, [0u8; 32])],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::from([(1u64, vec![configured_oracle])]),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_hyperlane_settlement(oracle_config);
+
+		let err = settlement
+			.validate_bound_input_oracle(&order, 1)
+			.unwrap_err();
+		assert!(
+			err.to_string()
+				.contains("not configured for source chain 1"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_output_oracle_success() {
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(
+					137,
+					address_to_bytes32(&output_oracle),
+				)],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::from([(137u64, vec![output_oracle.clone()])]),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_hyperlane_settlement(oracle_config);
+
+		assert_eq!(
+			settlement
+				.validate_bound_output_oracle(&order, 137)
+				.unwrap(),
+			output_oracle
+		);
+	}
+
+	#[test]
+	fn test_validate_bound_output_oracle_rejects_unsupported() {
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let signed_output_oracle = solver_types::Address(vec![0x44; 20]);
+		let configured_output_oracle = solver_types::Address(vec![0x55; 20]);
+		let order = OrderBuilder::new()
+			.with_data(make_eip7683_order_data_for_binding(
+				&input_oracle,
+				vec![make_output_for_binding(
+					137,
+					address_to_bytes32(&signed_output_oracle),
+				)],
+			))
+			.build();
+		let oracle_config = OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::from([(137u64, vec![configured_output_oracle])]),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		};
+		let settlement = test_hyperlane_settlement(oracle_config);
+
+		let err = settlement
+			.validate_bound_output_oracle(&order, 137)
+			.unwrap_err();
+		assert!(
+			err.to_string()
+				.contains("not configured for destination chain 137"),
+			"unexpected error: {err}"
+		);
+	}
+}

--- a/crates/solver-settlement/src/lib.rs
+++ b/crates/solver-settlement/src/lib.rs
@@ -33,6 +33,11 @@ pub mod utils;
 /// Block-hash pusher for L1→L2 buffer advancement
 pub mod pusher;
 
+/// Shared helpers for decoding order-bound oracle addresses from canonical
+/// EIP-7683 order data.
+mod oracle_binding;
+pub(crate) use oracle_binding::{parse_bound_input_oracle, parse_bound_output_oracle};
+
 /// Errors that can occur during settlement operations.
 #[derive(Debug, Error)]
 pub enum SettlementError {
@@ -751,7 +756,25 @@ impl SettlementService {
 		tx_hash: &TransactionHash,
 	) -> Result<FillProof, SettlementError> {
 		let implementation = self.find_settlement_for_order(order)?;
-		implementation.get_attestation(order, tx_hash).await
+		let proof = implementation.get_attestation(order, tx_hash).await?;
+
+		// Security: every FillProof must carry the order-bound input oracle.
+		// This is the central guard that protects against settlement implementations
+		// that select an oracle from configuration instead of binding to the signed
+		// order (cf. Fix 3, security/input-oracle-binding).
+		let expected = crate::parse_bound_input_oracle(order)?;
+		let actual = solver_types::utils::conversion::parse_address(&proof.oracle_address)
+			.map_err(|e| {
+				SettlementError::ValidationFailed(format!("Invalid FillProof oracle_address: {e}"))
+			})?;
+		if actual != expected {
+			return Err(SettlementError::ValidationFailed(format!(
+				"fill_proof.oracle_address 0x{} does not match order-bound input_oracle 0x{}",
+				alloy_primitives::hex::encode(&actual.0),
+				alloy_primitives::hex::encode(&expected.0),
+			)));
+		}
+		Ok(proof)
 	}
 
 	/// Checks if an order can be claimed using the appropriate settlement implementation.
@@ -1448,5 +1471,87 @@ mod tests {
 				.chain_id,
 			11
 		);
+	}
+
+	// ── Fix 3 Part C: SettlementService::get_attestation guard ─────────────
+
+	fn make_order_with_input_oracle(input_oracle_hex: &str) -> Order {
+		// OrderBuilder defaults already provide valid eip7683 fields; only override
+		// the input_oracle inside the data blob.
+		let mut order = OrderBuilder::new()
+			.with_settlement_name(Some("bound"))
+			.build();
+		let mut data = order.data.as_object().cloned().unwrap();
+		data.insert(
+			"input_oracle".to_string(),
+			serde_json::Value::String(input_oracle_hex.to_string()),
+		);
+		order.data = serde_json::Value::Object(data);
+		order
+	}
+
+	fn fill_proof_with_oracle(oracle_hex: &str) -> FillProof {
+		FillProof {
+			tx_hash: TransactionHash(vec![0xaa; 32]),
+			block_number: 1,
+			attestation_data: None,
+			filled_timestamp: 1,
+			oracle_address: oracle_hex.to_string(),
+		}
+	}
+
+	fn make_service_with_mock(attestation: FillProof) -> SettlementService {
+		let mut settlement = make_test_settlement(OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		settlement.attestation = Some(attestation);
+		SettlementService::new(
+			HashMap::from([(
+				"bound".to_string(),
+				Box::new(settlement) as Box<dyn SettlementInterface>,
+			)]),
+			"bound".to_string(),
+			1,
+		)
+	}
+
+	#[tokio::test]
+	async fn test_get_attestation_rejects_mismatched_fill_proof_oracle() {
+		let canonical_oracle_hex = "0xAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaa";
+		let attacker_oracle_hex = "0xBBbbBBbbBBbbBBbbBBbbBBbbBBbbBBbbBBbbBBbb";
+
+		let order = make_order_with_input_oracle(canonical_oracle_hex);
+		let attesting_proof = fill_proof_with_oracle(attacker_oracle_hex);
+		let service = make_service_with_mock(attesting_proof);
+
+		let tx_hash = TransactionHash(vec![0u8; 32]);
+		let result = service.get_attestation(&order, &tx_hash).await;
+		assert!(
+			matches!(result, Err(SettlementError::ValidationFailed(_))),
+			"expected ValidationFailed; got: {:?}",
+			result.map(|_| "Ok")
+		);
+		if let Err(SettlementError::ValidationFailed(msg)) = result {
+			assert!(
+				msg.contains("does not match order-bound input_oracle"),
+				"unexpected error message: {msg}"
+			);
+		}
+	}
+
+	#[tokio::test]
+	async fn test_get_attestation_passes_matching_fill_proof_oracle() {
+		let canonical_oracle_hex = "0xAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaaAAaa";
+
+		let order = make_order_with_input_oracle(canonical_oracle_hex);
+		let attesting_proof = fill_proof_with_oracle(canonical_oracle_hex);
+		let service = make_service_with_mock(attesting_proof);
+
+		let tx_hash = TransactionHash(vec![0u8; 32]);
+		let result = service.get_attestation(&order, &tx_hash).await;
+		assert!(result.is_ok(), "expected Ok; got {:?}", result.err());
 	}
 }

--- a/crates/solver-settlement/src/oracle_binding.rs
+++ b/crates/solver-settlement/src/oracle_binding.rs
@@ -20,9 +20,17 @@ fn parse_eip7683_order_data(order: &Order) -> Result<Eip7683OrderData, Settlemen
 /// Parse the order-bound input oracle from canonical `Order.data`.
 pub(crate) fn parse_bound_input_oracle(order: &Order) -> Result<Address, SettlementError> {
 	let order_data = parse_eip7683_order_data(order)?;
-	parse_address(&order_data.input_oracle).map_err(|e| {
+	let input_oracle = parse_address(&order_data.input_oracle).map_err(|e| {
 		SettlementError::ValidationFailed(format!("Invalid order-bound input oracle: {e}"))
-	})
+	})?;
+
+	if input_oracle.0.iter().all(|byte| *byte == 0) {
+		return Err(SettlementError::ValidationFailed(
+			"Order input oracle is zero; order-bound input oracle is required".to_string(),
+		));
+	}
+
+	Ok(input_oracle)
 }
 
 /// Parse the order-bound output oracle for the given destination chain.

--- a/crates/solver-settlement/src/oracle_binding.rs
+++ b/crates/solver-settlement/src/oracle_binding.rs
@@ -1,0 +1,55 @@
+//! Shared helpers for decoding order-bound oracle addresses from the canonical
+//! EIP-7683 order data. Moved from broadcaster.rs to be shared across all
+//! settlement implementations (broadcaster, direct, hyperlane).
+
+use crate::SettlementError;
+use solver_types::{bytes32_to_address, parse_address, Address, Eip7683OrderData, Order};
+
+fn parse_eip7683_order_data(order: &Order) -> Result<Eip7683OrderData, SettlementError> {
+	if order.standard != "eip7683" {
+		return Err(SettlementError::ValidationFailed(format!(
+			"Settlement only supports eip7683 orders, got '{}'",
+			order.standard
+		)));
+	}
+	serde_json::from_value(order.data.clone()).map_err(|e| {
+		SettlementError::ValidationFailed(format!("Failed to parse eip7683 order data: {e}"))
+	})
+}
+
+/// Parse the order-bound input oracle from canonical `Order.data`.
+pub(crate) fn parse_bound_input_oracle(order: &Order) -> Result<Address, SettlementError> {
+	let order_data = parse_eip7683_order_data(order)?;
+	parse_address(&order_data.input_oracle).map_err(|e| {
+		SettlementError::ValidationFailed(format!("Invalid order-bound input oracle: {e}"))
+	})
+}
+
+/// Parse the order-bound output oracle for the given destination chain.
+pub(crate) fn parse_bound_output_oracle(
+	order: &Order,
+	destination_chain: u64,
+) -> Result<Address, SettlementError> {
+	let order_data = parse_eip7683_order_data(order)?;
+	let output = order_data
+		.outputs
+		.iter()
+		.find(|output| output.chain_id.to::<u64>() == destination_chain)
+		.ok_or_else(|| {
+			SettlementError::ValidationFailed(format!(
+				"No order output found for destination chain {destination_chain}"
+			))
+		})?;
+
+	if output.oracle == [0u8; 32] {
+		return Err(SettlementError::ValidationFailed(format!(
+			"Order output oracle is zero for destination chain {destination_chain}; \
+			 order-bound output oracle is required"
+		)));
+	}
+
+	let oracle_hex = bytes32_to_address(&output.oracle);
+	parse_address(&oracle_hex).map_err(|e| {
+		SettlementError::ValidationFailed(format!("Invalid order-bound output oracle: {e}"))
+	})
+}


### PR DESCRIPTION
- Updated Eip7683OrderImpl to use the order-bound input oracle from canonical order data instead of FillProof's oracle address, ensuring order identity is preserved during claims.
- Introduced shared helpers for parsing order-bound oracles in the new oracle_binding module.
- Implemented validation methods for bound input and output oracles in DirectSettlement and HyperlaneSettlement, enforcing security checks against configured oracles.
- Added tests to verify correct behavior of oracle validation and rejection of mismatched oracles in settlement services.

# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
