### PR TITLE
Profitability gate: make fail-open observable + add operator-toggleable fail-closed mode

### DIFF
--- a/crates/solver-config/src/lib.rs
+++ b/crates/solver-config/src/lib.rs
@@ -458,6 +458,13 @@ pub struct TxBumpChainConfig {
 	pub max_replacements_per_stage: Option<u32>,
 	pub max_fee_per_gas_cap_wei: Option<String>,
 	pub max_priority_fee_per_gas_cap_wei: Option<String>,
+	/// When `true`, the bump sweeper's profitability gate treats every
+	/// fail-open branch (missing quote, pricing error, decimal parse,
+	/// etc.) as a skip instead of proceeding. Default `false` preserves
+	/// the existing liveness-first behavior. The
+	/// `BumpProfitabilityCheckSkipped` event fires in both modes — only
+	/// the proceed/skip decision changes.
+	pub profitability_gate_fail_closed: Option<bool>,
 }
 
 /// Top-level transaction-bump policy.
@@ -483,6 +490,10 @@ pub struct TxBumpConfig {
 	pub default_max_fee_per_gas_cap_wei: Option<String>,
 	#[serde(default)]
 	pub default_max_priority_fee_per_gas_cap_wei: Option<String>,
+	/// Default for `TxBumpChainConfig::profitability_gate_fail_closed`.
+	/// `false` (the default) preserves Nahim's fail-open behavior.
+	#[serde(default)]
+	pub default_profitability_gate_fail_closed: bool,
 	#[serde(default)]
 	pub chains: HashMap<u64, TxBumpChainConfig>,
 }
@@ -510,6 +521,7 @@ impl Default for TxBumpConfig {
 			default_max_replacements_per_stage: default_max_replacements_per_stage(),
 			default_max_fee_per_gas_cap_wei: None,
 			default_max_priority_fee_per_gas_cap_wei: None,
+			default_profitability_gate_fail_closed: false,
 			chains: HashMap::new(),
 		}
 	}
@@ -526,6 +538,12 @@ pub struct EffectiveTxBumpPolicy {
 	pub max_replacements_per_stage: u32,
 	pub max_fee_per_gas_cap_wei: Option<u128>,
 	pub max_priority_fee_per_gas_cap_wei: Option<u128>,
+	/// Resolved per-chain override of
+	/// `default_profitability_gate_fail_closed`. When `true`, the bump
+	/// sweeper's profitability gate skips the bump on every fail-open
+	/// branch; when `false` (default), the gate proceeds with the bump
+	/// while still emitting `BumpProfitabilityCheckSkipped`.
+	pub profitability_gate_fail_closed: bool,
 }
 
 impl TxBumpConfig {
@@ -549,6 +567,9 @@ impl TxBumpConfig {
 				.or_else(|| parse_cap(&self.default_max_fee_per_gas_cap_wei)),
 			max_priority_fee_per_gas_cap_wei: parse_cap(&chain.max_priority_fee_per_gas_cap_wei)
 				.or_else(|| parse_cap(&self.default_max_priority_fee_per_gas_cap_wei)),
+			profitability_gate_fail_closed: chain
+				.profitability_gate_fail_closed
+				.unwrap_or(self.default_profitability_gate_fail_closed),
 		})
 	}
 
@@ -1784,6 +1805,7 @@ mod tests {
 				max_replacements_per_stage: None,
 				max_fee_per_gas_cap_wei: Some("50000000000".into()),
 				max_priority_fee_per_gas_cap_wei: None,
+				profitability_gate_fail_closed: None,
 			},
 		);
 		let eff = cfg.for_chain(1).unwrap();

--- a/crates/solver-core/src/bump/service.rs
+++ b/crates/solver-core/src/bump/service.rs
@@ -333,12 +333,22 @@ impl TransactionBumpService {
 					error = %e,
 					"tx_bump: order retrieve failed; proceeding with bump (fail-open)"
 				);
+				self.emit_profitability_check_skipped(
+					order_id,
+					&tip.id,
+					chain_id,
+					tx_type,
+					"order not found",
+				);
+				if policy.profitability_gate_fail_closed {
+					return;
+				}
 				None
 			},
 		};
 		if let Some(order) = order_opt.as_ref() {
 			if self
-				.should_skip_for_profitability(order, &bumped, tip, chain_id, tx_type)
+				.should_skip_for_profitability(order, &bumped, tip, chain_id, tx_type, policy)
 				.await
 			{
 				return;
@@ -579,9 +589,38 @@ impl TransactionBumpService {
 		}
 	}
 
+	/// Emit a `BumpProfitabilityCheckSkipped` event. Called from every
+	/// fail-open branch of `should_skip_for_profitability` (and from the
+	/// order-lookup branch at the call site in `maybe_bump_component`)
+	/// regardless of whether the gate is in fail-open or fail-closed mode.
+	fn emit_profitability_check_skipped(
+		&self,
+		order_id: &str,
+		attempt_id: &str,
+		chain_id: u64,
+		tx_type: solver_types::TransactionType,
+		reason: &str,
+	) {
+		self.event_bus
+			.publish(SolverEvent::Delivery(
+				DeliveryEvent::BumpProfitabilityCheckSkipped {
+					order_id: order_id.to_string(),
+					attempt_id: attempt_id.to_string(),
+					chain_id,
+					tx_type,
+					reason: reason.to_string(),
+				},
+			))
+			.ok();
+	}
+
 	/// Returns `true` if the bump should be skipped due to insufficient
-	/// order-level profitability headroom. Fails open: any error or
-	/// missing data returns `false` (proceed with bump) and logs a `warn!`.
+	/// order-level profitability headroom.
+	///
+	/// Fail-open branches (missing quote, pricing error, decimal parse,
+	/// etc.) emit `BumpProfitabilityCheckSkipped` and then either skip
+	/// (when `policy.profitability_gate_fail_closed == true`) or proceed
+	/// (default) with the bump. The event fires in both modes.
 	async fn should_skip_for_profitability(
 		&self,
 		order: &solver_types::Order,
@@ -589,13 +628,29 @@ impl TransactionBumpService {
 		tip: &solver_types::TransactionAttempt,
 		chain_id: u64,
 		tx_type: solver_types::TransactionType,
+		policy: &EffectiveTxBumpPolicy,
 	) -> bool {
 		use rust_decimal::Decimal;
 		use std::str::FromStr;
 
-		// Fail-open: no quote_id → no profitability data → proceed silently.
+		// `fail_closed` is the boolean the seven fail-open branches return:
+		// `true` skips the bump, `false` proceeds.
+		let fail_closed = policy.profitability_gate_fail_closed;
+
+		// Fail-open: no quote_id → no profitability data.
 		let Some(quote_id) = order.quote_id.as_ref() else {
-			return false;
+			tracing::warn!(
+				order_id = %order.id,
+				"tx_bump: order has no quote_id; profitability gate cannot run (fail-open)"
+			);
+			self.emit_profitability_check_skipped(
+				&order.id,
+				&tip.id,
+				chain_id,
+				tx_type,
+				"no quote_id",
+			);
+			return fail_closed;
 		};
 
 		// Fail-open: stored quote lookup error → proceed with warn.
@@ -612,7 +667,14 @@ impl TransactionBumpService {
 					error = %e,
 					"tx_bump: stored quote lookup failed; proceeding with bump (fail-open)"
 				);
-				return false;
+				self.emit_profitability_check_skipped(
+					&order.id,
+					&tip.id,
+					chain_id,
+					tx_type,
+					"stored quote lookup failed",
+				);
+				return fail_closed;
 			},
 		};
 		let cb = &stored.cost_context.cost_breakdown;
@@ -624,7 +686,14 @@ impl TransactionBumpService {
 				tip_id = %tip.id,
 				"tx_bump: tip.tx.gas_limit is None; proceeding with bump (fail-open)"
 			);
-			return false;
+			self.emit_profitability_check_skipped(
+				&order.id,
+				&tip.id,
+				chain_id,
+				tx_type,
+				"tip gas_limit missing",
+			);
+			return fail_closed;
 		};
 
 		// Take EIP-1559 max_fee_per_gas first; fall back to legacy gas_price.
@@ -633,7 +702,14 @@ impl TransactionBumpService {
 				order_id = %order.id,
 				"tx_bump: bumped fees missing both max_fee_per_gas and gas_price; proceeding (fail-open)"
 			);
-			return false;
+			self.emit_profitability_check_skipped(
+				&order.id,
+				&tip.id,
+				chain_id,
+				tx_type,
+				"bumped fees missing",
+			);
+			return fail_closed;
 		};
 
 		let bumped_cost_wei = fee_per_gas.saturating_mul(gas_units as u128);
@@ -652,7 +728,14 @@ impl TransactionBumpService {
 					error = %e,
 					"tx_bump: wei_to_currency failed; proceeding with bump (fail-open)"
 				);
-				return false;
+				self.emit_profitability_check_skipped(
+					&order.id,
+					&tip.id,
+					chain_id,
+					tx_type,
+					"wei_to_currency error",
+				);
+				return fail_closed;
 			},
 		};
 
@@ -665,7 +748,14 @@ impl TransactionBumpService {
 					error = %e,
 					"tx_bump: bumped cost not parseable as Decimal; proceeding (fail-open)"
 				);
-				return false;
+				self.emit_profitability_check_skipped(
+					&order.id,
+					&tip.id,
+					chain_id,
+					tx_type,
+					"decimal parse error",
+				);
+				return fail_closed;
 			},
 		};
 
@@ -1937,5 +2027,166 @@ mod tests {
 		tokio::time::sleep(Duration::from_secs(2)).await;
 		svc.tick().await.unwrap();
 		// expect_submit().times(1) asserts the bump fired despite no quote_id.
+	}
+
+	// =====================================================================
+	// 17. Profitability gate fail-open (default) emits
+	// `BumpProfitabilityCheckSkipped` with reason="no quote_id" while the
+	// bump still proceeds. Locks in the observability half of OZ's review.
+	// =====================================================================
+	#[tokio::test]
+	async fn bump_proceeds_when_no_quote_id_emits_skipped_event() {
+		let cfg = default_enabled_config();
+		// Sanity-check: default is fail-open across the workspace.
+		assert!(
+			!cfg.chains
+				.get(&1u64)
+				.unwrap()
+				.profitability_gate_fail_closed
+				.unwrap_or(cfg.default_profitability_gate_fail_closed),
+			"default policy must be fail-open"
+		);
+
+		let signer = Address(vec![9; 20]);
+
+		// Stage 1: throwaway service to obtain attempt_store + storage Arcs.
+		let throwaway_mock = {
+			let mut m = MockDeliveryInterface::new();
+			let s = signer.clone();
+			m.expect_submission_signer()
+				.returning(move |_| Some(s.clone()));
+			mock_large_balance(&mut m);
+			m
+		};
+		let (service, attempt_store, storage, bus, _tmp) =
+			test_service(cfg.clone(), throwaway_mock);
+
+		// Default OrderBuilder leaves quote_id = None.
+		seed_active_order(&storage, "order-1").await;
+		seed_attempt(
+			&attempt_store,
+			"parent-1",
+			TransactionAttemptStatus::Broadcast,
+			None,
+			Some(signer.clone()),
+			10_000_000_000u128,
+		)
+		.await;
+
+		// Stage 2: real mock — submit MUST fire (fail-open proceeds).
+		let mut mock = MockDeliveryInterface::new();
+		let signer_clone = signer.clone();
+		mock.expect_submission_signer()
+			.returning(move |_| Some(signer_clone.clone()));
+		mock_large_balance(&mut mock);
+		let recorder: Arc<dyn TransactionAttemptRecorder> = attempt_store.clone();
+		let recorder_for_mock = recorder.clone();
+		mock.expect_submit()
+			.times(1)
+			.returning(move |tx, tracking| {
+				let recorder = recorder_for_mock.clone();
+				Box::pin(async move {
+					let tracking = tracking.expect("sweeper must supply tracking");
+					let outcome: Result<TransactionHash, DeliveryError> =
+						Ok(TransactionHash(vec![0xab; 32]));
+					simulate_submit_recording(
+						&recorder,
+						&tracking,
+						&tx,
+						&outcome,
+						Some(Address(vec![9; 20])),
+					)
+					.await;
+					outcome
+				})
+			});
+		let delivery_impls: HashMap<u64, Arc<dyn DeliveryInterface>> =
+			HashMap::from([(1u64, Arc::new(mock) as Arc<dyn DeliveryInterface>)]);
+		let delivery_svc = Arc::new(DeliveryService::new(delivery_impls, 1, 20, 60));
+		let svc = TransactionBumpService::new(
+			service.config.clone(),
+			storage.clone(),
+			attempt_store.clone(),
+			delivery_svc,
+			service.event_bus.clone(),
+			recorder,
+			test_pricing(),
+		);
+
+		let mut sub = bus.subscribe();
+		tokio::time::sleep(Duration::from_secs(2)).await;
+		svc.tick().await.unwrap();
+		let events = drain_bus_events(&mut sub);
+
+		let found = events.iter().any(|e| {
+			matches!(
+				e,
+				SolverEvent::Delivery(DeliveryEvent::BumpProfitabilityCheckSkipped {
+					order_id, reason, tx_type, chain_id, ..
+				}) if order_id == "order-1"
+					&& reason == "no quote_id"
+					&& *tx_type == TransactionType::Fill
+					&& *chain_id == 1u64
+			)
+		});
+		assert!(
+			found,
+			"expected BumpProfitabilityCheckSkipped(no quote_id), got: {events:?}"
+		);
+		// expect_submit().times(1) on Drop also asserts the bump fired.
+	}
+
+	// =====================================================================
+	// 18. Profitability gate fail-closed: same scenario, but the bump is
+	// skipped while the same event still fires.
+	// =====================================================================
+	#[tokio::test]
+	async fn bump_skipped_when_fail_closed_and_no_quote_id() {
+		let mut cfg = default_enabled_config();
+		// Flip the global default to fail-closed. The chain entry inherits
+		// it through `for_chain`.
+		cfg.default_profitability_gate_fail_closed = true;
+
+		let signer = Address(vec![9; 20]);
+
+		let mut mock = MockDeliveryInterface::new();
+		let signer_clone = signer.clone();
+		mock.expect_submission_signer()
+			.returning(move |_| Some(signer_clone.clone()));
+		mock_large_balance(&mut mock);
+		// The point: submit MUST NOT fire under fail-closed.
+		mock.expect_submit().times(0);
+
+		let (svc, store, storage, bus, _tmp) = test_service(cfg, mock);
+
+		seed_active_order(&storage, "order-1").await;
+		seed_attempt(
+			&store,
+			"parent-1",
+			TransactionAttemptStatus::Broadcast,
+			None,
+			Some(signer.clone()),
+			10_000_000_000u128,
+		)
+		.await;
+
+		let mut sub = bus.subscribe();
+		tokio::time::sleep(Duration::from_secs(2)).await;
+		svc.tick().await.unwrap();
+		let events = drain_bus_events(&mut sub);
+
+		let found = events.iter().any(|e| {
+			matches!(
+				e,
+				SolverEvent::Delivery(DeliveryEvent::BumpProfitabilityCheckSkipped {
+					order_id, reason, ..
+				}) if order_id == "order-1" && reason == "no quote_id"
+			)
+		});
+		assert!(
+			found,
+			"expected BumpProfitabilityCheckSkipped(no quote_id), got: {events:?}"
+		);
+		// expect_submit().times(0) asserts the bump was skipped.
 	}
 }

--- a/crates/solver-service/src/config_merge.rs
+++ b/crates/solver-service/src/config_merge.rs
@@ -2642,6 +2642,9 @@ fn translate_tx_bump(op: &solver_types::OperatorTxBumpConfig) -> solver_config::
 		default_max_priority_fee_per_gas_cap_wei: op
 			.default_max_priority_fee_per_gas_cap_wei
 			.clone(),
+		default_profitability_gate_fail_closed: op
+			.default_profitability_gate_fail_closed
+			.unwrap_or(defaults.default_profitability_gate_fail_closed),
 		chains: op
 			.chains
 			.iter()
@@ -2656,6 +2659,7 @@ fn translate_tx_bump(op: &solver_types::OperatorTxBumpConfig) -> solver_config::
 						max_priority_fee_per_gas_cap_wei: c
 							.max_priority_fee_per_gas_cap_wei
 							.clone(),
+						profitability_gate_fail_closed: c.profitability_gate_fail_closed,
 					},
 				)
 			})

--- a/crates/solver-types/src/events.rs
+++ b/crates/solver-types/src/events.rs
@@ -154,6 +154,24 @@ pub enum DeliveryEvent {
 		chain_id: u64,
 		tx_type: TransactionType,
 	},
+	/// Bump sweeper's profitability gate could not run a strict check for
+	/// this attempt — emitted from each fail-open branch of
+	/// `should_skip_for_profitability`. The boolean return (proceed vs.
+	/// skip) is controlled by the per-chain `profitability_gate_fail_closed`
+	/// flag; the event fires regardless of mode so operators can alert on
+	/// a non-zero rate of unverified bumps.
+	BumpProfitabilityCheckSkipped {
+		order_id: String,
+		attempt_id: String,
+		chain_id: u64,
+		tx_type: TransactionType,
+		/// Short, human-readable explanation of which branch fired.
+		/// Stable values: "order not found", "no quote_id",
+		/// "stored quote lookup failed", "tip gas_limit missing",
+		/// "bumped fees missing", "wei_to_currency error",
+		/// "decimal parse error".
+		reason: String,
+	},
 }
 
 /// Which EIP-1559 cap was the binding constraint on a blocked bump.

--- a/crates/solver-types/src/operator_config.rs
+++ b/crates/solver-types/src/operator_config.rs
@@ -742,6 +742,10 @@ pub struct OperatorTxBumpConfig {
 	pub default_max_replacements_per_stage: Option<u32>,
 	pub default_max_fee_per_gas_cap_wei: Option<String>,
 	pub default_max_priority_fee_per_gas_cap_wei: Option<String>,
+	/// Bootstrap mirror of
+	/// `solver_config::TxBumpConfig::default_profitability_gate_fail_closed`.
+	/// `None` resolves to the runtime default (`false`).
+	pub default_profitability_gate_fail_closed: Option<bool>,
 	pub chains: HashMap<u64, OperatorTxBumpChainConfig>,
 }
 
@@ -754,6 +758,9 @@ pub struct OperatorTxBumpChainConfig {
 	pub max_replacements_per_stage: Option<u32>,
 	pub max_fee_per_gas_cap_wei: Option<String>,
 	pub max_priority_fee_per_gas_cap_wei: Option<String>,
+	/// Bootstrap mirror of
+	/// `solver_config::TxBumpChainConfig::profitability_gate_fail_closed`.
+	pub profitability_gate_fail_closed: Option<bool>,
 }
 
 /// One side of a rebalance pair.


### PR DESCRIPTION
Sitting on top of #352. Two improvements to the profitability gate added in 06f9a98. Happy to fold into #352 — opened standalone for clarity.

### Why these changes

The new `should_skip_for_profitability` is the right shape. Two refinements:

1. **Fail-open without a structured signal hides exactly the situations operators need to know about.**
   The gate currently fails-open in seven branches: order lookup error, `order.quote_id == None`, stored-quote lookup error, `tip.tx.gas_limit == None`, both fee fields `None`, `wei_to_currency` error, and `Decimal::from_str` error. Each branch logs a `warn!` and proceeds with the bump. That's defensible for liveness, but it means a quote-storage hiccup or a pricing-service outage silently disables the financial protection — and operators have no metric to surface "how many bumps went out without a profitability check this hour." Added a `BumpProfitabilityCheckSkipped { reason, ... }` event so operators can alert on a non-zero rate. The reason field carries a short human-readable explanation per branch.

2. **`profitability_gate_fail_closed` config flag.**
   For operators who'd rather skip the bump than land an unverified one (cap + max-replacements still bound liveness damage when the gate is closed), added an opt-in flag defaulting to `false` — i.e., zero behavior change unless an operator explicitly turns it on. When `true`, every fail-open branch becomes a fail-closed skip while still emitting the new event.

### What's NOT in this PR but is worth a separate follow-up

**Cross-stage headroom drain.** The headroom (`gas_buffer + min_profit`) is order-level, but the per-stage check (`gas_open` / `gas_fill` / `gas_post_fill` / `gas_pre_claim` / `gas_claim`) consumes it independently for each `tx_type`. If Fill bumps and PostFill also bumps later, each check passes locally but the order ends up aggregate-underwater. Cleanest fix: track cumulative consumed headroom on the order or on the lineage row and subtract from the order-wide headroom on subsequent checks. Out of scope here because it needs storage/schema work — happy to open a separate PR.

**Nonce reclaim on long-pending tx** is a separate concern raised in DM — also a follow-up PR.

### Tests
- `bump_proceeds_when_no_quote_id_emits_skipped_event` — fail-open path emits structured event with correct reason.
- `bump_skipped_when_fail_closed_and_no_quote_id` — fail-closed path skips bump and emits event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-chain configuration to control transaction bump behavior when profitability checks cannot be completed
  * Improved observability with new events logged whenever profitability checks are skipped, including specific failure reasons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openintentsframework/oif-solver/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->