### PR TITLE
fix(security): validate allocatorData at intake for ResourceLock orders (C-02)

### DIFF
--- a/crates/solver-service/src/eip712/compact/mod.rs
+++ b/crates/solver-service/src/eip712/compact/mod.rs
@@ -63,6 +63,78 @@ pub fn create_signature_validator() -> impl SignatureValidator {
 	CompactSignatureValidator
 }
 
+/// Extract the allocator portion from an ABI-encoded `(sponsorSig, allocatorData)` blob.
+///
+/// TheCompact's `IInputSettlerCompact::finalise` consumes a `signatures` argument
+/// shaped as `abi.encode(bytes sponsorSig, bytes allocatorData)`. The solver forwards
+/// this blob verbatim, so a malformed/empty `allocatorData` is only discovered when
+/// `finalise` reverts on-chain — after the destination fill has already been fronted.
+///
+/// This mirrors the byte layout that [`extract_sponsor_signature`] relies on (two head
+/// offsets followed by length-prefixed `bytes` bodies) so the two extractors stay
+/// consistent with the on-chain encoding. Returns `Some(allocatorData)` when the second
+/// tuple element can be located, or `None` when the blob is not a well-formed
+/// two-element tuple (e.g. a raw 65-byte signature).
+pub fn extract_allocator_data(signature: &Bytes) -> Option<Bytes> {
+	// Need at least: two 32-byte head offsets + sponsorSig length word.
+	if signature.len() < 96 {
+		return None;
+	}
+
+	// Head slot 1 (bytes 32..64): offset to the second element (allocatorData).
+	let read_u256_as_usize = |start: usize| -> Option<usize> {
+		let slot = signature.get(start..start + 32)?;
+		// Reject offsets that don't fit in the lower 8 bytes (defensive; real offsets
+		// are small) so we never index with a truncated value.
+		if slot[..24].iter().any(|b| *b != 0) {
+			return None;
+		}
+		Some(u64::from_be_bytes(slot[24..32].try_into().ok()?) as usize)
+	};
+
+	let allocator_offset = read_u256_as_usize(32)?;
+	let allocator_len = read_u256_as_usize(allocator_offset)?;
+	let allocator_start = allocator_offset.checked_add(32)?;
+	let allocator_end = allocator_start.checked_add(allocator_len)?;
+
+	let allocator = signature.get(allocator_start..allocator_end)?;
+	Some(Bytes::from(allocator.to_vec()))
+}
+
+/// Validate the allocator portion of a Compact `(sponsorSig, allocatorData)` blob.
+///
+/// For ResourceLock (Compact) intents the solver fronts its own capital on the
+/// destination before any origin-chain authorization is checked. The sponsor
+/// sub-signature is validated elsewhere, but `allocatorData` is forwarded untouched
+/// into `finalise`. An empty or non-tuple-encoded `allocatorData` deterministically
+/// reverts at `finalise`, stranding the fill. Reject such payloads at intake.
+///
+/// Returns an error when the signature blob is not a well-formed `(bytes, bytes)`
+/// tuple or when `allocatorData` is empty.
+pub fn validate_allocator_data(signature: &Bytes) -> Result<(), APIError> {
+	match extract_allocator_data(signature) {
+		Some(allocator_data) => {
+			if allocator_data.is_empty() {
+				return Err(APIError::BadRequest {
+					error_type: ApiErrorType::OrderValidationFailed,
+					message: "ResourceLock allocatorData is empty; \
+						finalise would revert and strand the fill"
+						.to_string(),
+					details: None,
+				});
+			}
+			Ok(())
+		},
+		None => Err(APIError::BadRequest {
+			error_type: ApiErrorType::OrderValidationFailed,
+			message: "ResourceLock signature is not a well-formed \
+				abi.encode(sponsorSig, allocatorData) tuple"
+				.to_string(),
+			details: None,
+		}),
+	}
+}
+
 /// Extract sponsor signature from ABI-encoded signature bytes
 /// This handles ABI-encoded signatures: abi.encode(sponsorSig, allocatorSig)
 pub fn extract_sponsor_signature(signature: &Bytes) -> Bytes {
@@ -314,6 +386,70 @@ mod tests {
 		let short_sig = Bytes::from(vec![0x44u8; 32]);
 		let extracted_short = extract_sponsor_signature(&short_sig);
 		assert_eq!(extracted_short, short_sig);
+	}
+
+	/// Build the same non-padded `abi.encode(sponsorSig, allocatorData)` layout the manual
+	/// `extract_sponsor_signature` parser (and TheCompact) use: head offsets at bytes 0/32,
+	/// then length-prefixed bodies with the sponsor body NOT word-padded.
+	fn build_compact_blob(sponsor: &[u8], allocator: &[u8]) -> Bytes {
+		let mut blob = Vec::new();
+		// Offset to sponsorSig body length word (0x40).
+		blob.extend_from_slice(&[0u8; 28]);
+		blob.extend_from_slice(&64u32.to_be_bytes());
+		// Offset to allocatorData body length word: 64 + 32 + sponsor.len().
+		let allocator_offset = 64 + 32 + sponsor.len() as u32;
+		blob.extend_from_slice(&[0u8; 28]);
+		blob.extend_from_slice(&allocator_offset.to_be_bytes());
+		// sponsorSig length + body (no padding).
+		blob.extend_from_slice(&[0u8; 28]);
+		blob.extend_from_slice(&(sponsor.len() as u32).to_be_bytes());
+		blob.extend_from_slice(sponsor);
+		// allocatorData length + body.
+		blob.extend_from_slice(&[0u8; 28]);
+		blob.extend_from_slice(&(allocator.len() as u32).to_be_bytes());
+		blob.extend_from_slice(allocator);
+		Bytes::from(blob)
+	}
+
+	#[test]
+	fn test_extract_allocator_data_roundtrip() {
+		let sponsor = vec![0x11u8; 65];
+		let allocator = vec![0x22u8; 80];
+		let blob = build_compact_blob(&sponsor, &allocator);
+
+		// Sponsor extraction must still match.
+		assert_eq!(extract_sponsor_signature(&blob).to_vec(), sponsor);
+		// Allocator extraction returns the exact allocator bytes.
+		assert_eq!(extract_allocator_data(&blob).unwrap().to_vec(), allocator);
+	}
+
+	#[test]
+	fn test_validate_allocator_data_accepts_non_empty() {
+		let blob = build_compact_blob(&[0x11u8; 65], &[0x22u8; 65]);
+		assert!(validate_allocator_data(&blob).is_ok());
+	}
+
+	#[test]
+	fn test_validate_allocator_data_rejects_empty() {
+		let blob = build_compact_blob(&[0x11u8; 65], &[]);
+		let err = validate_allocator_data(&blob).unwrap_err();
+		match err {
+			APIError::BadRequest { message, .. } => assert!(message.contains("allocatorData")),
+			other => panic!("unexpected error: {other:?}"),
+		}
+	}
+
+	#[test]
+	fn test_validate_allocator_data_rejects_non_tuple() {
+		// A bare 65-byte signature is not a well-formed two-element tuple.
+		let raw = Bytes::from(vec![0x33u8; 65]);
+		let err = validate_allocator_data(&raw).unwrap_err();
+		match err {
+			APIError::BadRequest { message, .. } => {
+				assert!(message.contains("well-formed") || message.contains("tuple"))
+			},
+			other => panic!("unexpected error: {other:?}"),
+		}
 	}
 
 	#[test]

--- a/crates/solver-service/src/validators/signature.rs
+++ b/crates/solver-service/src/validators/signature.rs
@@ -122,6 +122,17 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 				details: None,
 			});
 		}
+
+		// 5. Validate the allocator portion of the Compact signature blob.
+		//
+		// The sponsor sub-signature is verified above, but the untouched
+		// abi.encode(sponsorSig, allocatorData) blob is later forwarded verbatim as the
+		// `signatures` argument of IInputSettlerCompact::finalise. A request with a valid
+		// sponsorSig but malformed/empty allocatorData would pass intake, get filled on the
+		// destination (fronting solver capital), then deterministically revert at finalise —
+		// stranding the fill. Reject malformed allocatorData here, before any fill.
+		compact::validate_allocator_data(&intent.signature)?;
+
 		tracing::debug!("EIP-712 signature validated");
 		Ok(())
 	}
@@ -222,6 +233,20 @@ mod tests {
 		Address(bytes)
 	}
 
+	/// Encode `abi.encode(bytes sponsorSig, bytes allocatorData)` the way TheCompact expects.
+	///
+	/// Uses `abi_encode_params` (not `abi_encode`) so the two `bytes` arguments are laid out
+	/// as a head/tail pair without the extra outer offset word that alloy prepends for a
+	/// standalone dynamic tuple — matching Solidity's `abi.encode(a, b)` exactly.
+	fn encode_compact_signature(sponsor_sig: &[u8], allocator_data: &[u8]) -> Vec<u8> {
+		use alloy_sol_types::sol_data;
+		type CompactSignatureTuple = (sol_data::Bytes, sol_data::Bytes);
+		<CompactSignatureTuple as SolType>::abi_encode_params(&(
+			sponsor_sig.to_vec(),
+			allocator_data.to_vec(),
+		))
+	}
+
 	fn build_signature_fixture() -> SignatureFixture {
 		let chain_id = 1u64;
 		let nonce = 1u64;
@@ -309,9 +334,15 @@ mod tests {
 		let message = Message::from_digest(*digest);
 		let signature = secp.sign_ecdsa_recoverable(message, &secret_key);
 		let (recovery_id, sig_bytes) = signature.serialize_compact();
-		let mut signature_bytes = sig_bytes.to_vec();
+		let mut sponsor_sig = sig_bytes.to_vec();
 		let rec_id: i32 = recovery_id.into();
-		signature_bytes.push((rec_id as u8) + 27);
+		sponsor_sig.push((rec_id as u8) + 27);
+
+		// TheCompact's finalise consumes signatures as abi.encode(sponsorSig, allocatorData).
+		// Wrap the sponsor signature with a non-empty, well-formed allocatorData blob so the
+		// happy-path fixture mirrors the on-chain expectation.
+		let allocator_data = vec![0xABu8; 65];
+		let signature_bytes = encode_compact_signature(&sponsor_sig, &allocator_data);
 
 		let lock_tag_hex = format!("0x{}", hex::encode(lock_tag));
 		let token_hex = format!("0x{}", hex::encode(token_address_bytes));
@@ -513,5 +544,63 @@ mod tests {
 			},
 			Err(other) => panic!("unexpected error: {other:?}"),
 		}
+	}
+
+	/// C-02: a valid sponsorSig paired with EMPTY allocatorData must be rejected at intake,
+	/// before any destination fill is generated. Otherwise finalise reverts and the fronted
+	/// fill is stranded.
+	#[tokio::test]
+	async fn validate_signature_rejects_empty_allocator_data() {
+		let mut fixture = build_signature_fixture();
+		// Re-wrap the same valid sponsor signature with an EMPTY allocatorData.
+		let sponsor_sig = compact::extract_sponsor_signature(&fixture.intent.signature);
+		fixture.intent.signature = Bytes::from(encode_compact_signature(&sponsor_sig, &[]));
+
+		let service = SignatureValidationService::new();
+		let result = service
+			.validate_signature(
+				"eip7683",
+				&fixture.intent,
+				&fixture.networks,
+				&fixture.delivery,
+			)
+			.await;
+
+		assert!(
+			matches!(
+				result,
+				Err(APIError::BadRequest { ref message, .. }) if message.contains("allocatorData")
+			),
+			"expected empty allocatorData rejection, got: {result:?}"
+		);
+	}
+
+	/// C-02: a valid sponsorSig that is NOT wrapped as abi.encode(sponsorSig, allocatorData)
+	/// (a bare 65-byte signature) must be rejected for ResourceLock intake.
+	#[tokio::test]
+	async fn validate_signature_rejects_non_tuple_allocator_blob() {
+		let mut fixture = build_signature_fixture();
+		let sponsor_sig = compact::extract_sponsor_signature(&fixture.intent.signature);
+		// Bare signature, not the ABI tuple form.
+		fixture.intent.signature = sponsor_sig;
+
+		let service = SignatureValidationService::new();
+		let result = service
+			.validate_signature(
+				"eip7683",
+				&fixture.intent,
+				&fixture.networks,
+				&fixture.delivery,
+			)
+			.await;
+
+		assert!(
+			matches!(
+				result,
+				Err(APIError::BadRequest { ref message, .. })
+					if message.contains("well-formed") || message.contains("tuple")
+			),
+			"expected non-tuple allocator blob rejection, got: {result:?}"
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Fixes **C-02**: malformed/unauthorized `allocatorData` in a ResourceLock (Compact) intent was accepted at intake and only failed (deterministically) at on-chain `finalise`, after the solver had already fronted destination-fill capital — stranding that fill (solver capital loss).

## Root cause

For ResourceLock intents, intake signature validation (`Eip7683SignatureValidator::validate_signature`) only verified the **sponsor** sub-signature extracted from the `abi.encode(sponsorSig, allocatorData)` blob. The `allocatorData` portion was never validated. That full blob is persisted by discovery and later forwarded verbatim as the `signatures` argument of `IInputSettlerCompact::finalise`. Because the Compact flow returns `None` from `generate_prepare_transaction` (no origin-chain openFor/validation) and the intent simulation covers only the destination fill, a request with a valid `sponsorSig` but malformed/empty `allocatorData` passed intake, got filled, then reverted at finalise.

## Fix

Validate the allocator portion at intake, **before any fill is generated**:

- `extract_allocator_data` (new) follows the same non-padded `abi.encode(sponsorSig, allocatorData)` byte layout that the existing `extract_sponsor_signature` parser already relies on, and returns the second tuple element. Following the existing layout (rather than strict alloy `abi_decode`) keeps the two extractors consistent with the on-chain encoding the solver actually receives.
- `validate_allocator_data` (new) rejects payloads that are not a well-formed two-element `(bytes, bytes)` tuple, and rejects an empty `allocatorData`.
- `validate_signature` now calls `validate_allocator_data` after sponsor-signature verification, returning `OrderValidationFailed` for malformed/empty allocator bytes — so they are rejected before any destination fill is submitted.

This is the smallest change that makes a malformed/unauthorized `allocatorData` rejected at intake. It is option (1) from the validated spec (allocator-data validation), which is decoupled from a particular allocator scheme.

## RED → GREEN

- **RED** (fix call disabled): the two new validator tests (`validate_signature_rejects_empty_allocator_data`, `validate_signature_rejects_non_tuple_allocator_blob`) failed with `got: Ok(())`, proving current code accepts malformed/empty allocatorData at intake. The happy-path test passed, confirming the RED is for the right reason.
- **GREEN** (fix enabled): all `solver-service` lib tests pass (626 passed). `cargo clippy -p solver-service --all-targets --all-features -- -D warnings --allow deprecated` is clean. `cargo fmt -p solver-service` applied.

New tests:
- `eip712::compact`: `test_extract_allocator_data_roundtrip`, `test_validate_allocator_data_accepts_non_empty`, `test_validate_allocator_data_rejects_empty`, `test_validate_allocator_data_rejects_non_tuple`.
- `validators::signature`: `validate_signature_rejects_empty_allocator_data`, `validate_signature_rejects_non_tuple_allocator_blob`; the existing happy-path fixture was updated to wrap the sponsor signature as a proper `abi.encode(sponsorSig, allocatorData)` blob.

## Default decisions / assumptions (please confirm)

1. **Chose option (1) over a pre-fill origin `finalise` eth_call simulation (option 2).** Building real `finalise` calldata at intake requires `solveParams`/`destination` (timestamp + solver) that are only known after a fill is planned, and the FillProof at intake time is not yet available — so a faithful origin simulation at intake was infeasible without fabricating those params. The allocator-data validation closes the malformed/empty-`allocatorData` class without that coupling. A full origin pre-fill simulation hook remains a reasonable defense-in-depth follow-up.
2. **Empty `allocatorData` is treated as invalid.** Assumes TheCompact deployments in scope require non-empty allocator authorization (signature-based or registered allocator data). If a configured allocator legitimately uses empty `allocatorData` (e.g. an on-chain "always-allow" allocator), this guard would need to be relaxed/config-gated.
3. **Validation only covers structure + non-emptiness**, not cryptographic allocator authorization. It does not verify the allocator signature/registration against TheCompact. That stronger check (recover/verify allocator sig, or call TheCompact's allocator check) is a recommended follow-up; the spec notes a more robust direction is to have the solver generate canonical allocator authorization rather than trust user bytes.

### Deferred follow-ups
- Origin-chain `finalise` eth_call simulation as defense-in-depth once claim/solve params are available pre-fill.
- Full allocator authorization verification (signature recovery / TheCompact allocator check), or solver-generated allocator data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)