### PR TITLE
fix(security): atomic Compact-input reservation ledger (C-03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5333,6 +5333,7 @@ dependencies = [
 name = "solver-storage"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "chrono",
  "fs2",

--- a/crates/solver-service/src/validators/order.rs
+++ b/crates/solver-service/src/validators/order.rs
@@ -7,11 +7,21 @@ use alloy_primitives::{hex, Address as AlloyAddress, U256};
 use alloy_sol_types::SolCall;
 use solver_config::Config;
 use solver_core::SolverEngine;
+use solver_storage::reservation_store::{ReservationError, ReservationStore};
 use solver_types::{
 	standards::eip7683::{interfaces::StandardOrder, LockType},
 	APIError, ApiErrorType,
 };
 use std::convert::TryFrom;
+
+/// TTL (seconds) for a Compact-input reservation.
+///
+/// Reservations are released when an order reaches a terminal state, but until
+/// that lifecycle wiring lands (see PR follow-up) the TTL provides a safety net
+/// so a crashed solver cannot strand a deposit's capacity forever. It is set
+/// comfortably longer than the worst-case order lifetime to avoid prematurely
+/// freeing capacity for a legitimately in-flight order.
+const COMPACT_RESERVATION_TTL_SECONDS: u64 = 3600;
 
 mod interfaces {
 	use alloy_sol_types::sol;
@@ -204,15 +214,33 @@ async fn validate_compact_deposit_for_order(
 	balance_buf.copy_from_slice(response.as_ref());
 	let balance = U256::from_be_bytes(balance_buf);
 
-	if balance < required_amount {
-		return Err(APIError::BadRequest {
-			error_type: ApiErrorType::OrderValidationFailed,
-			message: format!(
-				"Compact deposit for user {user:#x} is insufficient on chain {chain_id} (required {required_amount}, available {balance})",
-			),
-			details: None,
-		});
-	}
+	// Atomically reserve `required_amount` against this deposit. This closes the
+	// concurrency window where N orders backed by the same Compact deposit all
+	// pass a stateless balanceOf check, get filled on the destination, but only
+	// one origin claim can succeed (C-03). The ledger guarantees the total
+	// reserved across in-flight orders never exceeds the on-chain balance.
+	let reservation_store =
+		ReservationStore::new(solver.storage().clone(), COMPACT_RESERVATION_TTL_SECONDS);
+
+	reservation_store
+		.reserve(chain_id, user, token_id, required_amount, balance)
+		.await
+		.map_err(|e| match e {
+			ReservationError::InsufficientCapacity { .. } => APIError::BadRequest {
+				error_type: ApiErrorType::OrderValidationFailed,
+				message: e.to_string(),
+				details: None,
+			},
+			ReservationError::Contended => APIError::BadRequest {
+				error_type: ApiErrorType::OrderValidationFailed,
+				message: "Compact reservation ledger is contended; please retry".to_string(),
+				details: None,
+			},
+			ReservationError::Storage(msg) => APIError::InternalServerError {
+				error_type: ApiErrorType::OrderValidationFailed,
+				message: format!("Failed to reserve Compact deposit: {msg}"),
+			},
+		})?;
 
 	Ok(())
 }
@@ -579,7 +607,7 @@ mod tests {
 
 		match result {
 			Err(APIError::BadRequest { message, .. }) => {
-				assert!(message.contains("Compact deposit"));
+				assert!(message.contains("Insufficient Compact capacity"));
 			},
 			_ => panic!("expected compact deposit failure"),
 		}
@@ -887,6 +915,55 @@ mod tests {
 		)
 		.await
 		.is_ok());
+	}
+
+	#[tokio::test]
+	async fn test_resource_lock_concurrent_reserves_admit_only_one() {
+		// Two ResourceLock orders for the SAME (user, token_id) where the
+		// Compact balance backs only ONE of them. A stateless balanceOf check
+		// admits both (the C-03 bug); with the atomic reservation ledger wired
+		// in, exactly one must be admitted and the other rejected.
+		let token_id = U256::from(123u64);
+		let amount = U256::from(600u64); // two would need 1200
+		let balance = U256::from(1000u64); // backs only one
+
+		let standard_order = build_standard_order(TEST_CHAIN_ID, token_id, amount);
+
+		let mut contract_responses = HashMap::new();
+		contract_responses.insert(TEST_CHAIN_ID, balance.to_be_bytes::<32>().to_vec());
+
+		let delivery = Arc::new(TestDelivery::new(HashMap::new(), contract_responses))
+			as Arc<dyn DeliveryInterface>;
+		let mut delivery_map = HashMap::new();
+		delivery_map.insert(TEST_CHAIN_ID, delivery);
+
+		let config = build_config(TEST_CHAIN_ID, TEST_COMPACT);
+		let solver = Arc::new(build_solver_engine(config.clone(), delivery_map));
+		let config = Arc::new(config);
+
+		let s1 = Arc::clone(&solver);
+		let c1 = Arc::clone(&config);
+		let o1 = standard_order.clone();
+		let s2 = Arc::clone(&solver);
+		let c2 = Arc::clone(&config);
+		let o2 = standard_order.clone();
+
+		let h1 = tokio::spawn(async move {
+			super::ensure_user_capacity_for_order(&s1, &c1, LockType::ResourceLock, &o1).await
+		});
+		let h2 = tokio::spawn(async move {
+			super::ensure_user_capacity_for_order(&s2, &c2, LockType::ResourceLock, &o2).await
+		});
+
+		let r1 = h1.await.unwrap();
+		let r2 = h2.await.unwrap();
+
+		let successes = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+		assert_eq!(
+			successes, 1,
+			"exactly one ResourceLock order may be admitted against a single-backing deposit: \
+			 r1={r1:?} r2={r2:?}"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/solver-storage/Cargo.toml
+++ b/crates/solver-storage/Cargo.toml
@@ -12,6 +12,7 @@ testing = ["mockall"]
 cluster-tests = []
 
 [dependencies]
+alloy-primitives = { workspace = true }
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 fs2 = "0.4"

--- a/crates/solver-storage/src/lib.rs
+++ b/crates/solver-storage/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config_store;
 pub mod nonce_store;
 pub mod readiness;
 pub mod redis_health;
+pub mod reservation_store;
 
 // Re-export redis_health types for convenience
 pub use redis_health::{
@@ -569,6 +570,23 @@ impl StorageService {
 		let bytes =
 			serde_json::to_vec(data).map_err(|e| StorageError::Serialization(e.to_string()))?;
 		self.backend.set_bytes(&key, bytes, indexes, None).await
+	}
+
+	/// Stores raw bytes only if the key does not already exist.
+	///
+	/// Returns `Ok(true)` when the value was set, `Ok(false)` when the key
+	/// already held a (non-expired) value. This exposes the backend's atomic
+	/// set-if-not-exists primitive (Redis `SET NX`, in-memory lock) for callers
+	/// that need to initialize a key exactly once under concurrency.
+	pub async fn set_nx_bytes(
+		&self,
+		namespace: &str,
+		id: &str,
+		value: Vec<u8>,
+		ttl: Option<Duration>,
+	) -> Result<bool, StorageError> {
+		let key = format!("{namespace}:{id}");
+		self.backend.set_nx(&key, value, ttl).await
 	}
 
 	/// Atomically replaces raw bytes if the current bytes still match `expected`.

--- a/crates/solver-storage/src/reservation_store.rs
+++ b/crates/solver-storage/src/reservation_store.rs
@@ -1,0 +1,529 @@
+//! Compact-input reservation ledger.
+//!
+//! Guards against over-admission of `ResourceLock` (Compact) intents that are
+//! all backed by the same on-chain deposit. Intake admission for a Compact
+//! intent performs a stateless `TheCompact.balanceOf(owner, id) >= amount`
+//! check, but with no reservation in storage N concurrently submitted orders
+//! against the same deposit all pass and get filled on the destination chain,
+//! while only one origin claim can succeed. The solver eats the cost of the
+//! unbacked fills.
+//!
+//! This store maintains a per-key reserved total, updated atomically, so that
+//! `reserved + amount` can never exceed the available balance. Reservations are
+//! keyed by `(origin_chain_id, user, token_id)` — the tuple that uniquely
+//! identifies a Compact deposit.
+//!
+//! # Atomicity
+//!
+//! Reservations are mutated using the storage backend's atomic primitives via
+//! [`StorageService`]:
+//!
+//! - First reservation on a key uses `set_nx` (Redis `SET NX`, in-memory lock).
+//! - Subsequent reservations use a compare-and-swap loop on the raw reserved
+//!   bytes, retrying on contention. The check `reserved + amount <= balance`
+//!   happens inside the same CAS critical section, so two concurrent reserves
+//!   can never both succeed past the balance.
+//!
+//! Each reservation carries a TTL so a crashed solver (which never reaches a
+//! terminal state to release) cannot strand a deposit's capacity forever.
+
+use crate::{StorageError, StorageService};
+use alloy_primitives::{Address, U256};
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Storage namespace for Compact-input reservations.
+const RESERVATION_NAMESPACE: &str = "compact_reservation";
+
+/// Maximum number of compare-and-swap retries before giving up under contention.
+const MAX_CAS_RETRIES: usize = 16;
+
+/// Errors that can occur during reservation operations.
+#[derive(Error, Debug)]
+pub enum ReservationError {
+	/// Storage backend operation failed.
+	#[error("Storage error: {0}")]
+	Storage(String),
+
+	/// The requested reservation would exceed the available balance.
+	#[error(
+		"Insufficient Compact capacity for user {user:#x} token {token_id} on chain {chain_id}: \
+		 requested {requested}, already reserved {reserved}, available balance {balance}"
+	)]
+	InsufficientCapacity {
+		/// Origin chain id of the deposit.
+		chain_id: u64,
+		/// Deposit owner.
+		user: Address,
+		/// Compact token id.
+		token_id: U256,
+		/// Amount requested by this reservation.
+		requested: U256,
+		/// Amount already reserved by other in-flight orders.
+		reserved: U256,
+		/// On-chain available balance.
+		balance: U256,
+	},
+
+	/// The reservation ledger was contended beyond the retry budget.
+	#[error("Reservation ledger contended; please retry")]
+	Contended,
+}
+
+impl From<StorageError> for ReservationError {
+	fn from(err: StorageError) -> Self {
+		ReservationError::Storage(err.to_string())
+	}
+}
+
+/// Atomic ledger of reserved Compact-input amounts, keyed by deposit.
+///
+/// Wraps the shared [`StorageService`] so reservations live in the same backend
+/// (Redis in production) as the rest of solver state and are visible across all
+/// solver workers.
+pub struct ReservationStore {
+	storage: Arc<StorageService>,
+	ttl: Duration,
+}
+
+impl ReservationStore {
+	/// Create a new reservation store backed by the shared storage service.
+	///
+	/// `ttl_seconds` bounds how long an unreleased reservation lives; pick a
+	/// value comfortably larger than the worst-case order lifetime so that
+	/// legitimately in-flight orders are never prematurely freed, while a
+	/// crashed solver eventually self-heals.
+	pub fn new(storage: Arc<StorageService>, ttl_seconds: u64) -> Self {
+		Self {
+			storage,
+			ttl: Duration::from_secs(ttl_seconds),
+		}
+	}
+
+	/// Build the storage id for a reservation key.
+	fn reservation_id(chain_id: u64, user: &Address, token_id: U256) -> String {
+		format!("{chain_id}:{user:#x}:{token_id}")
+	}
+
+	/// Atomically reserve `amount` against the deposit identified by
+	/// `(chain_id, user, token_id)`, rejecting if `reserved + amount` would
+	/// exceed `balance`.
+	///
+	/// On success the reservation total is increased by `amount` and the new
+	/// total is returned. On failure no state is mutated.
+	pub async fn reserve(
+		&self,
+		chain_id: u64,
+		user: &Address,
+		token_id: U256,
+		amount: U256,
+		balance: U256,
+	) -> Result<U256, ReservationError> {
+		let id = Self::reservation_id(chain_id, user, token_id);
+
+		for _ in 0..MAX_CAS_RETRIES {
+			match self
+				.storage
+				.retrieve_bytes(RESERVATION_NAMESPACE, &id)
+				.await
+			{
+				Ok(current_bytes) => {
+					let reserved = decode_u256(&current_bytes);
+					let new_total = reserved.checked_add(amount).ok_or(
+						ReservationError::InsufficientCapacity {
+							chain_id,
+							user: *user,
+							token_id,
+							requested: amount,
+							reserved,
+							balance,
+						},
+					)?;
+					if new_total > balance {
+						return Err(ReservationError::InsufficientCapacity {
+							chain_id,
+							user: *user,
+							token_id,
+							requested: amount,
+							reserved,
+							balance,
+						});
+					}
+
+					let swapped = self
+						.storage
+						.compare_and_swap_bytes(
+							RESERVATION_NAMESPACE,
+							&id,
+							&current_bytes,
+							encode_u256(new_total),
+							None,
+							Some(self.ttl),
+						)
+						.await?;
+					if swapped {
+						debug!(
+							chain_id,
+							user = %format!("{user:#x}"),
+							token_id = %token_id,
+							amount = %amount,
+							new_total = %new_total,
+							"Reserved Compact input"
+						);
+						return Ok(new_total);
+					}
+					// Lost the race; retry from a fresh read.
+				},
+				Err(StorageError::NotFound(_)) => {
+					// No reservation yet: this would be the first.
+					if amount > balance {
+						return Err(ReservationError::InsufficientCapacity {
+							chain_id,
+							user: *user,
+							token_id,
+							requested: amount,
+							reserved: U256::ZERO,
+							balance,
+						});
+					}
+					let created = self
+						.storage
+						.set_nx_bytes(
+							RESERVATION_NAMESPACE,
+							&id,
+							encode_u256(amount),
+							Some(self.ttl),
+						)
+						.await?;
+					if created {
+						debug!(
+							chain_id,
+							user = %format!("{user:#x}"),
+							token_id = %token_id,
+							amount = %amount,
+							"Reserved Compact input (first)"
+						);
+						return Ok(amount);
+					}
+					// Another reserve created the key first; retry as an update.
+				},
+				Err(e) => return Err(e.into()),
+			}
+		}
+
+		warn!(
+			chain_id,
+			user = %format!("{user:#x}"),
+			token_id = %token_id,
+			"Compact reservation ledger contended beyond retry budget"
+		);
+		Err(ReservationError::Contended)
+	}
+
+	/// Release `amount` previously reserved for the deposit, e.g. when an order
+	/// reaches a terminal state (claimed/settled/failed).
+	///
+	/// Best-effort and idempotent-ish: releasing more than is currently
+	/// reserved saturates at zero rather than underflowing. A missing key is
+	/// treated as already released.
+	pub async fn release(
+		&self,
+		chain_id: u64,
+		user: &Address,
+		token_id: U256,
+		amount: U256,
+	) -> Result<(), ReservationError> {
+		let id = Self::reservation_id(chain_id, user, token_id);
+
+		for _ in 0..MAX_CAS_RETRIES {
+			let current_bytes = match self
+				.storage
+				.retrieve_bytes(RESERVATION_NAMESPACE, &id)
+				.await
+			{
+				Ok(bytes) => bytes,
+				Err(StorageError::NotFound(_)) => return Ok(()),
+				Err(e) => return Err(e.into()),
+			};
+
+			let reserved = decode_u256(&current_bytes);
+			let new_total = reserved.saturating_sub(amount);
+
+			if new_total.is_zero() {
+				// Best-effort delete; if it races we simply drop the (zero) key.
+				self.storage.remove(RESERVATION_NAMESPACE, &id).await.ok();
+				return Ok(());
+			}
+
+			let swapped = self
+				.storage
+				.compare_and_swap_bytes(
+					RESERVATION_NAMESPACE,
+					&id,
+					&current_bytes,
+					encode_u256(new_total),
+					None,
+					Some(self.ttl),
+				)
+				.await?;
+			if swapped {
+				debug!(
+					chain_id,
+					user = %format!("{user:#x}"),
+					token_id = %token_id,
+					amount = %amount,
+					new_total = %new_total,
+					"Released Compact input reservation"
+				);
+				return Ok(());
+			}
+			// Lost the race; retry.
+		}
+
+		Err(ReservationError::Contended)
+	}
+
+	/// Current reserved total for a deposit (0 if none).
+	pub async fn reserved(
+		&self,
+		chain_id: u64,
+		user: &Address,
+		token_id: U256,
+	) -> Result<U256, ReservationError> {
+		let id = Self::reservation_id(chain_id, user, token_id);
+		match self
+			.storage
+			.retrieve_bytes(RESERVATION_NAMESPACE, &id)
+			.await
+		{
+			Ok(bytes) => Ok(decode_u256(&bytes)),
+			Err(StorageError::NotFound(_)) => Ok(U256::ZERO),
+			Err(e) => Err(e.into()),
+		}
+	}
+}
+
+impl std::fmt::Debug for ReservationStore {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ReservationStore")
+			.field("ttl_secs", &self.ttl.as_secs())
+			.finish()
+	}
+}
+
+/// Encode a reserved total as fixed 32-byte big-endian so CAS comparisons are
+/// stable regardless of value.
+fn encode_u256(value: U256) -> Vec<u8> {
+	value.to_be_bytes::<32>().to_vec()
+}
+
+/// Decode a reserved total; malformed/short values are treated as zero so a
+/// corrupt entry fails safe (re-reservation rather than silent over-admission
+/// would require the value to read *higher*, which a short buffer never does).
+fn decode_u256(bytes: &[u8]) -> U256 {
+	if bytes.len() == 32 {
+		let mut buf = [0u8; 32];
+		buf.copy_from_slice(bytes);
+		U256::from_be_bytes(buf)
+	} else {
+		U256::ZERO
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::implementations::memory::MemoryStorage;
+
+	fn store_with_ttl(ttl_secs: u64) -> ReservationStore {
+		let storage = Arc::new(StorageService::new(Box::new(MemoryStorage::new())));
+		ReservationStore::new(storage, ttl_secs)
+	}
+
+	const USER: Address = Address::new([0x11; 20]);
+
+	#[tokio::test]
+	async fn first_reservation_succeeds_and_tracks_total() {
+		let store = store_with_ttl(300);
+		let token = U256::from(7u64);
+		let balance = U256::from(1000u64);
+
+		let total = store
+			.reserve(1, &USER, token, U256::from(400u64), balance)
+			.await
+			.unwrap();
+		assert_eq!(total, U256::from(400u64));
+		assert_eq!(
+			store.reserved(1, &USER, token).await.unwrap(),
+			U256::from(400u64)
+		);
+	}
+
+	#[tokio::test]
+	async fn second_reservation_within_balance_accumulates() {
+		let store = store_with_ttl(300);
+		let token = U256::from(7u64);
+		let balance = U256::from(1000u64);
+
+		store
+			.reserve(1, &USER, token, U256::from(400u64), balance)
+			.await
+			.unwrap();
+		let total = store
+			.reserve(1, &USER, token, U256::from(500u64), balance)
+			.await
+			.unwrap();
+		assert_eq!(total, U256::from(900u64));
+	}
+
+	#[tokio::test]
+	async fn over_reservation_is_rejected() {
+		let store = store_with_ttl(300);
+		let token = U256::from(7u64);
+		let balance = U256::from(1000u64);
+
+		store
+			.reserve(1, &USER, token, U256::from(700u64), balance)
+			.await
+			.unwrap();
+		let err = store
+			.reserve(1, &USER, token, U256::from(700u64), balance)
+			.await
+			.unwrap_err();
+		assert!(matches!(err, ReservationError::InsufficientCapacity { .. }));
+		// Reserved total must be unchanged after a rejected reservation.
+		assert_eq!(
+			store.reserved(1, &USER, token).await.unwrap(),
+			U256::from(700u64)
+		);
+	}
+
+	#[tokio::test]
+	async fn release_frees_capacity() {
+		let store = store_with_ttl(300);
+		let token = U256::from(7u64);
+		let balance = U256::from(1000u64);
+
+		store
+			.reserve(1, &USER, token, U256::from(800u64), balance)
+			.await
+			.unwrap();
+		store
+			.release(1, &USER, token, U256::from(800u64))
+			.await
+			.unwrap();
+		assert_eq!(store.reserved(1, &USER, token).await.unwrap(), U256::ZERO);
+		// Capacity is available again.
+		store
+			.reserve(1, &USER, token, U256::from(900u64), balance)
+			.await
+			.unwrap();
+	}
+
+	#[tokio::test]
+	async fn keys_are_isolated_by_chain_user_token() {
+		let store = store_with_ttl(300);
+		let balance = U256::from(1000u64);
+		let other_user = Address::new([0x22; 20]);
+
+		store
+			.reserve(1, &USER, U256::from(1u64), U256::from(900u64), balance)
+			.await
+			.unwrap();
+		// Different token id on same user: independent capacity.
+		store
+			.reserve(1, &USER, U256::from(2u64), U256::from(900u64), balance)
+			.await
+			.unwrap();
+		// Different chain: independent.
+		store
+			.reserve(2, &USER, U256::from(1u64), U256::from(900u64), balance)
+			.await
+			.unwrap();
+		// Different user: independent.
+		store
+			.reserve(
+				1,
+				&other_user,
+				U256::from(1u64),
+				U256::from(900u64),
+				balance,
+			)
+			.await
+			.unwrap();
+	}
+
+	/// RED-anchor test: two concurrent reservers for the same deposit where the
+	/// balance backs only one of them. Exactly one must succeed; the total
+	/// reserved must never exceed the balance. A stateless balance check (the
+	/// pre-fix behavior) would admit both.
+	#[tokio::test]
+	async fn concurrent_reserves_cannot_both_exceed_balance() {
+		let store = Arc::new(store_with_ttl(300));
+		let token = U256::from(42u64);
+		// Balance backs only a single 600 reservation; two would need 1200.
+		let balance = U256::from(1000u64);
+		let amount = U256::from(600u64);
+
+		let s1 = Arc::clone(&store);
+		let s2 = Arc::clone(&store);
+
+		let h1 = tokio::spawn(async move { s1.reserve(1, &USER, token, amount, balance).await });
+		let h2 = tokio::spawn(async move { s2.reserve(1, &USER, token, amount, balance).await });
+
+		let r1 = h1.await.unwrap();
+		let r2 = h2.await.unwrap();
+
+		let successes = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+		let failures = [&r1, &r2].iter().filter(|r| r.is_err()).count();
+		assert_eq!(
+			successes, 1,
+			"exactly one reservation must succeed: {r1:?} {r2:?}"
+		);
+		assert_eq!(failures, 1, "exactly one reservation must be rejected");
+
+		// The persisted reserved total must never exceed the balance.
+		let reserved = store.reserved(1, &USER, token).await.unwrap();
+		assert!(
+			reserved <= balance,
+			"reserved {reserved} exceeded balance {balance}"
+		);
+		assert_eq!(reserved, amount);
+	}
+
+	#[tokio::test]
+	async fn many_concurrent_reserves_respect_balance() {
+		let store = Arc::new(store_with_ttl(300));
+		let token = U256::from(99u64);
+		let balance = U256::from(1000u64);
+		let amount = U256::from(300u64); // only 3 of N can fit
+
+		let mut handles = Vec::new();
+		for _ in 0..10 {
+			let s = Arc::clone(&store);
+			handles.push(tokio::spawn(async move {
+				s.reserve(5, &USER, token, amount, balance).await
+			}));
+		}
+
+		let mut successes = 0usize;
+		for h in handles {
+			if h.await.unwrap().is_ok() {
+				successes += 1;
+			}
+		}
+		assert_eq!(
+			successes, 3,
+			"exactly floor(1000/300)=3 reservations should fit"
+		);
+
+		let reserved = store.reserved(5, &USER, token).await.unwrap();
+		assert!(
+			reserved <= balance,
+			"reserved {reserved} exceeded balance {balance}"
+		);
+		assert_eq!(reserved, U256::from(900u64));
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **C-03**: over-admission of `ResourceLock` (Compact) intents backed by the same on-chain deposit.

### Root cause
ResourceLock intake (`validate_compact_deposit_for_order`) only did a **stateless** `TheCompact.balanceOf(owner, id) >= amount` check with no reservation in storage and no atomic guard between the check and order persistence. The Compact path skips any origin prepare/open step, so destination fills are delivered before any origin claim. Because the OIF contract enforces single-claim idempotency, N concurrently-admitted orders backed by the same deposit all get filled on the destination chain but only **one** origin `finalise`/claim can succeed — the solver eats the cost of the unbacked fills.

### Fix
Add a solver-side **atomic reservation ledger** keyed by `(origin_chain_id, user, token_id)`:

- New `solver-storage::reservation_store::ReservationStore`, modeled on `nonce_store`, wrapping the shared `StorageService` so reservations live in the same backend (Redis in prod) and are visible across all solver workers.
- `reserve()` mutates a per-key reserved total atomically: the first reservation uses `set_nx`; subsequent reservations use a **compare-and-swap loop** that checks `reserved + amount <= balance` *inside* the CAS critical section. Two concurrent reserves can therefore never both succeed past the balance.
- Each reservation carries a TTL (safety net against a crashed solver stranding capacity).
- Exposed `StorageService::set_nx_bytes` to back the first-reservation path (thin passthrough to the existing `StorageInterface::set_nx` atomic primitive).
- Wired `reserve()` into `validate_compact_deposit_for_order`, replacing the bare `balanceOf` comparison. Insufficient capacity now returns `OrderValidationFailed`.

### RED → GREEN test result
- **RED** (`validators::order::test_resource_lock_concurrent_reserves_admit_only_one`): two concurrent ResourceLock orders for the same `(user, token_id)` where the balance backs only one. Pre-fix, the test failed because **both** were admitted (`r1=Ok(()) r2=Ok(())`, left=2 right=1). Post-fix exactly one is admitted.
- Ledger unit tests (`reservation_store`) prove concurrent reserves on the same key are serialized and the total reserved never exceeds balance (incl. a 10-way concurrent test asserting exactly `floor(balance/amount)` succeed).
- `cargo test -p solver-storage` → 226 passed; `cargo test -p solver-service` → 621 passed; `cargo clippy` clean on both; `cargo fmt --all --check` clean; `cargo check --all-targets --all-features` clean.

## Default decisions / assumptions (please confirm)
- **Reservation lives in the shared `StorageService` backend** (Redis), keyed `compact_reservation:{chain}:{user:#x}:{token_id}`, value = reserved total as 32-byte big-endian U256.
- **Release semantics — TTL only in this PR.** Per the finding's allowance ("if full lifecycle release is too broad for one PR, implement reserve + a TTL-based expiry and clearly document the release follow-up"), this PR ships **reserve + a 3600s TTL**. The `ReservationStore::release()` API is implemented and unit-tested but **not yet wired into the order lifecycle** (claimed/settled/failed terminal transitions). **Follow-up:** call `release()` from the order terminal-state handler (`solver-core/src/handlers/order.rs`) so capacity frees immediately rather than only on TTL expiry. Until then, capacity for a completed/failed order is held until the TTL lapses.
- **`lock.params` binding (secondary item in the finding) is NOT addressed here** — it is a separate concern from the concurrency ledger and deferred.
- **Per-input reservation:** each non-zero input is reserved independently; partial reservation across a multi-input order is not rolled back on a later-input failure within the same order (orders are validated before persistence; the TTL bounds any leak). Noted as a minor follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)