### PR TITLE
Pc02 allocator data validation (fix merge the pc04)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
       - msrv
       - rustfmt
       - clippy
+      - test
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/crates/solver-core/tests/tx_bump_storage_cas.rs
+++ b/crates/solver-core/tests/tx_bump_storage_cas.rs
@@ -128,6 +128,7 @@ async fn file_storage_cas_preserves_canonical_hash_under_concurrent_writes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires live Redis and can stall GitHub coverage; run explicitly with --ignored"]
 async fn redis_storage_cas_preserves_canonical_hash_under_concurrent_writes() {
 	let Some(redis_url) = redis_url_or_skip() else {
 		eprintln!("skipping Redis CAS test because REDIS_URL is not set");

--- a/crates/solver-discovery/src/implementations/offchain/_7683.rs
+++ b/crates/solver-discovery/src/implementations/offchain/_7683.rs
@@ -61,8 +61,12 @@ use solver_types::{
 	api::PostOrderRequest,
 	bytes32_to_address, create_http_provider, current_timestamp, normalize_bytes32_address,
 	standards::eip7683::{
+		compact_claims::compute_batch_compact_claim_hash,
 		compact_signatures::decode_compact_signatures,
-		interfaces::{IInputSettlerCompact, IInputSettlerEscrow, SolMandateOutput, StandardOrder},
+		interfaces::{
+			IAllocator, IInputSettlerCompact, IInputSettlerEscrow, ITheCompact, SolMandateOutput,
+			StandardOrder,
+		},
 		GasLimitOverrides, LockType, MandateOutput,
 	},
 	with_0x_prefix, ConfigSchema, Eip7683OrderData, Field, FieldType, ImplementationRegistry,
@@ -633,6 +637,128 @@ impl Eip7683OffchainDiscovery {
 		Ok(())
 	}
 }
+
+async fn validate_resource_lock_allocator_authorization(
+	order: &StandardOrder,
+	allocator_data: &Bytes,
+	providers: &HashMap<u64, DynProvider>,
+	networks: &NetworksConfig,
+) -> Result<(), DiscoveryError> {
+	let origin_chain_id = order.originChainId.to::<u64>();
+	let network = networks.get(&origin_chain_id).ok_or_else(|| {
+		DiscoveryError::ValidationError(format!(
+			"Chain ID {} not found in networks configuration",
+			order.originChainId
+		))
+	})?;
+	let provider = providers.get(&origin_chain_id).ok_or_else(|| {
+		DiscoveryError::ValidationError(format!(
+			"No RPC provider configured for chain ID {origin_chain_id}"
+		))
+	})?;
+
+	let the_compact_address = network
+		.the_compact_address
+		.as_ref()
+		.ok_or_else(|| {
+			DiscoveryError::ValidationError(format!(
+				"No TheCompact address found for chain ID {origin_chain_id}"
+			))
+		})
+		.and_then(|addr| {
+			if addr.0.len() == 20 {
+				Ok(AlloyAddress::from_slice(&addr.0))
+			} else {
+				Err(DiscoveryError::ValidationError(
+					"Invalid TheCompact address length".to_string(),
+				))
+			}
+		})?;
+	let arbiter = network
+		.input_settler_compact_address
+		.as_ref()
+		.ok_or_else(|| {
+			DiscoveryError::ValidationError(format!(
+				"No input settler compact address found for chain ID {origin_chain_id}"
+			))
+		})
+		.and_then(|addr| {
+			if addr.0.len() == 20 {
+				Ok(AlloyAddress::from_slice(&addr.0))
+			} else {
+				Err(DiscoveryError::ValidationError(
+					"Invalid input settler compact address length".to_string(),
+				))
+			}
+		})?;
+
+	if order.inputs.is_empty() {
+		return Err(DiscoveryError::ValidationError(
+			"ResourceLock order has no inputs to authorize against an allocator".to_string(),
+		));
+	}
+
+	let compact = ITheCompact::new(the_compact_address, provider);
+	let mut resolved_allocator: Option<AlloyAddress> = None;
+	for input in &order.inputs {
+		let details = compact.getLockDetails(input[0]).call().await.map_err(|e| {
+			DiscoveryError::Connection(format!("Failed to query TheCompact.getLockDetails: {e}"))
+		})?;
+		match resolved_allocator {
+			None => resolved_allocator = Some(details.allocator),
+			Some(existing) if existing != details.allocator => {
+				return Err(DiscoveryError::ValidationError(
+					"ResourceLock inputs resolve to multiple allocators".to_string(),
+				));
+			},
+			Some(_) => {},
+		}
+	}
+	let allocator = resolved_allocator.expect("inputs is non-empty");
+
+	if let Some(expected) = network.allocator_address.as_ref() {
+		if expected.0.len() != 20 {
+			return Err(DiscoveryError::ValidationError(
+				"Invalid configured allocator address length".to_string(),
+			));
+		}
+		let expected = AlloyAddress::from_slice(&expected.0);
+		if allocator != expected {
+			return Err(DiscoveryError::ValidationError(
+				"ResourceLock inputs use an allocator that differs from the configured allocator_address"
+					.to_string(),
+			));
+		}
+	}
+
+	let claim_hash = compute_batch_compact_claim_hash(order, arbiter).map_err(|e| {
+		DiscoveryError::ValidationError(format!("Failed to compute Compact claim hash: {e}"))
+	})?;
+	let allocator_contract = IAllocator::new(allocator, provider);
+	let authorized = allocator_contract
+		.isClaimAuthorized(
+			claim_hash,
+			arbiter,
+			order.user,
+			order.nonce,
+			U256::from(order.expires),
+			order.inputs.clone(),
+			allocator_data.clone(),
+		)
+		.call()
+		.await
+		.map_err(|e| {
+			DiscoveryError::Connection(format!("Allocator isClaimAuthorized call failed: {e}"))
+		})?;
+
+	if !authorized {
+		return Err(DiscoveryError::ValidationError(
+			"Allocator did not authorize the provided allocatorData".to_string(),
+		));
+	}
+
+	Ok(())
+}
 /// Handles intent submission requests.
 ///
 /// This is the main request handler for the POST /intent endpoint.
@@ -715,15 +841,38 @@ async fn handle_intent_submission(
 	let lock_type = LockType::from(&request.order);
 
 	if matches!(lock_type, LockType::ResourceLock) {
-		if let Err(e) = decode_compact_signatures(&signature) {
-			tracing::warn!(error = %e, "Failed to decode Compact signature payload");
+		let decoded = match decode_compact_signatures(&signature) {
+			Ok(decoded) => decoded,
+			Err(e) => {
+				tracing::warn!(error = %e, "Failed to decode Compact signature payload");
+				return (
+					StatusCode::BAD_REQUEST,
+					Json(IntentResponse {
+						order_id: None,
+						status: IntentResponseStatus::Rejected,
+						message: Some(e.to_string()),
+						order: order_json.clone(),
+					}),
+				)
+					.into_response();
+			},
+		};
+		if let Err(e) = validate_resource_lock_allocator_authorization(
+			&order,
+			&decoded.allocator_data,
+			&state.providers,
+			&state.networks,
+		)
+		.await
+		{
+			tracing::warn!(error = %e, "Failed to validate Compact allocator authorization");
 			return (
 				StatusCode::BAD_REQUEST,
 				Json(IntentResponse {
 					order_id: None,
 					status: IntentResponseStatus::Rejected,
 					message: Some(e.to_string()),
-					order: order_json,
+					order: order_json.clone(),
 				}),
 			)
 				.into_response();
@@ -979,6 +1128,7 @@ impl crate::DiscoveryRegistry for Registry {}
 mod tests {
 	use super::*;
 	use alloy_primitives::{Address as AlloyAddress, Bytes, U256};
+	use alloy_provider::{mock::Asserter, Provider, ProviderBuilder};
 	use axum::body;
 	use serde_json::json;
 	use solver_types::api::{OifOrder, OrderPayload, PostOrderRequest, SignatureType};
@@ -1052,7 +1202,19 @@ mod tests {
 		Bytes::from(shifted_payload)
 	}
 
-	fn resource_lock_request_with_shifted_signature() -> PostOrderRequest {
+	fn compact_signature(sponsor_sig: &[u8], allocator_data: &[u8]) -> Bytes {
+		let sponsor_tail = padded_bytes(sponsor_sig);
+		let allocator_offset = 64 + sponsor_tail.len();
+
+		let mut signature = Vec::new();
+		signature.extend_from_slice(&abi_word(64));
+		signature.extend_from_slice(&abi_word(allocator_offset));
+		signature.extend_from_slice(&sponsor_tail);
+		signature.extend_from_slice(&padded_bytes(allocator_data));
+		Bytes::from(signature)
+	}
+
+	fn resource_lock_request(signature: Bytes) -> PostOrderRequest {
 		let payload = OrderPayload {
 			signature_type: SignatureType::Eip712,
 			domain: json!({
@@ -1091,10 +1253,43 @@ mod tests {
 
 		PostOrderRequest {
 			order: OifOrder::OifResourceLockV0 { payload },
-			signature: shifted_compact_signature(&[0x11u8; 65]),
+			signature,
 			quote_id: None,
 			origin_submission: None,
 		}
+	}
+
+	fn resource_lock_request_with_shifted_signature() -> PostOrderRequest {
+		resource_lock_request(shifted_compact_signature(&[0x11u8; 65]))
+	}
+
+	fn resource_lock_request_with_allocator_data(
+		allocator_data: &'static [u8],
+	) -> PostOrderRequest {
+		resource_lock_request(compact_signature(&[0x11u8; 65], allocator_data))
+	}
+
+	fn encode_lock_details(allocator: AlloyAddress) -> Bytes {
+		let mut out = vec![0u8; 160];
+		out[44..64].copy_from_slice(allocator.as_slice());
+		Bytes::from(out)
+	}
+
+	fn encode_bool(value: bool) -> Bytes {
+		let mut out = vec![0u8; 32];
+		if value {
+			out[31] = 1;
+		}
+		Bytes::from(out)
+	}
+
+	fn mocked_provider_with_allocator_authorized(authorized: bool) -> DynProvider {
+		let asserter = Asserter::new();
+		asserter.push_success(&encode_lock_details(AlloyAddress::from([0xA1u8; 20])));
+		asserter.push_success(&encode_bool(authorized));
+		ProviderBuilder::new()
+			.connect_mocked_client(asserter)
+			.erased()
 	}
 
 	#[test]
@@ -1399,6 +1594,45 @@ mod tests {
 			.and_then(|v| v.as_str())
 			.unwrap_or_default()
 			.contains("Compact"));
+	}
+
+	#[tokio::test]
+	async fn test_handle_intent_submission_rejects_unauthorized_compact_allocator_data() {
+		use axum::extract::State;
+		use axum::Json;
+
+		let (tx, _rx) = mpsc::unbounded_channel();
+		let mut providers = HashMap::new();
+		providers.insert(1, mocked_provider_with_allocator_authorized(false));
+		let state = ApiState {
+			intent_sender: tx,
+			providers,
+			networks: create_test_networks_config(),
+		};
+
+		let response = handle_intent_submission(
+			State(state),
+			Json(resource_lock_request_with_allocator_data(
+				b"garbage allocator data",
+			)),
+		)
+		.await
+		.into_response();
+
+		assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+		let body_bytes = body::to_bytes(response.into_body(), usize::MAX)
+			.await
+			.expect("body");
+		let parsed: serde_json::Value = serde_json::from_slice(&body_bytes).expect("parse body");
+		assert_eq!(
+			parsed.get("status").and_then(|v| v.as_str()),
+			Some("rejected")
+		);
+		assert!(parsed
+			.get("message")
+			.and_then(|v| v.as_str())
+			.unwrap_or_default()
+			.contains("allocator"));
 	}
 
 	#[tokio::test]

--- a/crates/solver-e2e-tests/src/lib.rs
+++ b/crates/solver-e2e-tests/src/lib.rs
@@ -8,7 +8,7 @@
 //! Design choices are documented in `crates/solver-e2e-tests/README.md`.
 
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_primitives::{keccak256, Address, Bytes, FixedBytes, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_types::{BlockNumberOrTag, Filter, Log, TransactionReceipt, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
@@ -65,6 +65,13 @@ sol! {
 	#[sol(rpc)]
 	contract IMailboxMock {
 		function dispatchCounter() external view returns (uint256);
+	}
+
+	#[sol(rpc)]
+	contract ITheCompactE2e {
+		function DOMAIN_SEPARATOR() external view returns (bytes32);
+		function __registerAllocator(address allocator, bytes calldata proof) external;
+		function depositERC20(address token, bytes12 lockTag, uint256 amount, address recipient) external returns (uint256);
 	}
 }
 
@@ -198,6 +205,9 @@ pub struct ChainDeployment {
 	pub output_oracle: Address,
 	pub input_settler: Address,
 	pub output_settler: Address,
+	pub input_settler_compact: Option<Address>,
+	pub the_compact: Option<Address>,
+	pub allocator: Option<Address>,
 	/// `MockMailboxV2` address when `HarnessOptions::use_hyperlane_settlement`
 	/// is set. `None` for the default `Direct`-settlement layout.
 	/// Tests can read its `dispatchCounter` to assert the solver actually
@@ -247,6 +257,10 @@ pub struct HarnessOptions {
 	/// TOKA spending. Required for any test that submits Permit2-signed
 	/// orders through the off-chain HTTP API (`OifOrder::OifEscrowV0`).
 	pub enable_permit2: bool,
+	/// Deploy TheCompact, InputSettlerCompact, and SimpleAllocator on the origin
+	/// chain, register the allocator, and write those addresses into the solver
+	/// bootstrap config. Used by ResourceLock/Compact e2e scenarios.
+	pub enable_compact_simple_allocator: bool,
 	/// Addresses (`"0x..."` strings, any case) to write into a deny list
 	/// JSON file in the harness's tempdir. The harness sets
 	/// `SeedOverrides.deny_list` to that file's path so the solver loads it
@@ -367,6 +381,7 @@ impl Default for HarnessOptions {
 			admin_redis_url: None,
 			use_hyperlane_settlement: false,
 			enable_permit2: false,
+			enable_compact_simple_allocator: false,
 			deny_list_addresses: None,
 			run_solver: true,
 			tx_bump: None,
@@ -465,6 +480,16 @@ impl Harness {
 			install_permit2_at_canonical(&origin_provider)
 				.await
 				.context("install Permit2 (origin)")?;
+		}
+
+		if options.enable_compact_simple_allocator {
+			let (the_compact, input_settler_compact, allocator) =
+				deploy_compact_stack(&origin_provider, parse_address(SOLVER_ADDRESS)?)
+					.await
+					.context("deploy Compact stack (origin)")?;
+			origin.the_compact = Some(the_compact);
+			origin.input_settler_compact = Some(input_settler_compact);
+			origin.allocator = Some(allocator);
 		}
 
 		// Mint TOKA to user on origin (for the input leg) and TOKB to solver
@@ -674,6 +699,71 @@ impl Harness {
 				body.len()
 			)
 		})
+	}
+
+	pub fn compact_lock_tag(&self) -> Result<FixedBytes<12>> {
+		let allocator = self
+			.origin
+			.allocator
+			.ok_or_else(|| anyhow!("Compact allocator not deployed"))?;
+		let mut lock_tag = [0u8; 12];
+		lock_tag[1..].copy_from_slice(&allocator.as_slice()[9..]);
+		Ok(FixedBytes::from(lock_tag))
+	}
+
+	pub fn compact_token_id(&self) -> Result<U256> {
+		let lock_tag = self.compact_lock_tag()?;
+		let mut bytes = [0u8; 32];
+		bytes[..12].copy_from_slice(lock_tag.as_slice());
+		bytes[12..].copy_from_slice(self.origin.token_a.as_slice());
+		Ok(U256::from_be_bytes(bytes))
+	}
+
+	pub async fn compact_deposit_user_token_a(&self, amount: U256) -> Result<U256> {
+		let the_compact = self
+			.origin
+			.the_compact
+			.ok_or_else(|| anyhow!("TheCompact not deployed"))?;
+		let lock_tag = self.compact_lock_tag()?;
+		user_approve_max(
+			&self.origin.rpc_http,
+			&self.user_signer,
+			self.origin.token_a,
+			the_compact,
+		)
+		.await
+		.context("user approve(TheCompact, MAX) on TOKA")?;
+
+		let user_provider = build_provider(&self.origin.rpc_http, self.user_signer.clone()).await?;
+		let pending = ITheCompactE2e::new(the_compact, user_provider)
+			.depositERC20(self.origin.token_a, lock_tag, amount, self.user_address())
+			.send()
+			.await
+			.context("send TheCompact.depositERC20")?;
+		let receipt = pending
+			.get_receipt()
+			.await
+			.context("depositERC20 receipt")?;
+		if !receipt.status() {
+			return Err(anyhow!(
+				"depositERC20 reverted (tx {:?})",
+				receipt.transaction_hash
+			));
+		}
+
+		self.compact_token_id()
+	}
+
+	pub async fn compact_domain_separator(&self) -> Result<B256> {
+		let the_compact = self
+			.origin
+			.the_compact
+			.ok_or_else(|| anyhow!("TheCompact not deployed"))?;
+		ITheCompactE2e::new(the_compact, &self.origin_provider)
+			.DOMAIN_SEPARATOR()
+			.call()
+			.await
+			.context("TheCompact.DOMAIN_SEPARATOR")
 	}
 
 	/// Read the destination chain's `MockMailboxV2.dispatchCounter`. Returns
@@ -1481,6 +1571,59 @@ async fn deploy_no_args(provider: &DynProvider, name: &str) -> Result<Address> {
 	deploy_raw(provider, bytecode, Bytes::new()).await
 }
 
+async fn deploy_with_args(provider: &DynProvider, name: &str, ctor_args: Bytes) -> Result<Address> {
+	let bytecode = load_bytecode(name)?;
+	deploy_raw(provider, bytecode, ctor_args).await
+}
+
+async fn deploy_compact_stack(
+	provider: &DynProvider,
+	allocator_signer: Address,
+) -> Result<(Address, Address, Address)> {
+	let the_compact = deploy_no_args(provider, "TheCompact")
+		.await
+		.context("deploy TheCompact")?;
+	let input_settler_compact = deploy_with_args(
+		provider,
+		"InputSettlerCompact",
+		Bytes::from((the_compact,).abi_encode_params()),
+	)
+	.await
+	.context("deploy InputSettlerCompact")?;
+	let allocator = deploy_with_args(
+		provider,
+		"SimpleAllocator",
+		Bytes::from((allocator_signer, the_compact).abi_encode_params()),
+	)
+	.await
+	.context("deploy SimpleAllocator")?;
+
+	let pending = ITheCompactE2e::new(the_compact, provider)
+		.__registerAllocator(allocator, Bytes::new())
+		.send()
+		.await
+		.context("send TheCompact.__registerAllocator")?;
+	let receipt = pending
+		.get_receipt()
+		.await
+		.context("register allocator receipt")?;
+	if !receipt.status() {
+		return Err(anyhow!(
+			"register allocator reverted (tx {:?})",
+			receipt.transaction_hash
+		));
+	}
+
+	tracing::info!(
+		the_compact = %the_compact,
+		input_settler_compact = %input_settler_compact,
+		allocator = %allocator,
+		"Deployed Compact stack"
+	);
+
+	Ok((the_compact, input_settler_compact, allocator))
+}
+
 async fn deploy_chain(
 	provider: &DynProvider,
 	chain_id: u64,
@@ -1521,6 +1664,9 @@ async fn deploy_chain(
 		output_oracle: always_yes,
 		input_settler,
 		output_settler,
+		input_settler_compact: None,
+		the_compact: None,
+		allocator: None,
 		mock_mailbox: None,
 	})
 }
@@ -1667,9 +1813,9 @@ fn build_seed_overrides(
 			rpc_urls: Some(vec![d.rpc_http.clone()]),
 			input_settler_address: Some(d.input_settler),
 			output_settler_address: Some(d.output_settler),
-			input_settler_compact_address: None,
-			the_compact_address: None,
-			allocator_address: None,
+			input_settler_compact_address: d.input_settler_compact,
+			the_compact_address: d.the_compact,
+			allocator_address: d.allocator,
 		}
 	}
 

--- a/crates/solver-e2e-tests/tests/compact_allocator_e2e.rs
+++ b/crates/solver-e2e-tests/tests/compact_allocator_e2e.rs
@@ -1,0 +1,171 @@
+//! Compact allocator intake E2E.
+//!
+//! Run with:
+//!   cargo test -p solver-e2e-tests --test compact_allocator_e2e -- --ignored --test-threads=1 --nocapture
+
+use alloy_primitives::{keccak256, Bytes, B256, U256};
+use alloy_signer::SignerSync;
+use solver_e2e_tests::{
+	addr_to_bytes32, amount_with_decimals, unix_now_plus, Harness, HarnessOptions, MandateOutput,
+	OifOrder, OrderPayload, PostOrderRequest, SignatureType, StandardOrder, DEST_CHAIN_ID,
+	ORIGIN_CHAIN_ID, USER_PRIVATE_KEY,
+};
+use solver_types::standards::eip7683::compact_claims::compute_batch_compact_claim_hash;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires Anvil + oif-contracts/out with Compact artifacts; opt-in via --ignored"]
+async fn compact_order_with_unauthorized_allocator_data_is_rejected_at_intake() -> anyhow::Result<()>
+{
+	let h = Harness::boot_with(HarnessOptions {
+		enable_compact_simple_allocator: true,
+		..Default::default()
+	})
+	.await?;
+
+	let amount_in = amount_with_decimals(1_000);
+	let token_id = h.compact_deposit_user_token_a(amount_in).await?;
+	let amount_out = amount_with_decimals(990);
+
+	let order = StandardOrder {
+		user: h.user_address(),
+		nonce: U256::from(1u64),
+		originChainId: U256::from(ORIGIN_CHAIN_ID),
+		expires: unix_now_plus(60 * 60),
+		fillDeadline: unix_now_plus(30 * 60),
+		inputOracle: h.origin.input_oracle,
+		inputs: vec![[token_id, amount_in]],
+		outputs: vec![MandateOutput {
+			oracle: addr_to_bytes32(h.destination.output_oracle),
+			settler: addr_to_bytes32(h.destination.output_settler),
+			chainId: U256::from(DEST_CHAIN_ID),
+			token: addr_to_bytes32(h.destination.token_b),
+			amount: amount_out,
+			recipient: addr_to_bytes32(h.recipient_address()),
+			callbackData: Default::default(),
+			context: Default::default(),
+		}],
+	};
+
+	let compact_settler = h
+		.origin
+		.input_settler_compact
+		.ok_or_else(|| anyhow::anyhow!("Compact settler not deployed"))?;
+	let claim_hash = compute_batch_compact_claim_hash(&order, compact_settler)
+		.map_err(|e| anyhow::anyhow!("claim hash: {e}"))?;
+	let domain_separator = h.compact_domain_separator().await?;
+	let digest = keccak256(
+		[
+			&[0x19, 0x01][..],
+			domain_separator.as_slice(),
+			claim_hash.as_slice(),
+		]
+		.concat(),
+	);
+	let user_signer = USER_PRIVATE_KEY
+		.parse::<alloy_signer_local::PrivateKeySigner>()
+		.expect("static key parses");
+	let sponsor_signature = user_signer
+		.sign_hash_sync(&B256::from(digest))
+		.map_err(|e| anyhow::anyhow!("sign sponsor: {e}"))?;
+	let signature = compact_signature(&sponsor_signature.as_bytes(), b"garbage allocator data");
+
+	let request = PostOrderRequest {
+		order: OifOrder::OifResourceLockV0 {
+			payload: build_compact_payload(&h, &order)?,
+		},
+		signature,
+		quote_id: None,
+		origin_submission: None,
+	};
+
+	let client = reqwest::Client::builder()
+		.no_proxy()
+		.timeout(std::time::Duration::from_secs(15))
+		.build()?;
+	let response = client
+		.post(format!("{}/orders", h.api_base_url()))
+		.json(&request)
+		.send()
+		.await?;
+	assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+	let body: serde_json::Value = response.json().await?;
+	assert_eq!(
+		body.get("error").and_then(|v| v.as_str()),
+		Some("ORDER_VALIDATION_FAILED")
+	);
+	assert!(
+		body.get("message")
+			.and_then(|v| v.as_str())
+			.unwrap_or_default()
+			.contains("allocator"),
+		"response body should mention allocator rejection: {body}"
+	);
+
+	Ok(())
+}
+
+fn build_compact_payload(h: &Harness, order: &StandardOrder) -> anyhow::Result<OrderPayload> {
+	let lock_tag = h.compact_lock_tag()?;
+	Ok(OrderPayload {
+		signature_type: SignatureType::Eip712,
+		domain: serde_json::json!({
+			"name": "BatchCompact",
+			"version": "1",
+			"chainId": ORIGIN_CHAIN_ID.to_string(),
+			"verifyingContract": h.origin.the_compact.expect("TheCompact deployed").to_string(),
+		}),
+		primary_type: "BatchCompact".to_string(),
+		message: serde_json::json!({
+			"sponsor": order.user.to_string(),
+			"nonce": order.nonce.to_string(),
+			"expires": order.expires.to_string(),
+			"mandate": {
+				"fillDeadline": order.fillDeadline.to_string(),
+				"inputOracle": order.inputOracle.to_string(),
+				"outputs": [{
+					"oracle": format!("0x{}", hex::encode(order.outputs[0].oracle)),
+					"settler": format!("0x{}", hex::encode(order.outputs[0].settler)),
+					"chainId": order.outputs[0].chainId.to_string(),
+					"token": format!("0x{}", hex::encode(order.outputs[0].token)),
+					"amount": order.outputs[0].amount.to_string(),
+					"recipient": format!("0x{}", hex::encode(order.outputs[0].recipient)),
+					"callbackData": "0x",
+					"context": "0x"
+				}]
+			},
+			"commitments": [{
+				"lockTag": format!("0x{}", hex::encode(lock_tag)),
+				"token": h.origin.token_a.to_string(),
+				"amount": order.inputs[0][1].to_string()
+			}]
+		}),
+		types: None,
+	})
+}
+
+fn compact_signature(sponsor_sig: &[u8], allocator_data: &[u8]) -> Bytes {
+	let sponsor_tail = padded_bytes(sponsor_sig);
+	let allocator_offset = 64 + sponsor_tail.len();
+
+	let mut signature = Vec::new();
+	signature.extend_from_slice(&abi_word(64));
+	signature.extend_from_slice(&abi_word(allocator_offset));
+	signature.extend_from_slice(&sponsor_tail);
+	signature.extend_from_slice(&padded_bytes(allocator_data));
+	Bytes::from(signature)
+}
+
+fn padded_bytes(bytes: &[u8]) -> Vec<u8> {
+	let mut encoded = Vec::new();
+	encoded.extend_from_slice(&abi_word(bytes.len()));
+	encoded.extend_from_slice(bytes);
+	let padding = (32 - (bytes.len() % 32)) % 32;
+	encoded.extend(std::iter::repeat_n(0u8, padding));
+	encoded
+}
+
+fn abi_word(value: usize) -> [u8; 32] {
+	let mut word = [0u8; 32];
+	word[24..32].copy_from_slice(&(value as u64).to_be_bytes());
+	word
+}

--- a/crates/solver-service/src/eip712/compact/mod.rs
+++ b/crates/solver-service/src/eip712/compact/mod.rs
@@ -4,14 +4,12 @@
 //! specific logic for BatchCompact message hash computation and signature handling.
 
 use crate::eip712::{MessageHashComputer, SignatureValidator};
-use alloy_primitives::{keccak256, Address as AlloyAddress, Bytes, FixedBytes, Uint};
+use alloy_primitives::{Address as AlloyAddress, Bytes, FixedBytes};
 use alloy_sol_types::SolType;
 use solver_types::{
+	standards::eip7683::compact_claims::compute_batch_compact_claim_hash,
 	standards::eip7683::compact_signatures::decode_compact_signatures,
-	standards::eip7683::interfaces::{
-		SolMandateOutput as MandateOutput, StandardOrder as OifStandardOrder,
-	},
-	APIError, ApiErrorType,
+	standards::eip7683::interfaces::StandardOrder as OifStandardOrder, APIError, ApiErrorType,
 };
 
 /// TheCompact implementation of EIP-712 message hash computation
@@ -83,158 +81,7 @@ pub fn compute_batch_compact_hash(
 			details: None,
 		})?;
 
-	// Compute witness hash
-	let witness_hash = compute_witness_hash(&order)?;
-	let ids_and_amounts = order.inputs.to_vec();
-	let lock_hash = compute_lock_hash(&ids_and_amounts)?;
-
-	// Compute BatchCompact struct hash
-	compute_batch_compact_struct_hash(
-		contract_address,
-		order.user,
-		order.nonce,
-		Uint::<256, 4>::from(order.expires),
-		lock_hash,
-		witness_hash,
-	)
-}
-
-/// Compute witness hash for TheCompact mandate
-pub fn compute_witness_hash(order: &OifStandardOrder) -> Result<FixedBytes<32>, APIError> {
-	let mandate_type_hash = keccak256(
-		b"Mandate(uint32 fillDeadline,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
-	);
-
-	let outputs_hash = compute_outputs_hash(&order.outputs)?;
-
-	let mut data = Vec::new();
-	data.extend_from_slice(mandate_type_hash.as_slice());
-
-	// fillDeadline as uint32 with proper ABI padding
-	let mut fill_deadline_bytes = [0u8; 32];
-	fill_deadline_bytes[28..32].copy_from_slice(&order.fillDeadline.to_be_bytes());
-	data.extend_from_slice(&fill_deadline_bytes);
-
-	// inputOracle as address with proper ABI padding
-	let mut oracle_bytes = [0u8; 32];
-	oracle_bytes[12..32].copy_from_slice(order.inputOracle.as_slice());
-	data.extend_from_slice(&oracle_bytes);
-
-	data.extend_from_slice(outputs_hash.as_slice());
-
-	Ok(keccak256(data))
-}
-
-/// Compute hash of all mandate outputs
-pub fn compute_outputs_hash(outputs: &[MandateOutput]) -> Result<FixedBytes<32>, APIError> {
-	let mut hashes = Vec::new();
-
-	for output in outputs {
-		let output_hash = compute_single_output_hash(output)?;
-		hashes.extend_from_slice(output_hash.as_slice());
-	}
-
-	Ok(keccak256(hashes))
-}
-
-/// Compute hash of a single mandate output
-pub fn compute_single_output_hash(output: &MandateOutput) -> Result<FixedBytes<32>, APIError> {
-	let output_type_hash = keccak256(
-		b"MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
-	);
-
-	let mut data = Vec::new();
-	data.extend_from_slice(output_type_hash.as_slice());
-	data.extend_from_slice(output.oracle.as_slice());
-	data.extend_from_slice(output.settler.as_slice());
-	data.extend_from_slice(&output.chainId.to_be_bytes::<32>());
-	data.extend_from_slice(output.token.as_slice());
-	data.extend_from_slice(&output.amount.to_be_bytes::<32>());
-	data.extend_from_slice(output.recipient.as_slice());
-	data.extend_from_slice(keccak256(&output.callbackData).as_slice());
-	data.extend_from_slice(keccak256(&output.context).as_slice());
-
-	Ok(keccak256(data))
-}
-
-/// Compute hash of all locks in the compact
-pub fn compute_lock_hash(
-	ids_and_amounts: &[[Uint<256, 4>; 2]],
-) -> Result<FixedBytes<32>, APIError> {
-	let mut lock_hashes = Vec::new();
-
-	for id_amount in ids_and_amounts {
-		let token_id = id_amount[0];
-		let amount = id_amount[1];
-
-		let token_id_bytes = token_id.to_be_bytes::<32>();
-
-		// Extract lock tag (first 12 bytes)
-		let mut lock_tag_bytes = [0u8; 12];
-		lock_tag_bytes.copy_from_slice(&token_id_bytes[0..12]);
-		let lock_tag = FixedBytes::from(lock_tag_bytes);
-
-		// Extract token address (last 20 bytes)
-		let mut token_address_bytes = [0u8; 20];
-		token_address_bytes.copy_from_slice(&token_id_bytes[12..32]);
-		let token_address = AlloyAddress::from(token_address_bytes);
-
-		let lock_type_hash = keccak256(b"Lock(bytes12 lockTag,address token,uint256 amount)");
-
-		let mut lock_data = Vec::new();
-		lock_data.extend_from_slice(lock_type_hash.as_slice());
-
-		// lock_tag as bytes12 with proper ABI padding
-		let mut lock_tag_bytes = [0u8; 32];
-		lock_tag_bytes[0..12].copy_from_slice(lock_tag.as_slice());
-		lock_data.extend_from_slice(&lock_tag_bytes);
-
-		// token_address as address with proper ABI padding
-		let mut token_address_bytes = [0u8; 32];
-		token_address_bytes[12..32].copy_from_slice(token_address.as_slice());
-		lock_data.extend_from_slice(&token_address_bytes);
-
-		lock_data.extend_from_slice(&amount.to_be_bytes::<32>());
-
-		let lock_hash = keccak256(lock_data);
-		lock_hashes.extend_from_slice(lock_hash.as_slice());
-	}
-
-	Ok(keccak256(lock_hashes))
-}
-
-/// Compute the final BatchCompact struct hash
-pub fn compute_batch_compact_struct_hash(
-	contract_address: AlloyAddress,
-	sponsor: AlloyAddress,
-	nonce: Uint<256, 4>,
-	expires: Uint<256, 4>,
-	lock_hash: FixedBytes<32>,
-	witness: FixedBytes<32>,
-) -> Result<FixedBytes<32>, APIError> {
-	let batch_compact_type_hash = keccak256(
-		b"BatchCompact(address arbiter,address sponsor,uint256 nonce,uint256 expires,Lock[] commitments,Mandate mandate)Lock(bytes12 lockTag,address token,uint256 amount)Mandate(uint32 fillDeadline,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
-	);
-
-	let mut struct_data = Vec::new();
-	struct_data.extend_from_slice(batch_compact_type_hash.as_slice());
-
-	// contract_address as arbiter
-	let mut arbiter_bytes = [0u8; 32];
-	arbiter_bytes[12..32].copy_from_slice(contract_address.as_slice());
-	struct_data.extend_from_slice(&arbiter_bytes);
-
-	// sponsor
-	let mut sponsor_bytes = [0u8; 32];
-	sponsor_bytes[12..32].copy_from_slice(sponsor.as_slice());
-	struct_data.extend_from_slice(&sponsor_bytes);
-
-	struct_data.extend_from_slice(&nonce.to_be_bytes::<32>());
-	struct_data.extend_from_slice(&expires.to_be_bytes::<32>());
-	struct_data.extend_from_slice(lock_hash.as_slice());
-	struct_data.extend_from_slice(witness.as_slice());
-
-	Ok(keccak256(struct_data))
+	compute_batch_compact_claim_hash(&order, contract_address)
 }
 
 #[cfg(test)]
@@ -242,6 +89,7 @@ mod tests {
 	use super::*;
 	use alloy_primitives::Bytes;
 	use solver_types::standards::eip7683::compact_signatures::decode_compact_signatures;
+	use solver_types::standards::eip7683::interfaces::SolMandateOutput as MandateOutput;
 
 	fn abi_word(value: usize) -> [u8; 32] {
 		let mut word = [0u8; 32];
@@ -324,43 +172,63 @@ mod tests {
 		assert!(decode_compact_signatures(&short_sig).is_err());
 	}
 
+	/// pC-02 Task 0 parity gate: the solver's BatchCompact struct hash must match
+	/// the official `openintentsframework/oif-contracts` release-v1.0.0 claim hash
+	/// (the value an allocator's `isClaimAuthorized` receives, pre domain-separator).
+	///
+	/// The expected value is a known-answer vector generated from the official
+	/// release-v1.0.0 test harness formula (`InputSettlerCompact.base.t.sol`,
+	/// the-compact submodule `b9c3b54…`) for the order constructed below.
+	/// If this fails, the solver hash semantics no longer match the deployment
+	/// target and pC-02's allocator check would false-reject every order.
 	#[test]
-	fn test_compute_lock_hash() {
-		use alloy_primitives::Uint;
+	fn compute_batch_compact_hash_matches_official_release_v1_0_0_vector() {
+		use alloy_primitives::U256;
 
-		// Test case: Single lock with known values
-		let token_id = Uint::<256, 4>::from(0x123456789abcdef0u64); // 12 bytes lock tag + 20 bytes token address
-		let amount = Uint::<256, 4>::from(1000u64);
-		let ids_and_amounts = vec![[token_id, amount]];
+		// token_id = lockTag(12 bytes) || token(20 bytes)
+		let id_fb: FixedBytes<32> =
+			"0x0102030405060708090a0b0c4444444444444444444444444444444444444444"
+				.parse()
+				.unwrap();
+		let id = U256::from_be_bytes(id_fb.0);
 
-		let result = compute_lock_hash(&ids_and_amounts);
-		assert!(result.is_ok());
+		// bytes32(uint256(v)) — left-padded
+		let b32 = |v: u64| FixedBytes::<32>::from(U256::from(v).to_be_bytes::<32>());
 
-		let lock_hash = result.unwrap();
-		// Verify it's a valid 32-byte hash
-		assert_eq!(lock_hash.len(), 32);
+		let output = MandateOutput {
+			oracle: b32(0xAAAA),
+			settler: b32(0xBBBB),
+			chainId: U256::from(10u64),
+			token: b32(0xCCCC),
+			amount: U256::from(555u64),
+			recipient: b32(0xDDDD),
+			callbackData: Bytes::new(),
+			context: Bytes::new(),
+		};
 
-		// Test case: Multiple locks
-		let token_id_2 = Uint::<256, 4>::from(0xfedcba9876543210u64);
-		let amount_2 = Uint::<256, 4>::from(2000u64);
-		let multiple_locks = vec![[token_id, amount], [token_id_2, amount_2]];
+		let order = OifStandardOrder {
+			user: AlloyAddress::from([0x22u8; 20]),
+			nonce: U256::from(1u64),
+			originChainId: U256::from(31337u64),
+			expires: 2_000_000_000u32,
+			fillDeadline: 1_700_000_000u32,
+			inputOracle: AlloyAddress::from([0x33u8; 20]),
+			inputs: vec![[id, U256::from(123456789u64)]],
+			outputs: vec![output],
+		};
 
-		let result_multiple = compute_lock_hash(&multiple_locks);
-		assert!(result_multiple.is_ok());
+		let order_bytes = Bytes::from(OifStandardOrder::abi_encode(&order));
+		let arbiter = AlloyAddress::from([0x11u8; 20]);
 
-		let multiple_lock_hash = result_multiple.unwrap();
-		assert_eq!(multiple_lock_hash.len(), 32);
+		let got = compute_batch_compact_hash(&order_bytes, arbiter).expect("hash");
+		let expected: FixedBytes<32> =
+			"0x2142968938e7f2f2a043a1c4a6873e981c18871d77168a7818edf6d2fef10efd"
+				.parse()
+				.unwrap();
 
-		// Different inputs should produce different hashes
-		assert_ne!(lock_hash, multiple_lock_hash);
-
-		// Test case: Empty locks array
-		let empty_locks: Vec<[Uint<256, 4>; 2]> = vec![];
-		let result_empty = compute_lock_hash(&empty_locks);
-		assert!(result_empty.is_ok());
-
-		let empty_hash = result_empty.unwrap();
-		assert_eq!(empty_hash.len(), 32);
-		assert_ne!(empty_hash, lock_hash);
+		assert_eq!(
+			got, expected,
+			"solver BatchCompact hash must match official release-v1.0.0 claim hash"
+		);
 	}
 }

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -965,7 +965,7 @@ mod tests {
 	use super::*;
 	use crate::eip712::MessageHashComputer;
 	use alloy_primitives::{hex, keccak256, Address as AlloyAddress, Bytes, FixedBytes, U256};
-	use alloy_sol_types::SolType;
+	use alloy_sol_types::{SolCall, SolType};
 	use axum::body;
 	use axum::http::StatusCode;
 	use reqwest::Client;
@@ -988,7 +988,7 @@ mod tests {
 		SignatureType,
 	};
 	use solver_types::standards::eip7683::interfaces::{
-		SolMandateOutput, StandardOrder as OifStandardOrder,
+		IAllocator, ITheCompact, SolMandateOutput, StandardOrder as OifStandardOrder,
 	};
 	use solver_types::{APIError, Address, ApiErrorType, ErrorResponse};
 	use std::collections::HashMap;
@@ -998,6 +998,12 @@ mod tests {
 	use wiremock::{Mock, MockServer, ResponseTemplate};
 
 	async fn build_test_solver_engine() -> Arc<SolverEngine> {
+		build_test_solver_engine_with_allocator_authorized(true).await
+	}
+
+	async fn build_test_solver_engine_with_allocator_authorized(
+		allocator_authorized: bool,
+	) -> Arc<SolverEngine> {
 		let config: Config = serde_json::from_value(json!({
 			"solver": {
 				"id": "test-solver",
@@ -1073,8 +1079,18 @@ mod tests {
 		let solver_address = Address(vec![0x11; 20]);
 
 		let mut mock_delivery = MockDeliveryInterface::new();
-		mock_delivery.expect_eth_call().returning(|_| {
-			Box::pin(async move { Ok(Bytes::from(FixedBytes::from([0x99u8; 32]).to_vec())) })
+		mock_delivery.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let response = match selector {
+				Some(s) if s == ITheCompact::getLockDetailsCall::SELECTOR => {
+					encode_lock_details(AlloyAddress::from([0xA1u8; 20]))
+				},
+				Some(s) if s == IAllocator::isClaimAuthorizedCall::SELECTOR => {
+					encode_bool(allocator_authorized)
+				},
+				_ => Bytes::from(FixedBytes::from([0x99u8; 32]).to_vec()),
+			};
+			Box::pin(async move { Ok(response) })
 		});
 		let mut delivery_implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
 		delivery_implementations.insert(1, Arc::new(mock_delivery) as Arc<dyn DeliveryInterface>);
@@ -1121,8 +1137,37 @@ mod tests {
 		Arc::new(engine)
 	}
 
+	fn encode_lock_details(allocator: AlloyAddress) -> Bytes {
+		let mut out = vec![0u8; 160];
+		out[44..64].copy_from_slice(allocator.as_slice());
+		Bytes::from(out)
+	}
+
+	fn encode_bool(value: bool) -> Bytes {
+		let mut out = vec![0u8; 32];
+		if value {
+			out[31] = 1;
+		}
+		Bytes::from(out)
+	}
+
 	async fn build_test_app_state(discovery_url: Option<String>) -> AppState {
 		let solver = build_test_solver_engine().await;
+		build_test_app_state_with_solver(discovery_url, solver).await
+	}
+
+	async fn build_test_app_state_with_allocator_authorized(
+		discovery_url: Option<String>,
+		allocator_authorized: bool,
+	) -> AppState {
+		let solver = build_test_solver_engine_with_allocator_authorized(allocator_authorized).await;
+		build_test_app_state_with_solver(discovery_url, solver).await
+	}
+
+	async fn build_test_app_state_with_solver(
+		discovery_url: Option<String>,
+		solver: Arc<SolverEngine>,
+	) -> AppState {
 		let config = solver.config().clone();
 		let dynamic_config = Arc::new(RwLock::new(config));
 
@@ -1244,7 +1289,9 @@ mod tests {
 		Bytes::from(shifted_payload)
 	}
 
-	fn sample_resource_lock_request_with_shifted_signature() -> PostOrderRequest {
+	fn sample_resource_lock_request(
+		signature_from_sponsor: impl FnOnce(&[u8]) -> Bytes,
+	) -> PostOrderRequest {
 		let chain_id = 1u64;
 		let nonce = 1u64;
 		let expires = 1_700_000_000u32;
@@ -1321,7 +1368,7 @@ mod tests {
 		let mut sponsor_sig = sig_bytes.to_vec();
 		let rec_id: i32 = recovery_id.into();
 		sponsor_sig.push((rec_id as u8) + 27);
-		let shifted_signature = shifted_compact_signature(&sponsor_sig);
+		let signature = signature_from_sponsor(&sponsor_sig);
 
 		let lock_tag_hex = format!("0x{}", hex::encode(lock_tag));
 		let token_hex = format!("0x{}", hex::encode(token_address_bytes));
@@ -1371,10 +1418,20 @@ mod tests {
 
 		PostOrderRequest {
 			order: OifOrder::OifResourceLockV0 { payload },
-			signature: shifted_signature,
+			signature,
 			quote_id: None,
 			origin_submission: None,
 		}
+	}
+
+	fn sample_resource_lock_request_with_shifted_signature() -> PostOrderRequest {
+		sample_resource_lock_request(shifted_compact_signature)
+	}
+
+	fn sample_resource_lock_request_with_allocator_data(
+		allocator_data: &'static [u8],
+	) -> PostOrderRequest {
+		sample_resource_lock_request(|sponsor_sig| compact_signature(sponsor_sig, allocator_data))
 	}
 
 	fn sample_permit2_request_with_witness_user(
@@ -1649,6 +1706,35 @@ mod tests {
 		let parsed: ErrorResponse = serde_json::from_slice(&body_bytes).expect("parse body");
 		assert_eq!(parsed.error, "ORDER_VALIDATION_FAILED");
 		assert!(parsed.message.contains("Compact"));
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn handle_order_rejects_unauthorized_compact_allocator_data_before_forwarding() {
+		let mock_server = MockServer::start().await;
+		Mock::given(method("POST"))
+			.and(path("/intent"))
+			.respond_with(ResponseTemplate::new(200))
+			.expect(0)
+			.mount(&mock_server)
+			.await;
+
+		let discovery_url = format!("{}/intent", mock_server.uri());
+		let state =
+			build_test_app_state_with_allocator_authorized(Some(discovery_url), false).await;
+		let payload = to_value(sample_resource_lock_request_with_allocator_data(
+			b"garbage allocator data",
+		))
+		.expect("serialize request");
+
+		let response = super::handle_order(State(state), None, Json(payload)).await;
+
+		assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+		let body_bytes = body::to_bytes(response.into_body(), usize::MAX)
+			.await
+			.expect("body");
+		let parsed: ErrorResponse = serde_json::from_slice(&body_bytes).expect("parse body");
+		assert_eq!(parsed.error, "ORDER_VALIDATION_FAILED");
+		assert!(parsed.message.contains("allocator"));
 	}
 
 	#[tokio::test(flavor = "multi_thread")]

--- a/crates/solver-service/src/validators/compact_allocator.rs
+++ b/crates/solver-service/src/validators/compact_allocator.rs
@@ -1,0 +1,368 @@
+//! Allocator authorization validation for TheCompact ResourceLock orders (pC-02).
+//!
+//! For a ResourceLock order, `intent.signature` is
+//! `abi.encode(bytes sponsorSig, bytes allocatorData)`. Sponsor-signature
+//! validation only covers `sponsorSig`; the `allocatorData` half is forwarded
+//! unchanged to `IInputSettlerCompact::finalise`, where TheCompact passes it to
+//! the allocator's `authorizeClaim`. An enforcing allocator rejects unauthorized
+//! `allocatorData`, so without this check the solver could fill destination
+//! outputs and then have its claim revert (stranded funds).
+//!
+//! This module validates `allocatorData` at intake — before any fill — using the
+//! allocator's own `isClaimAuthorized` view (the off-chain counterpart of the
+//! on-chain `authorizeClaim`), against the exact claim hash `finalise` will use.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address as AlloyAddress, Bytes, FixedBytes, U256};
+use alloy_sol_types::SolCall;
+use solver_delivery::DeliveryService;
+use solver_types::{
+	standards::eip7683::interfaces::{IAllocator, ITheCompact, StandardOrder as OifStandardOrder},
+	APIError, Address, ApiErrorType, Transaction,
+};
+
+fn validation_error(message: impl Into<String>) -> APIError {
+	APIError::BadRequest {
+		error_type: ApiErrorType::OrderValidationFailed,
+		message: message.into(),
+		details: None,
+	}
+}
+
+/// Build a `view`-style transaction for an `eth_call`.
+fn view_tx(to: &Address, chain_id: u64, data: Vec<u8>) -> Transaction {
+	Transaction {
+		to: Some(to.clone()),
+		data,
+		value: U256::ZERO,
+		chain_id,
+		nonce: None,
+		gas_limit: None,
+		gas_price: None,
+		max_fee_per_gas: None,
+		max_priority_fee_per_gas: None,
+	}
+}
+
+/// Resolve the allocator address controlling a Compact resource-lock `id` via
+/// `TheCompact.getLockDetails(id)`.
+async fn resolve_allocator(
+	delivery: &Arc<DeliveryService>,
+	the_compact_address: &Address,
+	chain_id: u64,
+	id: U256,
+) -> Result<AlloyAddress, APIError> {
+	let call = ITheCompact::getLockDetailsCall { id };
+	let tx = view_tx(the_compact_address, chain_id, call.abi_encode());
+
+	let result = delivery
+		.contract_call(chain_id, tx)
+		.await
+		.map_err(|e| validation_error(format!("Failed to query TheCompact.getLockDetails: {e}")))?;
+
+	let decoded = ITheCompact::getLockDetailsCall::abi_decode_returns_validate(&result)
+		.map_err(|e| validation_error(format!("Failed to decode getLockDetails: {e}")))?;
+
+	Ok(decoded.allocator)
+}
+
+/// Validate that `allocator_data` is authorized by the allocator that controls
+/// the order inputs, before destination fills are allowed.
+///
+/// - `claim_hash` is the BatchCompact struct hash (the value the allocator's
+///   `isClaimAuthorized` / on-chain `authorizeClaim` receives). The caller has
+///   already computed this; it must use `arbiter` as the BatchCompact arbiter.
+/// - `arbiter` is the `InputSettlerCompact` address (the account that calls
+///   `TheCompact.batchClaim` during finalisation).
+/// - `configured_allocator`, when present (`network.allocator_address`), pins the
+///   allocator the solver expects; a mismatch is rejected.
+#[allow(clippy::too_many_arguments)]
+pub async fn validate_allocator_authorization(
+	order: &OifStandardOrder,
+	allocator_data: &Bytes,
+	claim_hash: FixedBytes<32>,
+	arbiter: AlloyAddress,
+	the_compact_address: &Address,
+	configured_allocator: Option<&Address>,
+	delivery: &Arc<DeliveryService>,
+	chain_id: u64,
+) -> Result<(), APIError> {
+	if order.inputs.is_empty() {
+		return Err(validation_error(
+			"ResourceLock order has no inputs to authorize against an allocator",
+		));
+	}
+
+	// Resolve the allocator for every input and require a single, consistent one.
+	// A mixed-allocator batch cannot be authorized by one `authorizeClaim` call.
+	let mut resolved: Option<AlloyAddress> = None;
+	for input in &order.inputs {
+		let allocator =
+			resolve_allocator(delivery, the_compact_address, chain_id, input[0]).await?;
+		match resolved {
+			None => resolved = Some(allocator),
+			Some(existing) if existing != allocator => {
+				return Err(validation_error(
+					"ResourceLock inputs resolve to multiple allocators",
+				));
+			},
+			Some(_) => {},
+		}
+	}
+	let allocator = resolved.expect("inputs is non-empty");
+
+	// If the solver pins an allocator, the resolved one must match it.
+	if let Some(expected) = configured_allocator {
+		let expected = AlloyAddress::from_slice(&expected.0);
+		if expected != allocator {
+			return Err(validation_error(
+				"ResourceLock inputs use an allocator that differs from the configured allocator_address",
+			));
+		}
+	}
+
+	// Ask the allocator whether this claim (with its allocatorData) is authorized.
+	let call = IAllocator::isClaimAuthorizedCall {
+		claimHash: claim_hash,
+		arbiter,
+		sponsor: order.user,
+		nonce: order.nonce,
+		expires: U256::from(order.expires),
+		idsAndAmounts: order.inputs.clone(),
+		allocatorData: allocator_data.clone(),
+	};
+	let allocator_addr = Address(allocator.as_slice().to_vec());
+	let tx = view_tx(&allocator_addr, chain_id, call.abi_encode());
+
+	let result = delivery
+		.contract_call(chain_id, tx)
+		.await
+		.map_err(|e| validation_error(format!("Allocator isClaimAuthorized call failed: {e}")))?;
+
+	let authorized = IAllocator::isClaimAuthorizedCall::abi_decode_returns_validate(&result)
+		.map_err(|e| {
+			validation_error(format!("Failed to decode isClaimAuthorized response: {e}"))
+		})?;
+
+	if !authorized {
+		return Err(validation_error(
+			"Allocator did not authorize the provided allocatorData",
+		));
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use alloy_sol_types::SolCall;
+	use solver_delivery::{DeliveryInterface, MockDeliveryInterface};
+	use std::collections::HashMap;
+
+	const CHAIN: u64 = 1;
+
+	fn allocator(byte: u8) -> AlloyAddress {
+		AlloyAddress::from([byte; 20])
+	}
+
+	fn the_compact() -> Address {
+		Address(vec![0x88u8; 20])
+	}
+
+	fn arbiter() -> AlloyAddress {
+		AlloyAddress::from([0x99u8; 20])
+	}
+
+	fn claim_hash() -> FixedBytes<32> {
+		FixedBytes::from([0x12u8; 32])
+	}
+
+	/// token_id = lockTag(12) || token(20), distinct per `byte`.
+	fn id_from(byte: u8) -> U256 {
+		let mut b = [0u8; 32];
+		b[0] = byte;
+		b[31] = byte;
+		U256::from_be_bytes(b)
+	}
+
+	fn encode_lock_details(allocator: AlloyAddress) -> Bytes {
+		let mut out = vec![0u8; 160];
+		out[44..64].copy_from_slice(allocator.as_slice());
+		Bytes::from(out)
+	}
+
+	fn encode_bool(value: bool) -> Bytes {
+		let mut out = vec![0u8; 32];
+		if value {
+			out[31] = 1;
+		}
+		Bytes::from(out)
+	}
+
+	fn order_with_inputs(ids: &[U256]) -> OifStandardOrder {
+		OifStandardOrder {
+			user: AlloyAddress::from([0x22u8; 20]),
+			nonce: U256::from(1u64),
+			originChainId: U256::from(CHAIN),
+			expires: 2_000_000_000u32,
+			fillDeadline: 1_700_000_000u32,
+			inputOracle: AlloyAddress::from([0x33u8; 20]),
+			inputs: ids.iter().map(|id| [*id, U256::from(1000u64)]).collect(),
+			outputs: vec![],
+		}
+	}
+
+	/// Delivery mock: `getLockDetails(id)` resolves via `lock_allocator_for(id)`;
+	/// `isClaimAuthorized` returns `authorized`.
+	fn delivery(
+		lock_allocator_for: impl Fn(U256) -> AlloyAddress + Send + Sync + 'static,
+		authorized: bool,
+	) -> Arc<DeliveryService> {
+		let mut mock = MockDeliveryInterface::new();
+		mock.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let resp = match selector {
+				Some(s) if s == ITheCompact::getLockDetailsCall::SELECTOR => {
+					let mut id_bytes = [0u8; 32];
+					id_bytes.copy_from_slice(&tx.data[4..36]);
+					encode_lock_details(lock_allocator_for(U256::from_be_bytes(id_bytes)))
+				},
+				Some(s) if s == IAllocator::isClaimAuthorizedCall::SELECTOR => {
+					encode_bool(authorized)
+				},
+				_ => Bytes::from(vec![0u8; 32]),
+			};
+			Box::pin(async move { Ok(resp) })
+		});
+		let mut impls: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		impls.insert(CHAIN, Arc::new(mock) as Arc<dyn DeliveryInterface>);
+		Arc::new(DeliveryService::new(impls, 1, 30, 60))
+	}
+
+	#[tokio::test]
+	async fn authorized_allocator_data_passes() {
+		let order = order_with_inputs(&[id_from(1)]);
+		let d = delivery(|_| allocator(0xA1), true);
+		validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			None,
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect("authorized empty allocator data should pass");
+	}
+
+	#[tokio::test]
+	async fn unauthorized_allocator_data_rejected() {
+		let order = order_with_inputs(&[id_from(1)]);
+		let d = delivery(|_| allocator(0xA1), false);
+		let err = validate_allocator_authorization(
+			&order,
+			&Bytes::from_static(b"garbage allocator data"),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			None,
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect_err("unauthorized allocator data must be rejected");
+		assert!(
+			matches!(err, APIError::BadRequest { message, .. } if message.contains("allocator"))
+		);
+	}
+
+	#[tokio::test]
+	async fn mixed_allocators_rejected() {
+		let id1 = id_from(1);
+		let id2 = id_from(2);
+		let order = order_with_inputs(&[id1, id2]);
+		let (a1, a2) = (allocator(0xA1), allocator(0xB2));
+		let d = delivery(move |id| if id == id1 { a1 } else { a2 }, true);
+		let err = validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			None,
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect_err("mixed allocators must be rejected");
+		assert!(
+			matches!(err, APIError::BadRequest { message, .. } if message.contains("multiple allocators"))
+		);
+	}
+
+	#[tokio::test]
+	async fn configured_allocator_mismatch_rejected() {
+		let order = order_with_inputs(&[id_from(1)]);
+		let d = delivery(|_| allocator(0xA1), true);
+		let configured = Address(vec![0xB2u8; 20]);
+		let err = validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			Some(&configured),
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect_err("allocator not matching configured allocator must be rejected");
+		assert!(
+			matches!(err, APIError::BadRequest { message, .. } if message.contains("configured allocator"))
+		);
+	}
+
+	#[tokio::test]
+	async fn configured_allocator_match_passes() {
+		let order = order_with_inputs(&[id_from(1)]);
+		let d = delivery(|_| allocator(0xA1), true);
+		let configured = Address(vec![0xA1u8; 20]);
+		validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			Some(&configured),
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect("resolved allocator matching configured one should pass");
+	}
+
+	#[tokio::test]
+	async fn no_inputs_rejected() {
+		let order = order_with_inputs(&[]);
+		let d = delivery(|_| allocator(0xA1), true);
+		let err = validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			None,
+			&d,
+			CHAIN,
+		)
+		.await
+		.expect_err("order with no inputs must be rejected");
+		assert!(
+			matches!(err, APIError::BadRequest { message, .. } if message.contains("no inputs"))
+		);
+	}
+}

--- a/crates/solver-service/src/validators/mod.rs
+++ b/crates/solver-service/src/validators/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains the validators for the OIF solver service.
 
+pub mod compact_allocator;
 pub mod intake;
 pub mod order;
 pub mod signature;

--- a/crates/solver-service/src/validators/signature.rs
+++ b/crates/solver-service/src/validators/signature.rs
@@ -11,7 +11,10 @@ use async_trait::async_trait;
 use solver_delivery::DeliveryService;
 use solver_types::{
 	api::PostOrderRequest,
-	standards::eip7683::{interfaces::StandardOrder as OifStandardOrder, LockType},
+	standards::eip7683::{
+		compact_signatures::decode_compact_signatures,
+		interfaces::StandardOrder as OifStandardOrder, LockType,
+	},
 	APIError, ApiErrorType, NetworksConfig,
 };
 use std::collections::HashMap;
@@ -83,13 +86,15 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 				})?;
 
 		// Get contract address for signature validation
-		let contract_address = {
-			let addr = network
-				.input_settler_compact_address
-				.clone()
-				.unwrap_or_else(|| network.input_settler_address.clone());
-			AlloyAddress::from_slice(&addr.0)
-		};
+		let contract_address = network
+			.input_settler_compact_address
+			.as_ref()
+			.map(|addr| AlloyAddress::from_slice(&addr.0))
+			.ok_or_else(|| APIError::BadRequest {
+				error_type: ApiErrorType::OrderValidationFailed,
+				message: "InputSettlerCompact contract not configured".to_string(),
+				details: None,
+			})?;
 
 		// Create compact-specific implementations using factory functions
 		let message_hasher = compact::create_message_hasher();
@@ -102,16 +107,17 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 		// 2. Compute message hash using interface
 		let struct_hash = message_hasher.compute_message_hash(&order_bytes, contract_address)?;
 
-		// 3. Extract signature using interface
-		let signature = signature_validator.extract_signature(&intent.signature)?;
+		// 3. Decode the canonical Compact signature tuple (sponsor + allocator).
+		//    Non-canonical encodings are rejected here (pC-04).
+		let decoded = decode_compact_signatures(&intent.signature)?;
 
-		// 4. Validate EIP-712 signature using interface
+		// 4. Validate the sponsor EIP-712 signature using interface.
 		let expected_signer = standard_order.user;
 
 		let is_valid = signature_validator.validate_signature(
 			domain_separator,
 			struct_hash,
-			&signature,
+			&decoded.sponsor,
 			expected_signer,
 		)?;
 
@@ -123,6 +129,23 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 			});
 		}
 		tracing::debug!("EIP-712 signature validated");
+
+		// 5. Validate allocator authorization for the decoded allocatorData (pC-02).
+		//    `struct_hash` is the BatchCompact claim hash the allocator authorizes;
+		//    `contract_address` is the InputSettlerCompact (the finalise arbiter).
+		crate::validators::compact_allocator::validate_allocator_authorization(
+			&standard_order,
+			&decoded.allocator_data,
+			struct_hash,
+			contract_address,
+			the_compact_address,
+			network.allocator_address.as_ref(),
+			delivery_service,
+			origin_chain_id,
+		)
+		.await?;
+		tracing::debug!("Compact allocator authorization validated");
+
 		Ok(())
 	}
 }
@@ -215,6 +238,61 @@ mod tests {
 		let mut implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
 		implementations.insert(chain_id, Arc::new(mock) as Arc<dyn DeliveryInterface>);
 		Arc::new(DeliveryService::new(implementations, 1, 30, 60))
+	}
+
+	fn fixture_domain_separator() -> FixedBytes<32> {
+		FixedBytes::from([0x99u8; 32])
+	}
+
+	fn lock_allocator() -> AlloyAddress {
+		AlloyAddress::from([0xA1u8; 20])
+	}
+
+	/// ABI return of `getLockDetails`: `(address token, address allocator,
+	/// uint8 resetPeriod, uint8 scope, bytes12 lockTag)` — five static words.
+	/// Only word 1 (allocator) matters for resolution.
+	fn encode_lock_details(allocator: AlloyAddress) -> Bytes {
+		let mut out = vec![0u8; 160];
+		out[44..64].copy_from_slice(allocator.as_slice());
+		Bytes::from(out)
+	}
+
+	fn encode_bool(value: bool) -> Bytes {
+		let mut out = vec![0u8; 32];
+		if value {
+			out[31] = 1;
+		}
+		Bytes::from(out)
+	}
+
+	/// Delivery mock answering `DOMAIN_SEPARATOR` (the fixture separator),
+	/// `getLockDetails` (resolving to `lock_allocator`), and `isClaimAuthorized`
+	/// (returning `authorized`).
+	fn compact_delivery(
+		chain_id: u64,
+		domain_separator: FixedBytes<32>,
+		lock_allocator: AlloyAddress,
+		authorized: bool,
+	) -> Arc<DeliveryService> {
+		use alloy_sol_types::SolCall;
+		use solver_types::standards::eip7683::interfaces::{IAllocator, ITheCompact};
+
+		let domain = Bytes::from(domain_separator.to_vec());
+		let mut mock = MockDeliveryInterface::new();
+		mock.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let resp = match selector {
+				Some(s) if s == ITheCompact::getLockDetailsCall::SELECTOR => {
+					encode_lock_details(lock_allocator)
+				},
+				Some(s) if s == IAllocator::isClaimAuthorizedCall::SELECTOR => {
+					encode_bool(authorized)
+				},
+				_ => domain.clone(),
+			};
+			Box::pin(async move { Ok(resp) })
+		});
+		delivery_service_from_mock(chain_id, mock)
 	}
 
 	fn address_from_hex(hex_str: &str) -> Address {
@@ -340,7 +418,7 @@ mod tests {
 			.compute_message_hash(&order_bytes, contract_address)
 			.expect("struct hash");
 
-		let domain_separator = FixedBytes::from([0x99u8; 32]);
+		let domain_separator = fixture_domain_separator();
 		let digest = keccak256(
 			[
 				&[0x19, 0x01][..],
@@ -417,13 +495,7 @@ mod tests {
 		let mut networks = NetworksConfig::new();
 		networks.insert(chain_id, network_config);
 
-		let mut mock_delivery = MockDeliveryInterface::new();
-		let domain_bytes = Bytes::from(domain_separator.to_vec());
-		mock_delivery.expect_eth_call().returning(move |_tx| {
-			let bytes = domain_bytes.clone();
-			Box::pin(async move { Ok(bytes) })
-		});
-		let delivery = delivery_service_from_mock(chain_id, mock_delivery);
+		let delivery = compact_delivery(chain_id, domain_separator, lock_allocator(), true);
 
 		SignatureFixture {
 			intent,
@@ -478,6 +550,60 @@ mod tests {
 		assert!(matches!(
 			result,
 			Err(APIError::BadRequest { message, .. }) if message.contains("Compact")
+		));
+	}
+
+	#[tokio::test]
+	async fn validate_signature_rejects_unauthorized_allocator_data() {
+		let mut fixture = build_signature_fixture();
+		// Keep the valid sponsor signature, but supply unauthorized allocator data.
+		let sponsor = decode_compact_signatures(&fixture.intent.signature)
+			.expect("canonical compact signature")
+			.sponsor
+			.to_vec();
+		fixture.intent.signature = compact_signature(&sponsor, b"garbage allocator data");
+
+		// An enforcing allocator rejects the unauthorized allocatorData.
+		let delivery = compact_delivery(
+			fixture.chain_id,
+			fixture_domain_separator(),
+			lock_allocator(),
+			false,
+		);
+
+		let service = SignatureValidationService::new();
+		let result = service
+			.validate_signature("eip7683", &fixture.intent, &fixture.networks, &delivery)
+			.await;
+
+		assert!(matches!(
+			result,
+			Err(APIError::BadRequest { message, .. }) if message.contains("allocator")
+		));
+	}
+
+	#[tokio::test]
+	async fn validate_signature_rejects_missing_input_settler_compact_address() {
+		let mut fixture = build_signature_fixture();
+		fixture
+			.networks
+			.get_mut(&fixture.chain_id)
+			.expect("network")
+			.input_settler_compact_address = None;
+
+		let service = SignatureValidationService::new();
+		let result = service
+			.validate_signature(
+				"eip7683",
+				&fixture.intent,
+				&fixture.networks,
+				&fixture.delivery,
+			)
+			.await;
+
+		assert!(matches!(
+			result,
+			Err(APIError::BadRequest { message, .. }) if message.contains("InputSettlerCompact")
 		));
 	}
 

--- a/crates/solver-types/src/standards/eip7683.rs
+++ b/crates/solver-types/src/standards/eip7683.rs
@@ -6,6 +6,9 @@
 
 pub mod compact_signatures;
 
+#[cfg(feature = "oif-interfaces")]
+pub mod compact_claims;
+
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -368,10 +371,20 @@ pub mod interfaces {
 			function fillOrderOutputs(bytes32 orderId, SolMandateOutput[] calldata outputs, bytes calldata fillerData) external;
 		}
 
-		/// TheCompact contract interface for domain separator fetching.
+		/// TheCompact contract interface for domain separator fetching and lock
+		/// detail resolution (used to resolve the allocator controlling a lock).
 		#[sol(rpc)]
 		interface ITheCompact {
 			function DOMAIN_SEPARATOR() external view returns (bytes32);
+			function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
+		}
+
+		/// IAllocator interface exposing the off-chain claim authorization predicate.
+		/// `isClaimAuthorized` returns whether the allocator authorizes the given
+		/// claim (the same predicate enforced on-chain during `finalise`).
+		#[sol(rpc)]
+		interface IAllocator {
+			function isClaimAuthorized(bytes32 claimHash, address arbiter, address sponsor, uint256 nonce, uint256 expires, uint256[2][] idsAndAmounts, bytes allocatorData) external view returns (bool);
 		}
 
 		/// Emitted by `InputSettlerEscrow.open()` on the origin chain.

--- a/crates/solver-types/src/standards/eip7683/compact_claims.rs
+++ b/crates/solver-types/src/standards/eip7683/compact_claims.rs
@@ -1,0 +1,251 @@
+//! TheCompact BatchCompact claim-hash computation.
+//!
+//! Computes the EIP-712 BatchCompact struct hash — the claim hash an allocator's
+//! `authorizeClaim` / `isClaimAuthorized` receives (pre domain-separator) and the
+//! hash a sponsor signs — for an OIF `StandardOrder`.
+//!
+//! Matches `openintentsframework/oif-contracts` release-v1.0.0 (the-compact
+//! submodule `b9c3b54`). Verified byte-exact by the parity test in this module and
+//! by the `solver-service` wrapper test on `compute_batch_compact_hash`. This is the
+//! single shared implementation used by both `/orders` intake (solver-service) and
+//! direct discovery intake (solver-discovery), so the two paths cannot diverge.
+
+use alloy_primitives::{keccak256, Address, FixedBytes, Uint};
+
+use crate::standards::eip7683::interfaces::{SolMandateOutput, StandardOrder};
+use crate::APIError;
+
+/// Compute the BatchCompact claim hash (EIP-712 struct hash) for a `StandardOrder`.
+///
+/// `arbiter` is the account that calls `TheCompact.batchClaim` during finalisation,
+/// i.e. the `InputSettlerCompact` address.
+pub fn compute_batch_compact_claim_hash(
+	order: &StandardOrder,
+	arbiter: Address,
+) -> Result<FixedBytes<32>, APIError> {
+	let witness_hash = compute_witness_hash(order)?;
+	let lock_hash = compute_lock_hash(&order.inputs)?;
+	compute_batch_compact_struct_hash(
+		arbiter,
+		order.user,
+		order.nonce,
+		Uint::<256, 4>::from(order.expires),
+		lock_hash,
+		witness_hash,
+	)
+}
+
+/// Compute witness hash for TheCompact mandate.
+fn compute_witness_hash(order: &StandardOrder) -> Result<FixedBytes<32>, APIError> {
+	let mandate_type_hash = keccak256(
+		b"Mandate(uint32 fillDeadline,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
+	);
+
+	let outputs_hash = compute_outputs_hash(&order.outputs)?;
+
+	let mut data = Vec::new();
+	data.extend_from_slice(mandate_type_hash.as_slice());
+
+	// fillDeadline as uint32 with proper ABI padding
+	let mut fill_deadline_bytes = [0u8; 32];
+	fill_deadline_bytes[28..32].copy_from_slice(&order.fillDeadline.to_be_bytes());
+	data.extend_from_slice(&fill_deadline_bytes);
+
+	// inputOracle as address with proper ABI padding
+	let mut oracle_bytes = [0u8; 32];
+	oracle_bytes[12..32].copy_from_slice(order.inputOracle.as_slice());
+	data.extend_from_slice(&oracle_bytes);
+
+	data.extend_from_slice(outputs_hash.as_slice());
+
+	Ok(keccak256(data))
+}
+
+/// Compute hash of all mandate outputs.
+fn compute_outputs_hash(outputs: &[SolMandateOutput]) -> Result<FixedBytes<32>, APIError> {
+	let mut hashes = Vec::new();
+
+	for output in outputs {
+		let output_hash = compute_single_output_hash(output)?;
+		hashes.extend_from_slice(output_hash.as_slice());
+	}
+
+	Ok(keccak256(hashes))
+}
+
+/// Compute hash of a single mandate output.
+fn compute_single_output_hash(output: &SolMandateOutput) -> Result<FixedBytes<32>, APIError> {
+	let output_type_hash = keccak256(
+		b"MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
+	);
+
+	let mut data = Vec::new();
+	data.extend_from_slice(output_type_hash.as_slice());
+	data.extend_from_slice(output.oracle.as_slice());
+	data.extend_from_slice(output.settler.as_slice());
+	data.extend_from_slice(&output.chainId.to_be_bytes::<32>());
+	data.extend_from_slice(output.token.as_slice());
+	data.extend_from_slice(&output.amount.to_be_bytes::<32>());
+	data.extend_from_slice(output.recipient.as_slice());
+	data.extend_from_slice(keccak256(&output.callbackData).as_slice());
+	data.extend_from_slice(keccak256(&output.context).as_slice());
+
+	Ok(keccak256(data))
+}
+
+/// Compute hash of all locks in the compact (`Lock[] commitments`).
+fn compute_lock_hash(ids_and_amounts: &[[Uint<256, 4>; 2]]) -> Result<FixedBytes<32>, APIError> {
+	let mut lock_hashes = Vec::new();
+
+	for id_amount in ids_and_amounts {
+		let token_id = id_amount[0];
+		let amount = id_amount[1];
+
+		let token_id_bytes = token_id.to_be_bytes::<32>();
+
+		// Extract lock tag (first 12 bytes)
+		let mut lock_tag_bytes = [0u8; 12];
+		lock_tag_bytes.copy_from_slice(&token_id_bytes[0..12]);
+		let lock_tag = FixedBytes::from(lock_tag_bytes);
+
+		// Extract token address (last 20 bytes)
+		let mut token_address_bytes = [0u8; 20];
+		token_address_bytes.copy_from_slice(&token_id_bytes[12..32]);
+		let token_address = Address::from(token_address_bytes);
+
+		let lock_type_hash = keccak256(b"Lock(bytes12 lockTag,address token,uint256 amount)");
+
+		let mut lock_data = Vec::new();
+		lock_data.extend_from_slice(lock_type_hash.as_slice());
+
+		// lock_tag as bytes12 with proper ABI padding
+		let mut lock_tag_bytes = [0u8; 32];
+		lock_tag_bytes[0..12].copy_from_slice(lock_tag.as_slice());
+		lock_data.extend_from_slice(&lock_tag_bytes);
+
+		// token_address as address with proper ABI padding
+		let mut token_address_bytes = [0u8; 32];
+		token_address_bytes[12..32].copy_from_slice(token_address.as_slice());
+		lock_data.extend_from_slice(&token_address_bytes);
+
+		lock_data.extend_from_slice(&amount.to_be_bytes::<32>());
+
+		let lock_hash = keccak256(lock_data);
+		lock_hashes.extend_from_slice(lock_hash.as_slice());
+	}
+
+	Ok(keccak256(lock_hashes))
+}
+
+/// Compute the final BatchCompact struct hash.
+fn compute_batch_compact_struct_hash(
+	arbiter: Address,
+	sponsor: Address,
+	nonce: Uint<256, 4>,
+	expires: Uint<256, 4>,
+	lock_hash: FixedBytes<32>,
+	witness: FixedBytes<32>,
+) -> Result<FixedBytes<32>, APIError> {
+	let batch_compact_type_hash = keccak256(
+		b"BatchCompact(address arbiter,address sponsor,uint256 nonce,uint256 expires,Lock[] commitments,Mandate mandate)Lock(bytes12 lockTag,address token,uint256 amount)Mandate(uint32 fillDeadline,address inputOracle,MandateOutput[] outputs)MandateOutput(bytes32 oracle,bytes32 settler,uint256 chainId,bytes32 token,uint256 amount,bytes32 recipient,bytes callbackData,bytes context)"
+	);
+
+	let mut struct_data = Vec::new();
+	struct_data.extend_from_slice(batch_compact_type_hash.as_slice());
+
+	// arbiter as address with proper ABI padding
+	let mut arbiter_bytes = [0u8; 32];
+	arbiter_bytes[12..32].copy_from_slice(arbiter.as_slice());
+	struct_data.extend_from_slice(&arbiter_bytes);
+
+	// sponsor
+	let mut sponsor_bytes = [0u8; 32];
+	sponsor_bytes[12..32].copy_from_slice(sponsor.as_slice());
+	struct_data.extend_from_slice(&sponsor_bytes);
+
+	struct_data.extend_from_slice(&nonce.to_be_bytes::<32>());
+	struct_data.extend_from_slice(&expires.to_be_bytes::<32>());
+	struct_data.extend_from_slice(lock_hash.as_slice());
+	struct_data.extend_from_slice(witness.as_slice());
+
+	Ok(keccak256(struct_data))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use alloy_primitives::{Bytes, U256};
+
+	#[test]
+	fn test_compute_lock_hash() {
+		let token_id = Uint::<256, 4>::from(0x123456789abcdef0u64);
+		let amount = Uint::<256, 4>::from(1000u64);
+		let ids_and_amounts = vec![[token_id, amount]];
+
+		let lock_hash = compute_lock_hash(&ids_and_amounts).unwrap();
+		assert_eq!(lock_hash.len(), 32);
+
+		let token_id_2 = Uint::<256, 4>::from(0xfedcba9876543210u64);
+		let amount_2 = Uint::<256, 4>::from(2000u64);
+		let multiple_locks = vec![[token_id, amount], [token_id_2, amount_2]];
+		let multiple_lock_hash = compute_lock_hash(&multiple_locks).unwrap();
+		assert_eq!(multiple_lock_hash.len(), 32);
+		assert_ne!(lock_hash, multiple_lock_hash);
+
+		let empty_locks: Vec<[Uint<256, 4>; 2]> = vec![];
+		let empty_hash = compute_lock_hash(&empty_locks).unwrap();
+		assert_eq!(empty_hash.len(), 32);
+		assert_ne!(empty_hash, lock_hash);
+	}
+
+	/// pC-02 Task 0 parity gate (shared helper): the claim hash must match the
+	/// official `openintentsframework/oif-contracts` release-v1.0.0 value
+	/// (the-compact `b9c3b54`). Vector generated from the official
+	/// `InputSettlerCompact.base.t.sol` BatchCompact struct-hash formula.
+	#[test]
+	fn compute_batch_compact_claim_hash_matches_official_release_v1_0_0_vector() {
+		// token_id = lockTag(12 bytes) || token(20 bytes)
+		let id_fb: FixedBytes<32> =
+			"0x0102030405060708090a0b0c4444444444444444444444444444444444444444"
+				.parse()
+				.unwrap();
+		let id = U256::from_be_bytes(id_fb.0);
+
+		// bytes32(uint256(v)) — left-padded
+		let b32 = |v: u64| FixedBytes::<32>::from(U256::from(v).to_be_bytes::<32>());
+
+		let output = SolMandateOutput {
+			oracle: b32(0xAAAA),
+			settler: b32(0xBBBB),
+			chainId: U256::from(10u64),
+			token: b32(0xCCCC),
+			amount: U256::from(555u64),
+			recipient: b32(0xDDDD),
+			callbackData: Bytes::new(),
+			context: Bytes::new(),
+		};
+
+		let order = StandardOrder {
+			user: Address::from([0x22u8; 20]),
+			nonce: U256::from(1u64),
+			originChainId: U256::from(31337u64),
+			expires: 2_000_000_000u32,
+			fillDeadline: 1_700_000_000u32,
+			inputOracle: Address::from([0x33u8; 20]),
+			inputs: vec![[id, U256::from(123456789u64)]],
+			outputs: vec![output],
+		};
+
+		let got =
+			compute_batch_compact_claim_hash(&order, Address::from([0x11u8; 20])).expect("hash");
+		let expected: FixedBytes<32> =
+			"0x2142968938e7f2f2a043a1c4a6873e981c18871d77168a7818edf6d2fef10efd"
+				.parse()
+				.unwrap();
+
+		assert_eq!(
+			got, expected,
+			"shared BatchCompact claim hash must match official release-v1.0.0 value"
+		);
+	}
+}


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for ERC-7683 ResourceLock orders with canonical Compact signature decoding and BatchCompact claim-hash verification.
  * On-intake allocator authorization: orders with unauthorized or malformed allocator data are rejected before processing.

* **Tests**
  * Extensive unit and e2e tests for valid, shifted/malformed compact signatures and allocator-authorization scenarios; e2e harness supports compact allocator flows.

* **Chores**
  * CI adjusted to wait for tests; a Redis-backed CAS test marked ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->