### PR TITLE
h-01 - feat: add settlement fee buffer configuration and quoting functionality

### DIFF
--- a/crates/solver-config/src/builders/config.rs
+++ b/crates/solver-config/src/builders/config.rs
@@ -20,6 +20,7 @@ pub struct ConfigBuilder {
 	monitoring_timeout_seconds: u64,
 	min_profitability_pct: Decimal,
 	gas_buffer_bps: u32,
+	settlement_fee_buffer_bps: u32,
 	commission_bps: u32,
 	rate_buffer_bps: u32,
 	storage_primary: String,
@@ -47,9 +48,10 @@ impl ConfigBuilder {
 			solver_id: "test-solver".to_string(),
 			monitoring_timeout_seconds: 60,
 			min_profitability_pct: Decimal::ZERO,
-			gas_buffer_bps: 1000, // 10% default
-			commission_bps: 0,    // Disabled by default for backward compatibility
-			rate_buffer_bps: 14,  // 0.14% default
+			gas_buffer_bps: 1000,            // 10% default
+			settlement_fee_buffer_bps: 1000, // 10% default
+			commission_bps: 0,               // Disabled by default for backward compatibility
+			rate_buffer_bps: 14,             // 0.14% default
 			storage_primary: "memory".to_string(),
 			storage_cleanup_interval_seconds: 60,
 			min_confirmations: 1,
@@ -160,6 +162,7 @@ impl ConfigBuilder {
 				id: self.solver_id,
 				min_profitability_pct: self.min_profitability_pct,
 				gas_buffer_bps: self.gas_buffer_bps,
+				settlement_fee_buffer_bps: self.settlement_fee_buffer_bps,
 				commission_bps: self.commission_bps,
 				rate_buffer_bps: self.rate_buffer_bps,
 				monitoring_timeout_seconds: self.monitoring_timeout_seconds,

--- a/crates/solver-config/src/lib.rs
+++ b/crates/solver-config/src/lib.rs
@@ -89,6 +89,10 @@ pub struct SolverConfig {
 	/// Applied as safety margin on gas cost estimates.
 	#[serde(default = "default_gas_buffer_bps")]
 	pub gas_buffer_bps: u32,
+	/// Settlement native fee buffer in basis points (e.g., 1000 = 10%).
+	/// Applied as safety margin on native settlement message fee quotes.
+	#[serde(default = "default_settlement_fee_buffer_bps")]
+	pub settlement_fee_buffer_bps: u32,
 	/// Commission in basis points (e.g., 20 = 0.20%).
 	/// Added to solver profit requirement.
 	#[serde(default = "default_commission_bps")]
@@ -345,6 +349,10 @@ pub struct PricingConfig {
 }
 
 fn default_gas_buffer_bps() -> u32 {
+	1000 // 10%
+}
+
+fn default_settlement_fee_buffer_bps() -> u32 {
 	1000 // 10%
 }
 
@@ -1208,6 +1216,13 @@ mod tests {
 
 		assert_eq!(config.solver.ingress_mode, SolverIngressMode::Active);
 		assert!(!config.solver.is_intake_disabled());
+	}
+
+	#[test]
+	fn test_settlement_fee_buffer_bps_defaults_to_1000() {
+		let config = ConfigBuilder::new().build();
+
+		assert_eq!(config.solver.settlement_fee_buffer_bps, 1000);
 	}
 
 	#[test]

--- a/crates/solver-core/src/bump/service.rs
+++ b/crates/solver-core/src/bump/service.rs
@@ -1364,6 +1364,8 @@ mod tests {
 			gas_pre_claim: Decimal::ZERO,
 			gas_claim: Decimal::ZERO,
 			gas_buffer,
+			settlement_fee: Decimal::ZERO,
+			settlement_fee_buffer: Decimal::ZERO,
 			rate_buffer: Decimal::ZERO,
 			base_price: Decimal::ZERO,
 			min_profit,

--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -70,15 +70,6 @@ sol! {
 			address source,
 			bytes[] calldata payloads
 		) external payable;
-
-		function quoteGasPayment(
-			uint32 destinationDomain,
-			address recipientOracle,
-			uint256 gasLimit,
-			bytes calldata customMetadata,
-			address source,
-			bytes[] calldata payloads
-		) external view returns (uint256);
 	}
 }
 
@@ -274,6 +265,8 @@ pub struct CostProfitService {
 	token_manager: Arc<TokenManager>,
 	/// Storage service for reading quotes
 	storage_service: Arc<StorageService>,
+	/// Settlement service for backend-owned native settlement fee quotes
+	settlement_service: Arc<solver_settlement::SettlementService>,
 }
 
 impl CostProfitService {
@@ -283,12 +276,14 @@ impl CostProfitService {
 		delivery_service: Arc<DeliveryService>,
 		token_manager: Arc<TokenManager>,
 		storage_service: Arc<StorageService>,
+		settlement_service: Arc<solver_settlement::SettlementService>,
 	) -> Self {
 		Self {
 			pricing_service,
 			delivery_service,
 			token_manager,
 			storage_service,
+			settlement_service,
 		}
 	}
 
@@ -739,6 +734,24 @@ impl CostProfitService {
 			}
 		}
 
+		let settlement_fee_wei = match self.build_post_fill_fee_params_for_quote(
+			request,
+			&swap_amounts_with_info,
+			config,
+		)? {
+			Some(params) => self
+				.settlement_service
+				.quote_post_fill_fee_primary(&params)
+				.await
+				.map_err(|e| APIError::InternalServerError {
+					error_type: ApiErrorType::ServiceError,
+					message: format!("Failed to quote settlement fee: {e}"),
+				})?
+				.map(|quote| quote.fee_wei)
+				.unwrap_or(U256::ZERO),
+			None => U256::ZERO,
+		};
+
 		// Build the synthetic post-fill tx + override, then estimate.
 		// All branches log exactly ONE outcome event and yield Option<u64>.
 		// We never `return` — the rest of cost calc must run regardless.
@@ -749,6 +762,7 @@ impl CostProfitService {
 					&swap_amounts_with_info,
 					config,
 					solver_address,
+					settlement_fee_wei,
 				)
 				.await
 			{
@@ -876,6 +890,7 @@ impl CostProfitService {
 				origin_chain_id,
 				dest_chain_id,
 				&gas_units,
+				settlement_fee_wei,
 			)
 			.await?;
 
@@ -936,7 +951,10 @@ impl CostProfitService {
 		);
 		execution_costs_by_chain.insert(
 			dest_chain_id,
-			cost_breakdown.gas_fill + cost_breakdown.gas_post_fill,
+			cost_breakdown.gas_fill
+				+ cost_breakdown.gas_post_fill
+				+ cost_breakdown.settlement_fee
+				+ cost_breakdown.settlement_fee_buffer,
 		);
 
 		// Calculate adjusted amounts (swap amounts +/- costs based on swap type)
@@ -988,6 +1006,7 @@ impl CostProfitService {
 		})
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	pub async fn calculate_total_cost(
 		&self,
 		inputs: &[OrderInput],
@@ -996,6 +1015,7 @@ impl CostProfitService {
 		origin_chain_id: u64,
 		dest_chain_id: u64,
 		gas_units: &GasUnits,
+		settlement_fee_wei: U256,
 	) -> Result<CostBreakdown, CostProfitError> {
 		// Read gas_buffer_bps from solver config (hot-reloadable)
 		let gas_buffer_bps_value = config.solver.gas_buffer_bps;
@@ -1059,6 +1079,12 @@ impl CostProfitService {
 		// so keep this component at zero to avoid double-charging.
 		let rate_buffer = Decimal::ZERO;
 
+		let settlement_fee = self.wei_to_usd(&settlement_fee_wei).await?;
+		let settlement_fee_buffer_bps =
+			Decimal::new(config.solver.settlement_fee_buffer_bps as i64, 0);
+		let settlement_fee_buffer =
+			(settlement_fee * settlement_fee_buffer_bps) / Decimal::from(10000);
+
 		// Input and output valuations do not depend on each other.
 		let (total_input_value_usd, total_output_value_usd) = tokio::try_join!(
 			self.calculate_inputs_usd_value(inputs),
@@ -1087,6 +1113,8 @@ impl CostProfitService {
 				+ gas_fill + gas_post_fill
 				+ gas_pre_claim
 				+ gas_claim + gas_buffer
+				+ settlement_fee
+				+ settlement_fee_buffer
 				+ rate_buffer;
 
 		// Calculate subtotal (actual costs only, excluding profit)
@@ -1102,6 +1130,8 @@ impl CostProfitService {
 			gas_pre_claim,
 			gas_claim,
 			gas_buffer,
+			settlement_fee,
+			settlement_fee_buffer,
 			rate_buffer,
 			base_price,
 			min_profit,
@@ -1183,6 +1213,25 @@ impl CostProfitService {
 		let available_inputs = order_parsed.parse_available_inputs();
 		let requested_outputs = order_parsed.parse_requested_outputs();
 
+		let settlement_fee_wei = match self.build_post_fill_fee_params_for_order(
+			order,
+			&requested_outputs,
+			origin_chain_id,
+			dest_chain_id,
+		)? {
+			Some(params) => self
+				.settlement_service
+				.quote_post_fill_fee_for_order(order, &params)
+				.await
+				.map_err(|e| APIError::InternalServerError {
+					error_type: ApiErrorType::ServiceError,
+					message: format!("Failed to quote settlement fee: {e}"),
+				})?
+				.map(|quote| quote.fee_wei)
+				.unwrap_or(U256::ZERO),
+			None => U256::ZERO,
+		};
+
 		// Use the unified cost calculation method
 		let cost_breakdown = self
 			.calculate_total_cost(
@@ -1192,6 +1241,7 @@ impl CostProfitService {
 				origin_chain_id,
 				dest_chain_id,
 				&gas_units,
+				settlement_fee_wei,
 			)
 			.await?;
 
@@ -1838,21 +1888,198 @@ impl CostProfitService {
 		})
 	}
 
+	fn build_post_fill_fee_params_for_quote(
+		&self,
+		request: &GetQuoteRequest,
+		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
+		config: &Config,
+	) -> Result<Option<solver_settlement::PostFillFeeParams>, APIError> {
+		let Some(input) = request.intent.inputs.first() else {
+			return Ok(None);
+		};
+		let Some(output) = request.intent.outputs.first() else {
+			return Ok(None);
+		};
+
+		let origin_chain_id =
+			input
+				.asset
+				.ethereum_chain_id()
+				.map_err(|e| APIError::BadRequest {
+					error_type: ApiErrorType::MissingChainId,
+					message: format!("Failed to derive origin chain id: {e}"),
+					details: None,
+				})?;
+		let dest_chain_id = output
+			.asset
+			.ethereum_chain_id()
+			.map_err(|e| APIError::BadRequest {
+				error_type: ApiErrorType::MissingChainId,
+				message: format!("Failed to derive destination chain id: {e}"),
+				details: None,
+			})?;
+		let amount = resolved_amounts
+			.get(&output.asset)
+			.map(|info| info.amount)
+			.ok_or_else(|| APIError::InternalServerError {
+				error_type: ApiErrorType::InternalError,
+				message: format!(
+					"Missing resolved swap amount for output asset on chain {dest_chain_id}; \
+					settlement fee quote must run after calculate_swap_amounts"
+				),
+			})?;
+		let source_settler = config
+			.networks
+			.get(&dest_chain_id)
+			.ok_or_else(|| APIError::BadRequest {
+				error_type: ApiErrorType::InvalidRequest,
+				message: format!(
+					"Network {dest_chain_id} not configured; cannot quote settlement fee"
+				),
+				details: None,
+			})?
+			.output_settler_address
+			.clone();
+
+		let token_addr = output
+			.asset
+			.ethereum_address()
+			.map_err(|e| APIError::BadRequest {
+				error_type: ApiErrorType::InvalidRequest,
+				message: format!("Output asset is not an EVM address: {e}"),
+				details: None,
+			})?;
+		let recipient_addr =
+			output
+				.receiver
+				.ethereum_address()
+				.map_err(|e| APIError::BadRequest {
+					error_type: ApiErrorType::InvalidRequest,
+					message: format!("Output receiver is not an EVM address: {e}"),
+					details: None,
+				})?;
+		let mut output_token = [0u8; 32];
+		output_token.copy_from_slice(
+			AlloyAddress::from_slice(token_addr.as_slice())
+				.into_word()
+				.as_slice(),
+		);
+		let mut output_recipient = [0u8; 32];
+		output_recipient.copy_from_slice(
+			AlloyAddress::from_slice(recipient_addr.as_slice())
+				.into_word()
+				.as_slice(),
+		);
+		let output_call = match output.calldata.as_deref() {
+			None => Vec::new(),
+			Some(s) if s.is_empty() || s == "0x" => Vec::new(),
+			Some(s) => alloy_primitives::hex::decode(s.trim_start_matches("0x")).map_err(|e| {
+				APIError::BadRequest {
+					error_type: ApiErrorType::InvalidRequest,
+					message: format!("Output calldata is not valid hex: {e}"),
+					details: None,
+				}
+			})?,
+		};
+
+		Ok(Some(solver_settlement::PostFillFeeParams {
+			origin_chain_id,
+			dest_chain_id,
+			output_token,
+			output_amount: amount,
+			output_recipient,
+			output_call,
+			source_settler,
+		}))
+	}
+
+	fn build_post_fill_fee_params_for_order(
+		&self,
+		order: &Order,
+		outputs: &[OrderOutput],
+		origin_chain_id: u64,
+		dest_chain_id: u64,
+	) -> Result<Option<solver_settlement::PostFillFeeParams>, APIError> {
+		let Some(output) = outputs.first() else {
+			return Ok(None);
+		};
+		let source_settler = order
+			.output_chains
+			.first()
+			.map(|chain| chain.settler_address.clone())
+			.ok_or_else(|| APIError::BadRequest {
+				error_type: ApiErrorType::MissingChainId,
+				message: "No output chain found".to_string(),
+				details: None,
+			})?;
+		let token_addr = output
+			.asset
+			.ethereum_address()
+			.map_err(|e| APIError::BadRequest {
+				error_type: ApiErrorType::InvalidRequest,
+				message: format!("Output asset is not an EVM address: {e}"),
+				details: None,
+			})?;
+		let recipient_addr =
+			output
+				.receiver
+				.ethereum_address()
+				.map_err(|e| APIError::BadRequest {
+					error_type: ApiErrorType::InvalidRequest,
+					message: format!("Output receiver is not an EVM address: {e}"),
+					details: None,
+				})?;
+		let mut output_token = [0u8; 32];
+		output_token.copy_from_slice(
+			AlloyAddress::from_slice(token_addr.as_slice())
+				.into_word()
+				.as_slice(),
+		);
+		let mut output_recipient = [0u8; 32];
+		output_recipient.copy_from_slice(
+			AlloyAddress::from_slice(recipient_addr.as_slice())
+				.into_word()
+				.as_slice(),
+		);
+		let output_call = match output.calldata.as_deref() {
+			None => Vec::new(),
+			Some(s) if s.is_empty() || s == "0x" => Vec::new(),
+			Some(s) => alloy_primitives::hex::decode(s.trim_start_matches("0x")).map_err(|e| {
+				APIError::BadRequest {
+					error_type: ApiErrorType::InvalidRequest,
+					message: format!("Output calldata is not valid hex: {e}"),
+					details: None,
+				}
+			})?,
+		};
+
+		Ok(Some(solver_settlement::PostFillFeeParams {
+			origin_chain_id,
+			dest_chain_id,
+			output_token,
+			output_amount: output.amount,
+			output_recipient,
+			output_call,
+			source_settler,
+		}))
+	}
+
 	/// Build a synthetic Hyperlane post-fill `submit(...)` transaction for
 	/// quote-time `eth_estimateGas`.
 	///
 	/// This mirrors `HyperlaneSettlement::generate_post_fill_transaction` for the
 	/// parts that determine gas units: selected output oracle, recipient input
 	/// oracle, source output settler, message gas limit, and fill-description
-	/// payload shape. It also performs the same `quoteGasPayment(...)` call and
-	/// attaches the resulting `value`, because some oracle deployments require
-	/// the payment even during `eth_estimateGas`.
+	/// payload shape. The caller supplies the settlement-owned fee quote as
+	/// transaction value, because some oracle deployments require the payment even
+	/// during `eth_estimateGas`.
 	async fn build_post_fill_tx_for_quote(
 		&self,
 		request: &GetQuoteRequest,
 		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
 		config: &Config,
 		solver_address: &Address,
+		settlement_fee_wei: U256,
 	) -> Result<Option<PostFillQuoteTx>, APIError> {
 		let Some(hyperlane_config) = hyperlane_config_for_quote(config) else {
 			return Ok(None);
@@ -2016,37 +2243,6 @@ impl CostProfitService {
 		let total_payload_size: usize = payloads.iter().map(|p| p.len()).sum();
 		let message_gas_limit = quote_hyperlane_message_gas_limit(total_payload_size);
 
-		let quote_call_data = IHyperlaneOracleForQuote::quoteGasPaymentCall {
-			destinationDomain: origin_chain_id as u32,
-			recipientOracle: alloy_primitives::Address::from_slice(&recipient_oracle.0),
-			gasLimit: message_gas_limit,
-			customMetadata: vec![].into(),
-			source: alloy_primitives::Address::from_slice(&output_settler.0),
-			payloads: payloads.clone().into_iter().map(Into::into).collect(),
-		};
-		let gas_payment = self
-			.delivery_service
-			.contract_call(
-				dest_chain_id,
-				Transaction {
-					to: Some(oracle_address.clone()),
-					data: quote_call_data.abi_encode(),
-					value: U256::ZERO,
-					chain_id: dest_chain_id,
-					nonce: None,
-					gas_limit: None,
-					gas_price: None,
-					max_fee_per_gas: None,
-					max_priority_fee_per_gas: None,
-				},
-			)
-			.await
-			.map_err(|e| APIError::InternalServerError {
-				error_type: ApiErrorType::ServiceError,
-				message: format!("Failed to quote Hyperlane post-fill gas payment: {e}"),
-			})?;
-		let gas_payment = U256::from_be_slice(gas_payment.as_ref());
-
 		let call_data = IHyperlaneOracleForQuote::submitCall {
 			destinationDomain: origin_chain_id as u32,
 			recipientOracle: alloy_primitives::Address::from_slice(&recipient_oracle.0),
@@ -2059,7 +2255,7 @@ impl CostProfitService {
 		let tx = Transaction {
 			to: Some(oracle_address),
 			data: call_data.abi_encode(),
-			value: gas_payment,
+			value: settlement_fee_wei,
 			chain_id: dest_chain_id,
 			nonce: None,
 			gas_limit: None,
@@ -2667,6 +2863,39 @@ mod tests {
 	const ETH_USD_PRICE: f64 = 4000.0;
 	const USDC_USD_PRICE: f64 = 1.0;
 
+	fn no_fee_settlement_service() -> Arc<solver_settlement::SettlementService> {
+		let mut mock = solver_settlement::MockSettlementInterface::new();
+		mock.expect_quote_post_fill_fee()
+			.returning(|_| Box::pin(async { Ok(None) }));
+		let mut implementations: HashMap<String, Box<dyn solver_settlement::SettlementInterface>> =
+			HashMap::new();
+		implementations.insert("mock".to_string(), Box::new(mock));
+		Arc::new(solver_settlement::SettlementService::new(
+			implementations,
+			"mock".to_string(),
+			1,
+		))
+	}
+
+	fn settlement_service_with_fee(
+		fee_wei: U256,
+		chain_id: u64,
+	) -> Arc<solver_settlement::SettlementService> {
+		let mut mock = solver_settlement::MockSettlementInterface::new();
+		mock.expect_quote_post_fill_fee().returning(move |_| {
+			let quote = solver_settlement::SettlementFeeQuote { fee_wei, chain_id };
+			Box::pin(async move { Ok(Some(quote)) })
+		});
+		let mut implementations: HashMap<String, Box<dyn solver_settlement::SettlementInterface>> =
+			HashMap::new();
+		implementations.insert("mock".to_string(), Box::new(mock));
+		Arc::new(solver_settlement::SettlementService::new(
+			implementations,
+			"mock".to_string(),
+			1,
+		))
+	}
+
 	fn create_test_networks_config() -> NetworksConfig {
 		let input_token = solver_types::utils::tests::builders::TokenConfigBuilder::new()
 			.address({
@@ -2702,10 +2931,15 @@ mod tests {
 
 	// Helper functions for creating test data
 	fn create_test_config() -> Config {
-		ConfigBuilder::new()
+		let mut config = ConfigBuilder::new()
 			.with_min_profitability_pct(Decimal::from_str("5.0").unwrap())
 			.rate_buffer_bps(0) // Disable rate buffer for tests with specific mock expectations
-			.build()
+			.networks(create_test_networks_config())
+			.build();
+		if let Some(gas) = config.gas.as_mut() {
+			gas.live_fill_estimate_enabled = false;
+		}
+		config
 	}
 	fn create_test_request(is_exact_input: bool) -> GetQuoteRequest {
 		GetQuoteRequest {
@@ -2818,6 +3052,8 @@ mod tests {
 			gas_pre_claim: Decimal::ZERO,
 			gas_claim: Decimal::from_str("0.01").unwrap(),
 			gas_buffer: Decimal::from_str("0.004").unwrap(),
+			settlement_fee: Decimal::ZERO,
+			settlement_fee_buffer: Decimal::ZERO,
 			rate_buffer: Decimal::ZERO,
 			base_price: Decimal::ZERO,
 			min_profit: Decimal::from_str("5.00").unwrap(),
@@ -2921,7 +3157,13 @@ mod tests {
 		let delivery = create_mock_delivery_service();
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			settlement_service_with_fee(U256::from(1u64), 137),
+		);
 
 		// Act
 		let result = service.get_cost_context_by_quote_id("test_quote_123").await;
@@ -2954,7 +3196,13 @@ mod tests {
 		let delivery = create_mock_delivery_service();
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// Act
 		let result = service
@@ -3107,7 +3355,13 @@ mod tests {
 		// Create services
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let request = create_test_request(true); // true for ExactInput
 		let context = create_test_validated_context(true); // true for ExactInput
@@ -3119,7 +3373,7 @@ mod tests {
 			.await;
 
 		// Assert
-		assert!(result.is_ok());
+		assert!(result.is_ok(), "result: {result:?}");
 		let cost_context = result.unwrap();
 
 		// Verify swap type
@@ -3128,9 +3382,20 @@ mod tests {
 		// Verify cost breakdown exists and has reasonable values
 		assert!(cost_context.cost_breakdown.total >= Decimal::ZERO);
 		assert!(cost_context.cost_breakdown.operational_cost >= Decimal::ZERO);
+		assert!(cost_context.cost_breakdown.settlement_fee > Decimal::ZERO);
+		assert!(cost_context.cost_breakdown.settlement_fee_buffer > Decimal::ZERO);
 
 		// Verify execution costs by chain
 		assert!(!cost_context.execution_costs_by_chain.is_empty());
+		assert!(
+			cost_context
+				.execution_costs_by_chain
+				.get(&137)
+				.copied()
+				.unwrap_or_default()
+				>= cost_context.cost_breakdown.settlement_fee
+					+ cost_context.cost_breakdown.settlement_fee_buffer
+		);
 
 		// Verify swap amounts were calculated
 		assert!(!cost_context.swap_amounts.is_empty());
@@ -3262,7 +3527,13 @@ mod tests {
 			create_mock_account_service(),
 		));
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let request = create_test_request(true);
 		let context = create_test_validated_context(true);
@@ -3431,7 +3702,13 @@ mod tests {
 		let pricing = Arc::new(PricingService::new(Box::new(mock_pricing), Vec::new()));
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// Create test request for ExactOutput
 		let request = create_test_request(false); // false for ExactOutput
@@ -3548,7 +3825,7 @@ mod tests {
 		let mut mock_pricing = MockPricingInterface::new();
 		mock_pricing
 			.expect_wei_to_currency()
-			.times(5)
+			.times(6)
 			.returning(|wei, _| {
 				let wei = wei.to_string();
 				Box::pin(async move { Ok(wei) })
@@ -3597,6 +3874,7 @@ mod tests {
 			delivery,
 			token_manager,
 			Arc::new(StorageService::new(Box::new(MockStorageInterface::new()))),
+			no_fee_settlement_service(),
 		);
 
 		let config = create_test_config();
@@ -3614,6 +3892,7 @@ mod tests {
 					pre_claim_units: 4,
 					claim_units: 5,
 				},
+				U256::from(10u64),
 			)
 			.await
 			.unwrap();
@@ -3624,7 +3903,9 @@ mod tests {
 		assert_eq!(breakdown.gas_pre_claim, Decimal::from(40));
 		assert_eq!(breakdown.gas_claim, Decimal::from(50));
 		assert_eq!(breakdown.gas_buffer, Decimal::from(60));
-		assert_eq!(breakdown.operational_cost, Decimal::from(660));
+		assert_eq!(breakdown.settlement_fee, Decimal::from(10));
+		assert_eq!(breakdown.settlement_fee_buffer, Decimal::from(1));
+		assert_eq!(breakdown.operational_cost, Decimal::from(671));
 	}
 
 	// ============================================================================
@@ -3723,6 +4004,8 @@ mod tests {
 			gas_pre_claim: Decimal::ZERO,
 			gas_claim: Decimal::from_str("0.01").unwrap(),
 			gas_buffer: Decimal::from_str("0.004").unwrap(),
+			settlement_fee: Decimal::ZERO,
+			settlement_fee_buffer: Decimal::ZERO,
 			rate_buffer: Decimal::ZERO,
 			base_price: Decimal::ZERO,
 			min_profit,
@@ -3814,7 +4097,13 @@ mod tests {
 	async fn test_validate_profitability_profitable_order() {
 		// Arrange
 		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -3846,7 +4135,13 @@ mod tests {
 	#[tokio::test]
 	async fn test_validate_profitability_unprofitable_order() {
 		let (pricing, delivery, token_manager, storage) = setup_unprofitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_unprofitable_order();
 		let cost_breakdown =
@@ -3873,6 +4168,54 @@ mod tests {
 			} => {
 				assert_eq!(error_type, ApiErrorType::InsufficientProfitability);
 				assert!(message.contains("Insufficient profit margin"));
+			},
+			other => panic!("Expected UnprocessableEntity error, got: {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn test_validate_profitability_rejects_when_settlement_fee_erases_margin() {
+		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
+
+		let order = create_profitable_order();
+		let mut cost_breakdown =
+			create_test_cost_breakdown_with_profit(Decimal::from_str("200.0").unwrap());
+		cost_breakdown.settlement_fee = Decimal::from_str("120.0").unwrap();
+		cost_breakdown.operational_cost += cost_breakdown.settlement_fee;
+		cost_breakdown.subtotal = cost_breakdown.operational_cost;
+		cost_breakdown.total = cost_breakdown.operational_cost;
+
+		// The order spread is $100. With the gas-only helper cost ($0.044), the
+		// order clears a 2% floor. Adding the settlement fee makes realized profit
+		// negative, so the gate must reject.
+		let result = service
+			.validate_profitability(
+				&order,
+				&cost_breakdown,
+				Decimal::from_str("2.0").unwrap(),
+				None,
+				"off-chain",
+			)
+			.await;
+
+		match result.unwrap_err() {
+			APIError::UnprocessableEntity {
+				error_type,
+				message,
+				details,
+			} => {
+				assert_eq!(error_type, ApiErrorType::InsufficientProfitability);
+				assert!(message.contains("Insufficient profit margin"));
+				let details = details.expect("profitability error should include details");
+				assert_eq!(details["operational_cost"], "$120.04");
+				assert_eq!(details["actual_profit"], "$-20.04");
 			},
 			other => panic!("Expected UnprocessableEntity error, got: {other:?}"),
 		}
@@ -3922,7 +4265,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -3986,7 +4335,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4018,7 +4373,13 @@ mod tests {
 	async fn test_validate_profitability_onchain_intent() {
 		// Arrange
 		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4047,7 +4408,13 @@ mod tests {
 	async fn test_validate_profitability_offchain_intent() {
 		// Arrange
 		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4091,7 +4458,13 @@ mod tests {
 		let token_manager = create_mock_token_manager();
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_zero_value_order();
 		let cost_breakdown =
@@ -4128,7 +4501,13 @@ mod tests {
 	async fn test_validate_profitability_order_parsing_failure() {
 		// Arrange
 		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// Create invalid order with malformed JSON
 		let mut invalid_order = create_profitable_order();
@@ -4188,7 +4567,13 @@ mod tests {
 		let token_manager = create_mock_token_manager();
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4244,7 +4629,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4271,7 +4662,13 @@ mod tests {
 	async fn test_validate_profitability_without_quote_context() {
 		// Arrange
 		let (pricing, delivery, token_manager, storage) = setup_profitable_mocks().await;
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let cost_breakdown =
@@ -4317,7 +4714,13 @@ mod tests {
 		let token_manager = create_mock_token_manager();
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_test_order_with_amounts(
 			U256::from_str("1000000000000000000").unwrap(), // 1 INPUT
@@ -4533,7 +4936,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_order_with_callback(vec![]); // Empty callback
 		let fill_tx = create_test_fill_transaction();
@@ -4581,7 +4990,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// Callback data: some arbitrary bytes
 		let callback_data = vec![0xde, 0xad, 0xbe, 0xef];
@@ -4630,7 +5045,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let callback_data = vec![0xde, 0xad, 0xbe, 0xef];
 		let order = create_order_with_callback(callback_data);
@@ -4677,7 +5098,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_order_with_multiple_outputs();
 		let fill_tx = create_test_fill_transaction();
@@ -4733,7 +5160,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let callback_data = vec![0xde, 0xad, 0xbe, 0xef];
 		let order = create_order_with_callback(callback_data);
@@ -4783,7 +5216,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
 		let token_manager = create_mock_token_manager();
 
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// Order with callback data
 		let callback_data = vec![0xde, 0xad, 0xbe, 0xef];
@@ -4836,7 +5275,13 @@ mod tests {
 		let storage = Arc::new(StorageService::new(Box::new(MockStorageInterface::new())));
 		let token_manager = create_mock_token_manager();
 
-		CostProfitService::new(pricing, delivery, token_manager, storage)
+		CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		)
 	}
 
 	#[tokio::test]
@@ -4952,7 +5397,13 @@ mod tests {
 		let delivery = create_mock_delivery_service();
 		let storage = Arc::new(StorageService::new(Box::new(MockStorageInterface::new())));
 		let token_manager = create_mock_token_manager();
-		CostProfitService::new(pricing, delivery, token_manager, storage)
+		CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		)
 	}
 
 	#[tokio::test]
@@ -5178,7 +5629,13 @@ mod tests {
 		));
 
 		let storage = Arc::new(StorageService::new(Box::new(MockStorageInterface::new())));
-		CostProfitService::new(pricing, delivery, token_manager, storage)
+		CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		)
 	}
 
 	/// Build a Config that has `networks` populated to match the live-estimate
@@ -5629,7 +6086,13 @@ mod tests {
 		));
 
 		let storage = Arc::new(StorageService::new(Box::new(MockStorageInterface::new())));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 		(service, override_calls, bare_calls)
 	}
 
@@ -6400,7 +6863,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		// Fresh breakdown intentionally has a high operational cost that would
@@ -6431,7 +6900,13 @@ mod tests {
 		// breakdown and reject for insufficient margin.
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(MockStorageInterface::new())));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let mut fresh_breakdown =
@@ -6472,7 +6947,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		let order = create_profitable_order();
 		let mut fresh_breakdown =
@@ -6577,7 +7058,13 @@ mod tests {
 
 		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
 		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
-		let validator_service = CostProfitService::new(pricing, delivery, token_manager, storage);
+		let validator_service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
 
 		// 4. Order whose spread comfortably exceeds the stored operational cost.
 		let order = create_profitable_order();

--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -736,6 +736,7 @@ impl CostProfitService {
 
 		let settlement_fee_wei = match self.build_post_fill_fee_params_for_quote(
 			request,
+			context,
 			&swap_amounts_with_info,
 			config,
 		)? {
@@ -759,6 +760,7 @@ impl CostProfitService {
 			match self
 				.build_post_fill_tx_for_quote(
 					request,
+					context,
 					&swap_amounts_with_info,
 					config,
 					solver_address,
@@ -1713,6 +1715,46 @@ impl CostProfitService {
 		}
 	}
 
+	fn resolve_quote_output_amount(
+		request: &GetQuoteRequest,
+		context: &ValidatedQuoteContext,
+		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
+		output: &solver_types::QuoteOutput,
+		dest_chain_id: u64,
+		caller: &str,
+	) -> Result<U256, APIError> {
+		if let Some(info) = resolved_amounts.get(&output.asset) {
+			return Ok(info.amount);
+		}
+
+		if let Some(known_outputs) = &context.known_outputs {
+			if let Some((_, amount)) = known_outputs.iter().find(|(known_output, _)| {
+				known_output.asset == output.asset && known_output.receiver == output.receiver
+			}) {
+				return Ok(*amount);
+			}
+
+			if request.intent.outputs.len() == 1 && known_outputs.len() == 1 {
+				return Ok(known_outputs[0].1);
+			}
+		}
+
+		if let Some(amount) = output.amount.as_deref() {
+			return U256::from_str(amount).map_err(|e| APIError::BadRequest {
+				error_type: ApiErrorType::InvalidRequest,
+				message: format!("Output amount is not a valid integer: {e}"),
+				details: None,
+			});
+		}
+
+		Err(APIError::InternalServerError {
+			error_type: ApiErrorType::InternalError,
+			message: format!(
+				"Missing output amount for asset on chain {dest_chain_id}; {caller} must run after calculate_swap_amounts or receive exact-output context"
+			),
+		})
+	}
+
 	/// Build a synthetic fill `Transaction` from a resolved quote request, suitable
 	/// for `eth_estimateGas` against the destination chain's OutputSettler.
 	///
@@ -1739,7 +1781,7 @@ impl CostProfitService {
 	async fn build_fill_tx_for_quote(
 		&self,
 		request: &GetQuoteRequest,
-		_context: &ValidatedQuoteContext,
+		context: &ValidatedQuoteContext,
 		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
 		config: &Config,
 		solver_address: &Address,
@@ -1781,16 +1823,14 @@ impl CostProfitService {
 		// errors. Do NOT silently encode a zero amount; that would make
 		// estimateGas return a misleadingly low value and reintroduce the
 		// quote/validator divergence we're trying to eliminate.
-		let amount: U256 = resolved_amounts
-			.get(&output.asset)
-			.map(|info| info.amount)
-			.ok_or_else(|| APIError::InternalServerError {
-				error_type: ApiErrorType::InternalError,
-				message: format!(
-					"Missing resolved swap amount for output asset on chain {chain_id}; \
-					build_fill_tx_for_quote must run after calculate_swap_amounts"
-				),
-			})?;
+		let amount = Self::resolve_quote_output_amount(
+			request,
+			context,
+			resolved_amounts,
+			output,
+			chain_id,
+			"build_fill_tx_for_quote",
+		)?;
 
 		// Left-pad / right-align: 20-byte address occupies bytes32[12..32], the
 		// leading 12 bytes are zero. Mirrors the convention used in
@@ -1891,6 +1931,7 @@ impl CostProfitService {
 	fn build_post_fill_fee_params_for_quote(
 		&self,
 		request: &GetQuoteRequest,
+		context: &ValidatedQuoteContext,
 		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
 		config: &Config,
 	) -> Result<Option<solver_settlement::PostFillFeeParams>, APIError> {
@@ -1918,16 +1959,14 @@ impl CostProfitService {
 				message: format!("Failed to derive destination chain id: {e}"),
 				details: None,
 			})?;
-		let amount = resolved_amounts
-			.get(&output.asset)
-			.map(|info| info.amount)
-			.ok_or_else(|| APIError::InternalServerError {
-				error_type: ApiErrorType::InternalError,
-				message: format!(
-					"Missing resolved swap amount for output asset on chain {dest_chain_id}; \
-					settlement fee quote must run after calculate_swap_amounts"
-				),
-			})?;
+		let amount = Self::resolve_quote_output_amount(
+			request,
+			context,
+			resolved_amounts,
+			output,
+			dest_chain_id,
+			"settlement fee quote",
+		)?;
 		let source_settler = config
 			.networks
 			.get(&dest_chain_id)
@@ -2076,6 +2115,7 @@ impl CostProfitService {
 	async fn build_post_fill_tx_for_quote(
 		&self,
 		request: &GetQuoteRequest,
+		context: &ValidatedQuoteContext,
 		resolved_amounts: &std::collections::HashMap<InteropAddress, TokenAmountInfo>,
 		config: &Config,
 		solver_address: &Address,
@@ -2145,16 +2185,14 @@ impl CostProfitService {
 			})?;
 		let output_settler = network.output_settler_address.clone();
 
-		let amount: U256 = resolved_amounts
-			.get(&output.asset)
-			.map(|info| info.amount)
-			.ok_or_else(|| APIError::InternalServerError {
-				error_type: ApiErrorType::InternalError,
-				message: format!(
-					"Missing resolved swap amount for output asset on chain {dest_chain_id}; \
-					build_post_fill_tx_for_quote must run after calculate_swap_amounts"
-				),
-			})?;
+		let amount = Self::resolve_quote_output_amount(
+			request,
+			context,
+			resolved_amounts,
+			output,
+			dest_chain_id,
+			"build_post_fill_tx_for_quote",
+		)?;
 
 		let token_addr = output
 			.asset
@@ -6482,18 +6520,31 @@ mod tests {
 		config
 	}
 
-	/// Like `config_for_live_estimate(false)` but with chain 137 dropped
-	/// from `config.networks`. `build_post_fill_tx_for_quote` then errors
-	/// at the `Network <id> not configured` branch and the call site
-	/// emits `outcome=skipped_build_tx`.
+	/// Like `config_for_live_estimate(false)` but with a malformed Hyperlane
+	/// output oracle on chain 137. Fee-param construction still succeeds because
+	/// the destination network remains configured; only `build_post_fill_tx_for_quote`
+	/// errors, and the call site emits `outcome=skipped_build_tx`.
 	///
 	/// The upstream cost calc still resolves because `calculate_swap_amounts`
 	/// reads token info via the `TokenManager`, which carries its own
-	/// per-test networks — `config.networks` is only consulted by the
-	/// post-fill builder.
-	fn config_missing_dest_network_for_post_fill() -> Config {
+	/// per-test networks.
+	fn config_malformed_output_oracle_for_post_fill() -> Config {
 		let mut config = config_for_live_estimate(false);
-		config.networks.remove(&137);
+		config.settlement.implementations.insert(
+			"hyperlane".to_string(),
+			serde_json::json!({
+				"oracles": {
+					"input": {
+						"1": ["0x1111111111111111111111111111111111111111"],
+						"137": ["0x2222222222222222222222222222222222222222"]
+					},
+					"output": {
+						"1": ["0x1111111111111111111111111111111111111111"],
+						"137": ["not-an-address"]
+					}
+				}
+			}),
+		);
 		config.gas = Some(solver_config::GasConfig {
 			flows: HashMap::from([(
 				"permit2_escrow".to_string(),
@@ -6613,8 +6664,8 @@ mod tests {
 			"outcome field mismatch: {captured:#?}",
 		);
 
-		// Case 3: SKIPPED_BUILD_TX — chain enabled, but dest network missing
-		// from `config.networks` so `build_post_fill_tx_for_quote` errors.
+		// Case 3: SKIPPED_BUILD_TX — chain enabled, but Hyperlane output oracle
+		// malformed so `build_post_fill_tx_for_quote` errors.
 		let captured = capture_post_fill_events(|| {
 			let request = request.clone();
 			let context = context.clone();
@@ -6622,7 +6673,7 @@ mod tests {
 			async move {
 				let (service, _, _) =
 					cost_profit_service_for_post_fill_override(None, Some(5_000_000));
-				let config = config_missing_dest_network_for_post_fill();
+				let config = config_malformed_output_oracle_for_post_fill();
 				let _ = service
 					.calculate_cost_context_for_flow_keys(
 						&request,
@@ -6783,6 +6834,31 @@ mod tests {
 			U256::from(1_000_000u64),
 			"builder must use resolved amount, not the stale request value"
 		);
+	}
+
+	#[test]
+	fn exact_output_post_fill_fee_params_use_known_output_amount() {
+		let config = config_with_output_settler_on_dest(QUOTE_OUTPUT_SETTLER);
+		let request = create_test_request(false);
+		let context = create_test_validated_context(false);
+		let input_asset = request.intent.inputs[0].asset.clone();
+		let mut resolved = HashMap::new();
+		resolved.insert(
+			input_asset.clone(),
+			TokenAmountInfo {
+				token: input_asset,
+				amount: U256::from(1_000_000_000_000_000_000u128),
+				decimals: 18,
+			},
+		);
+		let service = cost_profit_service_no_delivery_chains();
+
+		let params = service
+			.build_post_fill_fee_params_for_quote(&request, &context, &resolved, &config)
+			.expect("exact-output fee params should use known output amount")
+			.expect("quote has a post-fill output");
+
+		assert_eq!(params.output_amount, U256::from_str("2000000000").unwrap());
 	}
 
 	// ----- Task 5: validator honors stored cost_breakdown for quoted orders ---

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -184,6 +184,7 @@ impl SolverEngine {
 			delivery.clone(),
 			token_manager.clone(),
 			storage.clone(),
+			settlement.clone(),
 		));
 
 		let intent_handler = Arc::new(IntentHandler::new(

--- a/crates/solver-core/src/handlers/intent.rs
+++ b/crates/solver-core/src/handlers/intent.rs
@@ -880,12 +880,25 @@ mod tests {
 				MockAccountInterface::new(),
 			))),
 		));
+		let mut mock_settlement = solver_settlement::MockSettlementInterface::new();
+		mock_settlement
+			.expect_quote_post_fill_fee()
+			.returning(|_| Box::pin(async { Ok(None) }));
+		let settlement_service = Arc::new(solver_settlement::SettlementService::new(
+			HashMap::from([(
+				"mock".to_string(),
+				Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+			)]),
+			"mock".to_string(),
+			1,
+		));
 
 		Arc::new(CostProfitService::new(
 			pricing_service,
 			delivery_service,
 			token_manager,
 			Arc::new(StorageService::new(Box::new(MockStorageInterface::new()))),
+			settlement_service,
 		))
 	}
 

--- a/crates/solver-demo/src/operations/init/mod.rs
+++ b/crates/solver-demo/src/operations/init/mod.rs
@@ -1202,6 +1202,7 @@ mod tests {
 			orders_auth_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,

--- a/crates/solver-e2e-tests/src/lib.rs
+++ b/crates/solver-e2e-tests/src/lib.rs
@@ -1772,6 +1772,7 @@ fn build_seed_overrides(
 		orders_auth_enabled: Some(options.enable_admin_api),
 		min_profitability_pct: None,
 		gas_buffer_bps: None,
+		settlement_fee_buffer_bps: None,
 		commission_bps: None,
 		rate_buffer_bps: None,
 		monitoring_timeout_seconds: None,

--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -303,6 +303,7 @@ pub async fn handle_get_config(
 		solver: AdminSolverResponse {
 			min_profitability_pct: operator_config.solver.min_profitability_pct.to_string(),
 			gas_buffer_bps: operator_config.solver.gas_buffer_bps,
+			settlement_fee_buffer_bps: operator_config.solver.settlement_fee_buffer_bps,
 			commission_bps: operator_config.solver.commission_bps,
 			rate_buffer_bps: operator_config.solver.rate_buffer_bps,
 		},
@@ -934,6 +935,7 @@ async fn ensure_new_token_approvals(
 /// ```
 ///
 /// - `gasBufferBps`: Gas buffer in basis points (e.g., 1500 = 15%)
+/// - `settlementFeeBufferBps`: Native settlement fee buffer in basis points (e.g., 1000 = 10%)
 /// - `minProfitabilityPct`: Minimum profitability as decimal string (e.g., "2.5" for 2.5%)
 /// - `commissionBps`: Commission in basis points (e.g., 20 = 0.20%)
 /// - `rateBufferBps`: Rate buffer in basis points (e.g., 14 = 0.14%)
@@ -963,7 +965,15 @@ pub async fn handle_update_fees(
 		)));
 	}
 
-	// 2b. Validate commission_bps is reasonable (0-10000 = 0-100%)
+	// 2b. Validate settlement_fee_buffer_bps is reasonable (0-10000 = 0-100%)
+	if request.settlement_fee_buffer_bps > 10000 {
+		return Err(AdminAuthError::InvalidMessage(format!(
+			"Invalid settlementFeeBufferBps: {} exceeds maximum of 10000 (100%)",
+			request.settlement_fee_buffer_bps
+		)));
+	}
+
+	// 2c. Validate commission_bps is reasonable (0-10000 = 0-100%)
 	if request.commission_bps > 10000 {
 		return Err(AdminAuthError::InvalidMessage(format!(
 			"Invalid commissionBps: {} exceeds maximum of 10000 (100%)",
@@ -971,7 +981,7 @@ pub async fn handle_update_fees(
 		)));
 	}
 
-	// 2c. Validate rate_buffer_bps is reasonable (<10000 to avoid zero rate)
+	// 2d. Validate rate_buffer_bps is reasonable (<10000 to avoid zero rate)
 	if request.rate_buffer_bps >= 10000 {
 		return Err(AdminAuthError::InvalidMessage(format!(
 			"Invalid rateBufferBps: {} must be less than 10000",
@@ -985,6 +995,7 @@ pub async fn handle_update_fees(
 	// 4. Update fee configuration
 	let mut operator_config = versioned.data;
 	operator_config.solver.gas_buffer_bps = request.gas_buffer_bps;
+	operator_config.solver.settlement_fee_buffer_bps = request.settlement_fee_buffer_bps;
 	operator_config.solver.min_profitability_pct = min_profitability;
 	operator_config.solver.commission_bps = request.commission_bps;
 	operator_config.solver.rate_buffer_bps = request.rate_buffer_bps;
@@ -1009,6 +1020,7 @@ pub async fn handle_update_fees(
 	tracing::info!(
 		version = new_versioned.version,
 		gas_buffer_bps = request.gas_buffer_bps,
+		settlement_fee_buffer_bps = request.settlement_fee_buffer_bps,
 		commission_bps = request.commission_bps,
 		rate_buffer_bps = request.rate_buffer_bps,
 		min_profitability_pct = %request.min_profitability_pct,
@@ -1018,8 +1030,9 @@ pub async fn handle_update_fees(
 	Ok(Json(AdminActionResponse {
 		success: true,
 		message: format!(
-			"Fee configuration updated: gasBufferBps={}, minProfitabilityPct={}, commissionBps={}, rateBufferBps={}",
+			"Fee configuration updated: gasBufferBps={}, settlementFeeBufferBps={}, minProfitabilityPct={}, commissionBps={}, rateBufferBps={}",
 			request.gas_buffer_bps,
+			request.settlement_fee_buffer_bps,
 			request.min_profitability_pct,
 			request.commission_bps,
 			request.rate_buffer_bps
@@ -1037,6 +1050,7 @@ pub async fn handle_get_fees(State(state): State<AdminApiState>) -> Json<FeeConf
 	Json(FeeConfigResponse {
 		min_profitability_pct: config.solver.min_profitability_pct.to_string(),
 		gas_buffer_bps: config.solver.gas_buffer_bps,
+		settlement_fee_buffer_bps: config.solver.settlement_fee_buffer_bps,
 		commission_bps: config.solver.commission_bps,
 		rate_buffer_bps: config.solver.rate_buffer_bps,
 		monitoring_timeout_seconds: config.solver.monitoring_timeout_seconds,
@@ -1737,6 +1751,7 @@ mod tests {
 			solver: OperatorSolverConfig {
 				min_profitability_pct: rust_decimal::Decimal::ZERO,
 				gas_buffer_bps: 1000,
+				settlement_fee_buffer_bps: 1000,
 				commission_bps: 20,
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 60,
@@ -2752,8 +2767,97 @@ mod tests {
 		// ConfigBuilder default values
 		assert_eq!(response.min_profitability_pct, "0");
 		assert_eq!(response.gas_buffer_bps, 1000);
+		assert_eq!(response.settlement_fee_buffer_bps, 1000);
 		assert_eq!(response.commission_bps, 0); // Disabled by default for backward compatibility
 		assert_eq!(response.rate_buffer_bps, 14);
+	}
+
+	#[tokio::test]
+	#[serial]
+	async fn test_handle_update_fees_updates_settlement_fee_buffer() {
+		let _jwt_secret = strong_jwt_secret_guard();
+		let admin = alloy_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+		let withdrawals = OperatorWithdrawalsConfig {
+			enabled: false,
+			recipient_allowlist: vec![],
+		};
+		let mut operator_config = build_operator_config(admin, withdrawals);
+		operator_config.networks.insert(
+			1,
+			OperatorNetworkConfig {
+				chain_id: 1,
+				name: "chain-1".to_string(),
+				network_type: NetworkType::Parent,
+				tokens: vec![],
+				rpc_urls: vec![OperatorRpcEndpoint {
+					http: "http://localhost:8545".to_string(),
+					ws: None,
+				}],
+				input_settler_address: alloy_address("0x1111111111111111111111111111111111111111"),
+				output_settler_address: alloy_address("0x2222222222222222222222222222222222222222"),
+				input_settler_compact_address: None,
+				the_compact_address: None,
+				allocator_address: None,
+			},
+		);
+		operator_config.networks.insert(
+			137,
+			OperatorNetworkConfig {
+				chain_id: 137,
+				name: "chain-137".to_string(),
+				network_type: NetworkType::Hub,
+				tokens: vec![],
+				rpc_urls: vec![OperatorRpcEndpoint {
+					http: "http://localhost:8546".to_string(),
+					ws: None,
+				}],
+				input_settler_address: alloy_address("0x3333333333333333333333333333333333333333"),
+				output_settler_address: alloy_address("0x4444444444444444444444444444444444444444"),
+				input_settler_compact_address: None,
+				the_compact_address: None,
+				allocator_address: None,
+			},
+		);
+		let state = create_admin_state_with_operator_config(
+			operator_config,
+			create_delivery_service(None, false),
+		)
+		.await;
+		let state_for_assert = state.clone();
+
+		let response = handle_update_fees(
+			State(state),
+			VerifiedAdmin {
+				admin: solver_types::Address::from(admin),
+				contents: UpdateFeeConfigContents {
+					gas_buffer_bps: 1500,
+					settlement_fee_buffer_bps: 2500,
+					min_profitability_pct: "2.5".to_string(),
+					commission_bps: 20,
+					rate_buffer_bps: 14,
+					nonce: 1,
+					deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+				},
+			},
+		)
+		.await
+		.unwrap()
+		.0;
+
+		assert!(response.success);
+		assert!(response.message.contains("settlementFeeBufferBps=2500"));
+
+		let versioned = state_for_assert.config_store.get().await.unwrap();
+		assert_eq!(versioned.data.solver.settlement_fee_buffer_bps, 2500);
+		assert_eq!(
+			state_for_assert
+				.dynamic_config
+				.read()
+				.await
+				.solver
+				.settlement_fee_buffer_bps,
+			2500
+		);
 	}
 
 	#[tokio::test]
@@ -3039,6 +3143,7 @@ mod tests {
 		let response = FeeConfigResponse {
 			min_profitability_pct: "2.5".to_string(),
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 2500,
 			commission_bps: 20,
 			rate_buffer_bps: 14,
 			monitoring_timeout_seconds: 60,
@@ -3047,6 +3152,7 @@ mod tests {
 		let json = serde_json::to_string(&response).unwrap();
 		assert!(json.contains("\"minProfitabilityPct\":\"2.5\""));
 		assert!(json.contains("\"gasBufferBps\":1500"));
+		assert!(json.contains("\"settlementFeeBufferBps\":2500"));
 		assert!(json.contains("\"commissionBps\":20"));
 		assert!(json.contains("\"rateBufferBps\":14"));
 		assert!(json.contains("\"monitoringTimeoutSeconds\":60"));

--- a/crates/solver-service/src/apis/quote/generation.rs
+++ b/crates/solver-service/src/apis/quote/generation.rs
@@ -2156,6 +2156,8 @@ mod tests {
 				gas_pre_claim: Decimal::ZERO,
 				gas_claim: Decimal::from_str("0.001").unwrap(),
 				gas_buffer: Decimal::from_str("0.0005").unwrap(),
+				settlement_fee: Decimal::ZERO,
+				settlement_fee_buffer: Decimal::ZERO,
 				rate_buffer: Decimal::from_str("0.01").unwrap(),
 				base_price: Decimal::from_str("1.0").unwrap(),
 				min_profit: Decimal::from_str("0.005").unwrap(),

--- a/crates/solver-service/src/apis/quote/generation.rs
+++ b/crates/solver-service/src/apis/quote/generation.rs
@@ -2021,6 +2021,9 @@ mod tests {
 				.expect_select_oracle()
 				.returning(|oracles, _context| oracles.first().cloned());
 		}
+		mock_settlement
+			.expect_quote_post_fill_fee()
+			.returning(|_| Box::pin(async { Ok(None) }));
 
 		let mut implementations: HashMap<String, Box<dyn SettlementInterface>> = HashMap::new();
 		implementations.insert("test".to_string(), Box::new(mock_settlement));

--- a/crates/solver-service/src/apis/quote/mod.rs
+++ b/crates/solver-service/src/apis/quote/mod.rs
@@ -137,6 +137,7 @@ pub async fn process_quote_request(
 		solver.delivery().clone(),
 		solver.token_manager().clone(),
 		solver.storage().clone(),
+		solver.settlement().clone(),
 	);
 
 	let solver_address = solver.solver_address().clone();
@@ -780,6 +781,8 @@ mod tests {
 				gas_pre_claim: rust_decimal::Decimal::ZERO,
 				gas_claim: rust_decimal::Decimal::new(1, 2),  // 0.01
 				gas_buffer: rust_decimal::Decimal::new(4, 3), // 0.004
+				settlement_fee: rust_decimal::Decimal::ZERO,
+				settlement_fee_buffer: rust_decimal::Decimal::ZERO,
 				rate_buffer: rust_decimal::Decimal::ZERO,
 				base_price: rust_decimal::Decimal::ZERO,
 				min_profit: rust_decimal::Decimal::new(5, 0), // 5.0

--- a/crates/solver-service/src/apis/quote/mod.rs
+++ b/crates/solver-service/src/apis/quote/mod.rs
@@ -639,6 +639,9 @@ mod tests {
 		mock_settlement
 			.expect_select_oracle()
 			.returning(|oracles, _context| oracles.first().cloned());
+		mock_settlement
+			.expect_quote_post_fill_fee()
+			.returning(|_| Box::pin(async { Ok(None) }));
 
 		let mut implementations: HashMap<String, Box<dyn SettlementInterface>> = HashMap::new();
 		implementations.insert("test".to_string(), Box::new(mock_settlement));

--- a/crates/solver-service/src/apis/quote/validation.rs
+++ b/crates/solver-service/src/apis/quote/validation.rs
@@ -1555,6 +1555,8 @@ mod tests {
 				gas_pre_claim: Decimal::ZERO,
 				gas_claim: Decimal::ZERO,
 				gas_buffer: Decimal::ZERO,
+				settlement_fee: Decimal::ZERO,
+				settlement_fee_buffer: Decimal::ZERO,
 				rate_buffer: Decimal::ZERO,
 				base_price: Decimal::ZERO,
 				min_profit: Decimal::ZERO,

--- a/crates/solver-service/src/apis/rebalance.rs
+++ b/crates/solver-service/src/apis/rebalance.rs
@@ -1057,6 +1057,7 @@ mod tests {
 			solver: OperatorSolverConfig {
 				min_profitability_pct: rust_decimal::Decimal::ZERO,
 				gas_buffer_bps: 1000,
+				settlement_fee_buffer_bps: 1000,
 				commission_bps: 20,
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 60,

--- a/crates/solver-service/src/auth/admin/types.rs
+++ b/crates/solver-service/src/auth/admin/types.rs
@@ -140,6 +140,7 @@ sol! {
 	/// Update fee configuration (gas buffer and min profitability)
 	struct UpdateFeeConfig {
 		uint32 gasBufferBps;
+		uint32 settlementFeeBufferBps;
 		string minProfitabilityPct;
 		uint32 commissionBps;
 		uint32 rateBufferBps;
@@ -428,6 +429,8 @@ impl WithdrawContents {
 pub struct UpdateFeeConfigContents {
 	/// Gas buffer in basis points (e.g., 1000 = 10%)
 	pub gas_buffer_bps: u32,
+	/// Settlement native fee buffer in basis points (e.g., 1000 = 10%)
+	pub settlement_fee_buffer_bps: u32,
 	/// Minimum profitability percentage as a decimal string (e.g., "1.5" for 1.5%)
 	pub min_profitability_pct: String,
 	/// Commission in basis points (e.g., 20 = 0.20%)
@@ -445,6 +448,7 @@ impl UpdateFeeConfigContents {
 	pub fn to_eip712(&self) -> UpdateFeeConfig {
 		UpdateFeeConfig {
 			gasBufferBps: self.gas_buffer_bps,
+			settlementFeeBufferBps: self.settlement_fee_buffer_bps,
 			minProfitabilityPct: self.min_profitability_pct.clone(),
 			commissionBps: self.commission_bps,
 			rateBufferBps: self.rate_buffer_bps,
@@ -1707,6 +1711,7 @@ mod tests {
 	fn test_update_fee_config_struct_hash() {
 		let contents = UpdateFeeConfigContents {
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "2.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1726,6 +1731,7 @@ mod tests {
 	fn test_update_fee_config_different_values_different_hash() {
 		let contents1 = UpdateFeeConfigContents {
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "2.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1735,6 +1741,7 @@ mod tests {
 
 		let contents2 = UpdateFeeConfigContents {
 			gas_buffer_bps: 2000, // Different gas buffer
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "2.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1746,6 +1753,7 @@ mod tests {
 
 		let contents3 = UpdateFeeConfigContents {
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "3.0".to_string(), // Different profitability
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1760,6 +1768,7 @@ mod tests {
 	fn test_update_fee_config_admin_action_trait() {
 		let contents = UpdateFeeConfigContents {
 			gas_buffer_bps: 1000,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "1.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1779,6 +1788,7 @@ mod tests {
 	fn test_update_fee_config_message_hash() {
 		let contents = UpdateFeeConfigContents {
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "2.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1798,6 +1808,7 @@ mod tests {
 	fn test_update_fee_config_serialization() {
 		let contents = UpdateFeeConfigContents {
 			gas_buffer_bps: 1500,
+			settlement_fee_buffer_bps: 1000,
 			min_profitability_pct: "2.5".to_string(),
 			commission_bps: 20,
 			rate_buffer_bps: 14,
@@ -1807,6 +1818,7 @@ mod tests {
 
 		let json = serde_json::to_string(&contents).unwrap();
 		assert!(json.contains("\"gasBufferBps\":1500"));
+		assert!(json.contains("\"settlementFeeBufferBps\":1000"));
 		assert!(json.contains("\"minProfitabilityPct\":\"2.5\""));
 		assert!(json.contains("\"commissionBps\":20"));
 		assert!(json.contains("\"rateBufferBps\":14"));
@@ -1824,6 +1836,7 @@ mod tests {
 	fn test_update_fee_config_deserialize_with_string_nonce() {
 		let json = r#"{
 			"gasBufferBps": 1500,
+			"settlementFeeBufferBps": 1000,
 			"minProfitabilityPct": "2.5",
 			"commissionBps": 20,
 			"rateBufferBps": 14,
@@ -1833,6 +1846,7 @@ mod tests {
 
 		let contents: UpdateFeeConfigContents = serde_json::from_str(json).unwrap();
 		assert_eq!(contents.gas_buffer_bps, 1500);
+		assert_eq!(contents.settlement_fee_buffer_bps, 1000);
 		assert_eq!(contents.min_profitability_pct, "2.5");
 		assert_eq!(contents.commission_bps, 20);
 		assert_eq!(contents.rate_buffer_bps, 14);
@@ -1846,6 +1860,7 @@ mod tests {
 			"signature": "0xabababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab1b",
 			"contents": {
 				"gasBufferBps": 1500,
+				"settlementFeeBufferBps": 1000,
 				"minProfitabilityPct": "2.5",
 				"commissionBps": 20,
 				"rateBufferBps": 14,
@@ -1857,6 +1872,7 @@ mod tests {
 		let request: SignedAdminRequest<UpdateFeeConfigContents> =
 			serde_json::from_str(json).unwrap();
 		assert_eq!(request.contents.gas_buffer_bps, 1500);
+		assert_eq!(request.contents.settlement_fee_buffer_bps, 1000);
 		assert_eq!(request.contents.min_profitability_pct, "2.5");
 		assert_eq!(request.contents.commission_bps, 20);
 		assert_eq!(request.contents.rate_buffer_bps, 14);

--- a/crates/solver-service/src/config_merge.rs
+++ b/crates/solver-service/src/config_merge.rs
@@ -426,6 +426,7 @@ pub fn merge_to_operator_config(
 		.unwrap_or(seed.defaults.min_profitability_pct);
 
 	let gas_buffer_bps = initializer.gas_buffer_bps.unwrap_or(1000);
+	let settlement_fee_buffer_bps = initializer.settlement_fee_buffer_bps.unwrap_or(1000);
 	let commission_bps = initializer
 		.commission_bps
 		.unwrap_or(seed.defaults.commission_bps);
@@ -496,6 +497,7 @@ pub fn merge_to_operator_config(
 		solver: OperatorSolverConfig {
 			min_profitability_pct,
 			gas_buffer_bps,
+			settlement_fee_buffer_bps,
 			commission_bps,
 			rate_buffer_bps,
 			monitoring_timeout_seconds,
@@ -1205,6 +1207,7 @@ fn build_solver_config_from_operator(
 		id: operator_config.solver_id.clone(),
 		min_profitability_pct: operator_config.solver.min_profitability_pct,
 		gas_buffer_bps: operator_config.solver.gas_buffer_bps,
+		settlement_fee_buffer_bps: operator_config.solver.settlement_fee_buffer_bps,
 		commission_bps: operator_config.solver.commission_bps,
 		rate_buffer_bps: operator_config.solver.rate_buffer_bps,
 		monitoring_timeout_seconds: operator_config.solver.monitoring_timeout_seconds,
@@ -2541,6 +2544,7 @@ pub fn config_to_operator_config(config: &Config) -> Result<OperatorConfig, Merg
 		solver: OperatorSolverConfig {
 			min_profitability_pct: config.solver.min_profitability_pct,
 			gas_buffer_bps: config.solver.gas_buffer_bps,
+			settlement_fee_buffer_bps: config.solver.settlement_fee_buffer_bps,
 			commission_bps: config.solver.commission_bps,
 			rate_buffer_bps: config.solver.rate_buffer_bps,
 			monitoring_timeout_seconds: config.solver.monitoring_timeout_seconds,
@@ -3507,6 +3511,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -3828,6 +3833,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -3889,6 +3895,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -3944,6 +3951,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -3990,6 +3998,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4082,6 +4091,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: Some(Decimal::from_str("2.5").unwrap()), // Override: 2.5%
 			gas_buffer_bps: Some(1500),                                     // Override: 15%
+			settlement_fee_buffer_bps: Some(2000),                          // Override: 20%
 			commission_bps: Some(25),                                       // Override: 0.25%
 			rate_buffer_bps: Some(30),                                      // Override: 0.30%
 			monitoring_timeout_seconds: None,
@@ -4104,6 +4114,9 @@ mod tests {
 
 		// Verify gas_buffer_bps is applied
 		assert_eq!(config.solver.gas_buffer_bps, 1500);
+
+		// Verify settlement_fee_buffer_bps is applied
+		assert_eq!(config.solver.settlement_fee_buffer_bps, 2000);
 
 		// Verify commission_bps is applied
 		assert_eq!(config.solver.commission_bps, 25);
@@ -4148,6 +4161,9 @@ mod tests {
 
 		// Should use default gas_buffer_bps (1000 = 10%)
 		assert_eq!(config.solver.gas_buffer_bps, 1000);
+
+		// Should use default settlement_fee_buffer_bps (1000 = 10%)
+		assert_eq!(config.solver.settlement_fee_buffer_bps, 1000);
 
 		// Should use seed default commission_bps
 		assert_eq!(
@@ -4305,6 +4321,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4372,6 +4389,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4464,6 +4482,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4531,6 +4550,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4604,6 +4624,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4729,6 +4750,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4862,6 +4884,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4933,6 +4956,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -4998,6 +5022,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5098,6 +5123,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5207,6 +5233,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5375,6 +5402,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5515,6 +5543,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5619,6 +5648,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5745,6 +5775,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5900,6 +5931,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -5948,6 +5980,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -6010,6 +6043,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -6065,6 +6099,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -6138,6 +6173,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -6325,6 +6361,7 @@ mod tests {
 			solver: OperatorSolverConfig {
 				min_profitability_pct: Decimal::from_str("0.0").unwrap(),
 				gas_buffer_bps: 1000,
+				settlement_fee_buffer_bps: 1000,
 				commission_bps: 20,
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 30,
@@ -6417,6 +6454,10 @@ mod tests {
 		assert_eq!(
 			op_config.solver.gas_buffer_bps,
 			config.solver.gas_buffer_bps
+		);
+		assert_eq!(
+			op_config.solver.settlement_fee_buffer_bps,
+			config.solver.settlement_fee_buffer_bps
 		);
 		assert_eq!(
 			op_config.solver.commission_bps,
@@ -7350,6 +7391,7 @@ mod tests {
 			deny_list: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,

--- a/crates/solver-settlement/src/implementations/hyperlane.rs
+++ b/crates/solver-settlement/src/implementations/hyperlane.rs
@@ -8,7 +8,7 @@ use crate::{
 		address_to_bytes32, check_is_proven, create_providers_for_chains, parse_address_table,
 		parse_oracle_config, SettlementMessageTracker,
 	},
-	OracleConfig, SettlementError, SettlementInterface,
+	OracleConfig, PostFillFeeParams, SettlementError, SettlementFeeQuote, SettlementInterface,
 };
 use alloy_primitives::{hex, FixedBytes, U256};
 use alloy_provider::{DynProvider, Provider};
@@ -1004,6 +1004,52 @@ impl SettlementInterface for HyperlaneSettlement {
 		Box::new(HyperlaneSettlementSchema)
 	}
 
+	async fn quote_post_fill_fee(
+		&self,
+		params: &PostFillFeeParams,
+	) -> Result<Option<SettlementFeeQuote>, SettlementError> {
+		if self.get_output_oracles(params.dest_chain_id).is_empty()
+			|| self.get_input_oracles(params.origin_chain_id).is_empty()
+		{
+			return Ok(None);
+		}
+
+		let recipient_oracle = self
+			.select_oracle(&self.get_input_oracles(params.origin_chain_id), None)
+			.ok_or_else(|| SettlementError::ValidationFailed("No input oracle".into()))?;
+
+		let fill_description = encode_fill_description(
+			[0u8; 32],
+			[0u8; 32],
+			0,
+			params.output_token,
+			params.output_amount,
+			params.output_recipient,
+			params.output_call.clone(),
+			vec![],
+		)?;
+		let payloads = vec![fill_description];
+		let total_payload_size: usize = payloads.iter().map(|p| p.len()).sum();
+		let gas_limit = self.calculate_message_gas_limit(total_payload_size);
+
+		let fee_wei = self
+			.estimate_gas_payment(
+				params.dest_chain_id,
+				params.origin_chain_id as u32,
+				recipient_oracle,
+				gas_limit,
+				vec![],
+				params.source_settler.clone(),
+				payloads,
+			)
+			.await?;
+
+		Ok(Some(SettlementFeeQuote {
+			fee_wei,
+			chain_id: params.dest_chain_id,
+		}))
+	}
+
 	async fn get_attestation(
 		&self,
 		order: &Order,
@@ -1424,10 +1470,13 @@ impl crate::SettlementRegistry for Registry {}
 mod tests {
 	use super::*;
 	use crate::OracleSelectionStrategy;
+	use alloy_provider::ProviderBuilder;
 	use solver_types::standards::eip7683::MandateOutput;
 	use solver_types::utils::tests::builders::{
 		Eip7683OrderDataBuilder, MandateOutputBuilder, OrderBuilder,
 	};
+	use wiremock::matchers::method;
+	use wiremock::{Mock, MockServer, ResponseTemplate};
 
 	fn test_storage() -> Arc<StorageService> {
 		Arc::new(StorageService::new(Box::new(
@@ -1438,6 +1487,20 @@ mod tests {
 	fn test_hyperlane_settlement(oracle_config: OracleConfig) -> HyperlaneSettlement {
 		HyperlaneSettlement {
 			providers: HashMap::new(),
+			oracle_config,
+			mailbox_addresses: HashMap::new(),
+			igp_addresses: HashMap::new(),
+			message_tracker: Arc::new(MessageTracker::new(test_storage())),
+			default_gas_limit: 500_000,
+		}
+	}
+
+	fn test_hyperlane_settlement_with_providers(
+		oracle_config: OracleConfig,
+		providers: HashMap<u64, DynProvider>,
+	) -> HyperlaneSettlement {
+		HyperlaneSettlement {
+			providers,
 			oracle_config,
 			mailbox_addresses: HashMap::new(),
 			igp_addresses: HashMap::new(),
@@ -1931,6 +1994,85 @@ mod tests {
 			ready,
 			"can_claim must return true when PostFill is not required and message_id is missing"
 		);
+	}
+
+	#[tokio::test]
+	async fn hyperlane_quotes_post_fill_fee_using_real_message_gas_limit() {
+		let server = MockServer::start().await;
+		let quoted_fee = U256::from(1_000_000_000_000_000_000u128);
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+				"jsonrpc": "2.0",
+				"id": 1,
+				"result": format!("0x{}", hex::encode(quoted_fee.to_be_bytes::<32>()))
+			})))
+			.mount(&server)
+			.await;
+
+		let origin_chain = 1u64;
+		let dest_chain = 2u64;
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let provider = ProviderBuilder::new()
+			.connect_http(server.uri().parse().expect("valid RPC URL"))
+			.erased();
+		let settlement = test_hyperlane_settlement_with_providers(
+			OracleConfig {
+				input_oracles: HashMap::from([(origin_chain, vec![input_oracle.clone()])]),
+				output_oracles: HashMap::from([(dest_chain, vec![output_oracle])]),
+				routes: HashMap::from([(origin_chain, vec![dest_chain])]),
+				selection_strategy: OracleSelectionStrategy::First,
+			},
+			HashMap::from([(dest_chain, provider)]),
+		);
+		let params = PostFillFeeParams {
+			origin_chain_id: origin_chain,
+			dest_chain_id: dest_chain,
+			output_token: [0x11; 32],
+			output_amount: U256::from(1000u64),
+			output_recipient: [0x22; 32],
+			output_call: vec![0xab, 0xcd],
+			source_settler: solver_types::Address(vec![0x55; 20]),
+		};
+		let expected_payload = encode_fill_description(
+			[0u8; 32],
+			[0u8; 32],
+			0,
+			params.output_token,
+			params.output_amount,
+			params.output_recipient,
+			params.output_call.clone(),
+			vec![],
+		)
+		.unwrap();
+		let expected_gas_limit = settlement.calculate_message_gas_limit(expected_payload.len());
+
+		let quote = settlement
+			.quote_post_fill_fee(&params)
+			.await
+			.unwrap()
+			.expect("hyperlane route has a fee");
+		assert_eq!(quote.fee_wei, quoted_fee);
+		assert_eq!(quote.chain_id, dest_chain);
+
+		let requests = server.received_requests().await.unwrap();
+		assert_eq!(requests.len(), 1);
+		let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+		let input_hex = body["params"][0]["input"].as_str().unwrap();
+		let input = hex::decode(input_hex.trim_start_matches("0x")).unwrap();
+		let decoded = IHyperlaneOracle::quoteGasPayment_0Call::abi_decode(&input).unwrap();
+		assert_eq!(decoded.destinationDomain, origin_chain as u32);
+		assert_eq!(
+			decoded.recipientOracle,
+			alloy_primitives::Address::from_slice(&input_oracle.0)
+		);
+		assert_eq!(decoded.gasLimit, expected_gas_limit);
+		assert_eq!(
+			decoded.source,
+			alloy_primitives::Address::from_slice(&params.source_settler.0)
+		);
+		assert_eq!(decoded.payloads.len(), 1);
+		assert_eq!(decoded.payloads[0].as_ref(), expected_payload.as_slice());
 	}
 
 	#[tokio::test]

--- a/crates/solver-settlement/src/lib.rs
+++ b/crates/solver-settlement/src/lib.rs
@@ -163,6 +163,31 @@ pub struct OracleConfig {
 	pub selection_strategy: OracleSelectionStrategy,
 }
 
+/// Inputs needed to quote a settlement backend's native post-fill message fee.
+///
+/// Callers derive the output fields from quote/order data, while payload encoding
+/// and backend-specific fee mechanics stay owned by the settlement implementation.
+#[derive(Debug, Clone)]
+pub struct PostFillFeeParams {
+	pub origin_chain_id: u64,
+	pub dest_chain_id: u64,
+	pub output_token: [u8; 32],
+	pub output_amount: alloy_primitives::U256,
+	pub output_recipient: [u8; 32],
+	pub output_call: Vec<u8>,
+	/// Output settler that attests on the destination chain.
+	pub source_settler: Address,
+}
+
+/// Native-token settlement-message fee quote returned by a backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettlementFeeQuote {
+	/// Native `msg.value` paid by the settlement transaction.
+	pub fee_wei: alloy_primitives::U256,
+	/// Chain whose native token denominates `fee_wei`.
+	pub chain_id: u64,
+}
+
 /// Trait defining the interface for settlement mechanisms.
 ///
 /// This trait must be implemented by each settlement mechanism to handle
@@ -264,6 +289,17 @@ pub trait SettlementInterface: Send + Sync {
 	/// with specific validation rules. The schema is used to validate TOML configuration
 	/// before initializing the settlement mechanism.
 	fn config_schema(&self) -> Box<dyn ConfigSchema>;
+
+	/// Quote the native-token fee this backend attaches to its post-fill message.
+	///
+	/// Backends without a native post-fill fee use the default `None`. Callers should
+	/// treat `Err` as unpriceable for routes that require the backend.
+	async fn quote_post_fill_fee(
+		&self,
+		_params: &PostFillFeeParams,
+	) -> Result<Option<SettlementFeeQuote>, SettlementError> {
+		Ok(None)
+	}
 
 	/// Gets attestation data for a filled order by extracting proof data needed for claiming.
 	///
@@ -453,6 +489,31 @@ impl SettlementService {
 	/// Get the configured poll interval for settlement monitoring
 	pub fn poll_interval_seconds(&self) -> u64 {
 		self.poll_interval_seconds
+	}
+
+	/// Quote the native post-fill fee from the primary settlement implementation.
+	pub async fn quote_post_fill_fee_primary(
+		&self,
+		params: &PostFillFeeParams,
+	) -> Result<Option<SettlementFeeQuote>, SettlementError> {
+		let settlement = self.implementations.get(&self.primary).ok_or_else(|| {
+			SettlementError::ValidationFailed(format!(
+				"Primary settlement '{}' not found",
+				self.primary
+			))
+		})?;
+		settlement.quote_post_fill_fee(params).await
+	}
+
+	/// Quote the native post-fill fee using the settlement bound to an order.
+	pub async fn quote_post_fill_fee_for_order(
+		&self,
+		order: &Order,
+		params: &PostFillFeeParams,
+	) -> Result<Option<SettlementFeeQuote>, SettlementError> {
+		self.find_settlement_for_order(order)?
+			.quote_post_fill_fee(params)
+			.await
 	}
 
 	/// Check whether the L2 block-hash buffer needs to be advanced for an order.
@@ -840,6 +901,8 @@ mod tests {
 		buffer_coverage: Option<(PusherDirection, u64)>,
 		post_fill_tx: Option<Transaction>,
 		pre_claim_tx: Option<Transaction>,
+		post_fill_fee_quote: Option<SettlementFeeQuote>,
+		post_fill_fee_should_fail: bool,
 	}
 
 	#[async_trait]
@@ -850,6 +913,18 @@ mod tests {
 
 		fn config_schema(&self) -> Box<dyn ConfigSchema> {
 			Box::new(TestSchema)
+		}
+
+		async fn quote_post_fill_fee(
+			&self,
+			_params: &PostFillFeeParams,
+		) -> Result<Option<SettlementFeeQuote>, SettlementError> {
+			if self.post_fill_fee_should_fail {
+				return Err(SettlementError::ValidationFailed(
+					"fee quote failed".to_string(),
+				));
+			}
+			Ok(self.post_fill_fee_quote.clone())
 		}
 
 		async fn get_attestation(
@@ -955,6 +1030,8 @@ mod tests {
 			buffer_coverage: None,
 			post_fill_tx: None,
 			pre_claim_tx: None,
+			post_fill_fee_quote: None,
+			post_fill_fee_should_fail: false,
 		}
 	}
 
@@ -1145,6 +1222,124 @@ mod tests {
 			readiness,
 			SettlementReadiness::Waiting(WaitingReason::Unknown)
 		));
+	}
+
+	#[tokio::test]
+	async fn default_post_fill_fee_quote_returns_none() {
+		let settlement = make_test_settlement(OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		let params = PostFillFeeParams {
+			origin_chain_id: 1,
+			dest_chain_id: 2,
+			output_token: [0u8; 32],
+			output_amount: alloy_primitives::U256::from(1u64),
+			output_recipient: [0u8; 32],
+			output_call: vec![],
+			source_settler: addr(0x11),
+		};
+
+		assert!(settlement
+			.quote_post_fill_fee(&params)
+			.await
+			.unwrap()
+			.is_none());
+	}
+
+	fn sample_post_fill_fee_params() -> PostFillFeeParams {
+		PostFillFeeParams {
+			origin_chain_id: 1,
+			dest_chain_id: 2,
+			output_token: [0u8; 32],
+			output_amount: alloy_primitives::U256::from(1u64),
+			output_recipient: [0u8; 32],
+			output_call: vec![],
+			source_settler: addr(0x11),
+		}
+	}
+
+	#[tokio::test]
+	async fn service_routes_post_fill_fee_quote_to_primary() {
+		let mut settlement = make_test_settlement(OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		settlement.post_fill_fee_quote = Some(SettlementFeeQuote {
+			fee_wei: alloy_primitives::U256::from(5u64),
+			chain_id: 2,
+		});
+		let service = SettlementService::new(
+			HashMap::from([(
+				"primary_impl".to_string(),
+				Box::new(settlement) as Box<dyn SettlementInterface>,
+			)]),
+			"primary_impl".to_string(),
+			20,
+		);
+
+		let quote = service
+			.quote_post_fill_fee_primary(&sample_post_fill_fee_params())
+			.await
+			.unwrap()
+			.unwrap();
+
+		assert_eq!(quote.fee_wei, alloy_primitives::U256::from(5u64));
+		assert_eq!(quote.chain_id, 2);
+	}
+
+	#[tokio::test]
+	async fn service_routes_post_fill_fee_quote_to_order_binding() {
+		let mut settlement = make_test_settlement(OracleConfig {
+			input_oracles: HashMap::new(),
+			output_oracles: HashMap::new(),
+			routes: HashMap::new(),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		settlement.post_fill_fee_quote = Some(SettlementFeeQuote {
+			fee_wei: alloy_primitives::U256::from(7u64),
+			chain_id: 2,
+		});
+		let service = SettlementService::new(
+			HashMap::from([(
+				"bound".to_string(),
+				Box::new(settlement) as Box<dyn SettlementInterface>,
+			)]),
+			"missing_primary".to_string(),
+			20,
+		);
+		let order = OrderBuilder::new()
+			.with_settlement_name(Some("bound"))
+			.build();
+
+		let quote = service
+			.quote_post_fill_fee_for_order(&order, &sample_post_fill_fee_params())
+			.await
+			.unwrap()
+			.unwrap();
+
+		assert_eq!(quote.fee_wei, alloy_primitives::U256::from(7u64));
+		assert_eq!(quote.chain_id, 2);
+	}
+
+	#[tokio::test]
+	async fn service_fails_closed_when_primary_missing_for_post_fill_fee_quote() {
+		let service = SettlementService::new(HashMap::new(), "missing".to_string(), 20);
+
+		let err = service
+			.quote_post_fill_fee_primary(&sample_post_fill_fee_params())
+			.await
+			.unwrap_err();
+
+		assert!(
+			err.to_string()
+				.contains("Primary settlement 'missing' not found"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/crates/solver-types/src/admin_api.rs
+++ b/crates/solver-types/src/admin_api.rs
@@ -128,6 +128,7 @@ pub struct AdminTokenResponse {
 pub struct AdminSolverResponse {
 	pub min_profitability_pct: String,
 	pub gas_buffer_bps: u32,
+	pub settlement_fee_buffer_bps: u32,
 	pub commission_bps: u32,
 	pub rate_buffer_bps: u32,
 }
@@ -151,6 +152,7 @@ pub struct AdminConfigSummary {
 pub struct FeeConfigResponse {
 	pub min_profitability_pct: String,
 	pub gas_buffer_bps: u32,
+	pub settlement_fee_buffer_bps: u32,
 	pub commission_bps: u32,
 	pub rate_buffer_bps: u32,
 	pub monitoring_timeout_seconds: u64,

--- a/crates/solver-types/src/costs.rs
+++ b/crates/solver-types/src/costs.rs
@@ -32,6 +32,10 @@ pub struct CostBreakdown {
 	pub gas_claim: Decimal,
 	#[serde(with = "rust_decimal::serde::str")]
 	pub gas_buffer: Decimal,
+	#[serde(default, with = "rust_decimal::serde::str")]
+	pub settlement_fee: Decimal,
+	#[serde(default, with = "rust_decimal::serde::str")]
+	pub settlement_fee_buffer: Decimal,
 
 	// Market components
 	#[serde(with = "rust_decimal::serde::str")]
@@ -75,4 +79,33 @@ pub struct CostContext {
 	/// For ExactInput: inputs unchanged, outputs = swap_amounts - cost_amounts
 	/// For ExactOutput: outputs unchanged, inputs = swap_amounts + cost_amounts
 	pub adjusted_amounts: HashMap<InteropAddress, TokenAmountInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn cost_breakdown_deserializes_legacy_json_without_settlement_fee() {
+		let legacy = r#"{
+			"gas_open":"1",
+			"gas_fill":"2",
+			"gas_post_fill":"0",
+			"gas_pre_claim":"0",
+			"gas_claim":"1",
+			"gas_buffer":"0",
+			"rate_buffer":"0",
+			"base_price":"0",
+			"min_profit":"0",
+			"operational_cost":"4",
+			"subtotal":"4",
+			"total":"4",
+			"currency":"USD"
+		}"#;
+
+		let breakdown: CostBreakdown = serde_json::from_str(legacy).unwrap();
+
+		assert_eq!(breakdown.settlement_fee, Decimal::ZERO);
+		assert_eq!(breakdown.settlement_fee_buffer, Decimal::ZERO);
+	}
 }

--- a/crates/solver-types/src/operator_config.rs
+++ b/crates/solver-types/src/operator_config.rs
@@ -544,6 +544,11 @@ pub struct OperatorSolverConfig {
 	#[serde(default = "default_gas_buffer_bps")]
 	pub gas_buffer_bps: u32,
 
+	/// Settlement native fee buffer in basis points (e.g., 1000 = 10%).
+	/// Applied as safety margin on native settlement message fee quotes.
+	#[serde(default = "default_settlement_fee_buffer_bps")]
+	pub settlement_fee_buffer_bps: u32,
+
 	/// Commission in basis points (e.g., 20 = 0.20%).
 	/// Added to solver profit requirement.
 	#[serde(default = "default_commission_bps")]
@@ -565,6 +570,10 @@ pub struct OperatorSolverConfig {
 }
 
 fn default_gas_buffer_bps() -> u32 {
+	1000 // 10%
+}
+
+fn default_settlement_fee_buffer_bps() -> u32 {
 	1000 // 10%
 }
 
@@ -1134,6 +1143,7 @@ mod tests {
 			solver: OperatorSolverConfig {
 				min_profitability_pct: Decimal::ONE,
 				gas_buffer_bps: 1000,
+				settlement_fee_buffer_bps: 1000,
 				commission_bps: 20,
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 28800,
@@ -1248,5 +1258,17 @@ mod tests {
 			OperatorSettlementType::Hyperlane
 		);
 		assert!(parsed.settlement.hyperlane.is_some());
+	}
+
+	#[test]
+	fn test_operator_solver_config_defaults_settlement_fee_buffer_bps() {
+		let json = serde_json::json!({
+			"min_profitability_pct": "1",
+			"monitoring_timeout_seconds": 28800
+		});
+
+		let parsed: OperatorSolverConfig = serde_json::from_value(json).unwrap();
+
+		assert_eq!(parsed.settlement_fee_buffer_bps, 1000);
 	}
 }

--- a/crates/solver-types/src/seed_overrides.rs
+++ b/crates/solver-types/src/seed_overrides.rs
@@ -25,6 +25,7 @@
 //!   "orders_auth_enabled": true,
 //!   "min_profitability_pct": "2.0",
 //!   "gas_buffer_bps": 1500,
+//!   "settlement_fee_buffer_bps": 2000,
 //!   "admin": {
 //!     "enabled": true,
 //!     "domain": "solver.example.com",
@@ -97,6 +98,11 @@ pub struct SeedOverrides {
 	/// If not set, uses default (1000 = 10%).
 	#[serde(default)]
 	pub gas_buffer_bps: Option<u32>,
+
+	/// Settlement native fee buffer in basis points (e.g., 1000 = 10%).
+	/// If not set, uses default (1000 = 10%).
+	#[serde(default)]
+	pub settlement_fee_buffer_bps: Option<u32>,
 
 	/// Commission in basis points (e.g., 20 = 0.20%).
 	/// If not set, uses default.
@@ -723,6 +729,7 @@ mod tests {
 			orders_auth_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -762,6 +769,7 @@ mod tests {
 			orders_auth_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -806,6 +814,7 @@ mod tests {
 			orders_auth_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -890,6 +899,7 @@ mod tests {
 			orders_auth_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
+			settlement_fee_buffer_bps: None,
 			commission_bps: None,
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
@@ -927,6 +937,7 @@ mod tests {
             ],
             "min_profitability_pct": "2.5",
             "gas_buffer_bps": 1500,
+            "settlement_fee_buffer_bps": 2000,
             "commission_bps": 20,
             "rate_buffer_bps": 14
         }"#;
@@ -938,6 +949,7 @@ mod tests {
 			Some(Decimal::from_str("2.5").unwrap())
 		);
 		assert_eq!(config.gas_buffer_bps, Some(1500));
+		assert_eq!(config.settlement_fee_buffer_bps, Some(2000));
 		assert_eq!(config.commission_bps, Some(20));
 		assert_eq!(config.rate_buffer_bps, Some(14));
 	}
@@ -964,6 +976,7 @@ mod tests {
 			Some(Decimal::from_str("3.0").unwrap())
 		);
 		assert_eq!(config.gas_buffer_bps, None);
+		assert_eq!(config.settlement_fee_buffer_bps, None);
 		assert_eq!(config.commission_bps, None);
 		assert_eq!(config.rate_buffer_bps, None);
 	}
@@ -985,6 +998,7 @@ mod tests {
 
 		assert_eq!(config.min_profitability_pct, None);
 		assert_eq!(config.gas_buffer_bps, None);
+		assert_eq!(config.settlement_fee_buffer_bps, None);
 		assert_eq!(config.commission_bps, None);
 		assert_eq!(config.rate_buffer_bps, None);
 	}

--- a/crates/solver-types/src/utils/eip712.rs
+++ b/crates/solver-types/src/utils/eip712.rs
@@ -808,6 +808,7 @@ pub fn admin_eip712_types() -> serde_json::Value {
 		],
 		"UpdateFeeConfig": [
 			{"name": "gasBufferBps", "type": "uint32"},
+			{"name": "settlementFeeBufferBps", "type": "uint32"},
 			{"name": "minProfitabilityPct", "type": "string"},
 			{"name": "commissionBps", "type": "uint32"},
 			{"name": "rateBufferBps", "type": "uint32"},
@@ -1984,14 +1985,16 @@ mod tests {
 			.as_array()
 			.expect("should be an array");
 
-		// UpdateFeeConfig should have: gasBufferBps, minProfitabilityPct, commissionBps, rateBufferBps, nonce, deadline
-		assert_eq!(fee_config.len(), 6);
+		// UpdateFeeConfig should have: gasBufferBps, settlementFeeBufferBps, minProfitabilityPct,
+		// commissionBps, rateBufferBps, nonce, deadline.
+		assert_eq!(fee_config.len(), 7);
 
 		let names: Vec<&str> = fee_config
 			.iter()
 			.map(|f| f["name"].as_str().unwrap())
 			.collect();
 		assert!(names.contains(&"gasBufferBps"));
+		assert!(names.contains(&"settlementFeeBufferBps"));
 		assert!(names.contains(&"minProfitabilityPct"));
 		assert!(names.contains(&"commissionBps"));
 		assert!(names.contains(&"rateBufferBps"));


### PR DESCRIPTION
- Introduced  to  for native fee margin configuration.
- Updated  to include  with a default value.
- Enhanced  to calculate and quote settlement fees during transaction processing.
- Added tests to verify default values and functionality of the new settlement fee buffer.
- Updated various APIs and data structures to accommodate the new settlement fee buffer configuration.

# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable settlement fee buffer parameter (defaults to 10%) for managing post-fill settlement costs.
  * Admin API now supports retrieving and updating settlement fee buffer settings.
  * Post-fill settlement fee quoting capability added to the settlement layer.

* **Improvements**
  * Cost and profit calculations now incorporate settlement fees and buffers in margin analysis.
  * API responses include detailed settlement fee breakdown information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->