### PR TITLE
h-22 fix: reject unsupported intent assets before fill simulation

### DIFF
--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -1237,6 +1237,18 @@ impl CostProfitService {
 		Ok(())
 	}
 
+	/// Returns true if `recipient_interop_hex` is permitted by the configured
+	/// callback whitelist. An empty whitelist means "allow all callbacks",
+	/// matching the quote-time contract in solver-service's
+	/// `validate_callback_whitelist`.
+	fn callback_recipient_whitelisted(config: &Config, recipient_interop_hex: &str) -> bool {
+		let whitelist = &config.order.callback_whitelist;
+		whitelist.is_empty()
+			|| whitelist
+				.iter()
+				.any(|entry| entry.to_lowercase() == recipient_interop_hex)
+	}
+
 	fn validate_callback_policy_before_simulation(
 		outputs: &[OrderOutput],
 		config: &Config,
@@ -1268,11 +1280,8 @@ impl CostProfitService {
 				.map(|addr| format!("0x{}", alloy_primitives::hex::encode(addr)))
 				.unwrap_or_else(|_| "unknown".to_string());
 
-			let is_whitelisted = config
-				.order
-				.callback_whitelist
-				.iter()
-				.any(|entry| entry.to_lowercase() == recipient_interop_hex);
+			let is_whitelisted =
+				Self::callback_recipient_whitelisted(config, &recipient_interop_hex);
 
 			if !is_whitelisted {
 				return Err(CostProfitError::Config(format!(
@@ -2618,11 +2627,7 @@ impl CostProfitService {
 
 		// Check whitelist using EIP-7930 InteropAddress format
 		// Whitelist entries should be in EIP-7930 hex format (e.g., "0x0001000002210514...")
-		let is_whitelisted = config
-			.order
-			.callback_whitelist
-			.iter()
-			.any(|entry| entry.to_lowercase() == recipient_interop_hex);
+		let is_whitelisted = Self::callback_recipient_whitelisted(config, &recipient_interop_hex);
 
 		if !is_whitelisted {
 			tracing::warn!(
@@ -5299,8 +5304,12 @@ mod tests {
 		let order = create_order_with_callback(callback_data);
 		let fill_tx = create_test_fill_transaction();
 
-		// Empty whitelist - recipient not whitelisted
-		let config = create_config_with_callback_whitelist(vec![]);
+		// Non-empty whitelist that does NOT contain the recipient (0x2222..).
+		// An empty whitelist would mean allow-all, so a different address is
+		// used here to exercise the genuine "not whitelisted" rejection path.
+		let config = create_config_with_callback_whitelist(vec![
+			"0x000100000189149999999999999999999999999999999999999999".to_string(),
+		]);
 
 		// Act
 		let result = service
@@ -5316,6 +5325,97 @@ mod tests {
 			},
 			other => panic!("Expected Config error, got: {other:?}"),
 		}
+	}
+
+	#[tokio::test]
+	async fn test_simulate_callback_empty_whitelist_allows_all() {
+		// An empty callback_whitelist means "allow all callbacks" (the same
+		// contract enforced at quote time by validate_callback_whitelist). A
+		// callback to any recipient must therefore be simulated, not rejected.
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery.expect_config_schema().returning(|| {
+			Box::new(solver_delivery::implementations::evm::alloy::AlloyDeliverySchema)
+		});
+		mock_delivery
+			.expect_estimate_gas()
+			.returning(|_| Box::pin(async move { Ok(95000u64) }));
+
+		let mut delivery_implementations = HashMap::new();
+		delivery_implementations.insert(
+			137,
+			Arc::new(mock_delivery) as Arc<dyn solver_delivery::DeliveryInterface>,
+		);
+		let delivery = Arc::new(DeliveryService::new(
+			delivery_implementations,
+			137,
+			3600,
+			60,
+		));
+
+		let mock_pricing = MockPricingInterface::new();
+		let mock_storage = MockStorageInterface::new();
+		let pricing = Arc::new(PricingService::new(Box::new(mock_pricing), Vec::new()));
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let token_manager = create_mock_token_manager();
+
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
+
+		let callback_data = vec![0xde, 0xad, 0xbe, 0xef];
+		let order = create_order_with_callback(callback_data);
+		let fill_tx = create_test_fill_transaction();
+		// Empty whitelist = allow all callbacks.
+		let config = create_config_with_callback_whitelist(vec![]);
+
+		let result = service
+			.simulate_callback_and_estimate_gas(&order, &fill_tx, &config)
+			.await;
+
+		assert!(
+			result.is_ok(),
+			"empty whitelist must allow all callbacks, got: {result:?}"
+		);
+		let simulation_result = result.unwrap();
+		assert!(simulation_result.has_callback);
+		assert_eq!(simulation_result.estimated_gas_units, 95000);
+	}
+
+	#[test]
+	fn callback_recipient_whitelisted_empty_allows_all() {
+		let config = create_config_with_callback_whitelist(vec![]);
+		assert!(
+			CostProfitService::callback_recipient_whitelisted(
+				&config,
+				"0x000100000189142222222222222222222222222222222222222222"
+			),
+			"empty whitelist must allow any recipient"
+		);
+	}
+
+	#[test]
+	fn callback_recipient_whitelisted_nonempty_checks_membership() {
+		let config = create_config_with_callback_whitelist(vec![
+			"0x000100000189142222222222222222222222222222222222222222".to_string(),
+		]);
+		assert!(
+			CostProfitService::callback_recipient_whitelisted(
+				&config,
+				"0x000100000189142222222222222222222222222222222222222222"
+			),
+			"listed recipient must be allowed"
+		);
+		assert!(
+			!CostProfitService::callback_recipient_whitelisted(
+				&config,
+				"0x000100000189149999999999999999999999999999999999999999"
+			),
+			"unlisted recipient must be rejected when whitelist is non-empty"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -1122,6 +1122,128 @@ impl CostProfitService {
 			.await
 	}
 
+	/// Performs cheap local validation that must happen before fill simulation.
+	///
+	/// This avoids spending RPC capacity on `eth_estimateGas` for orders whose
+	/// assets or callback payloads are known locally to be unsupported.
+	pub async fn validate_before_fill_simulation(
+		&self,
+		order: &Order,
+		config: &Config,
+	) -> Result<(), CostProfitError> {
+		let order_parsed = order.parse_order_data().map_err(|e| APIError::BadRequest {
+			error_type: ApiErrorType::InvalidRequest,
+			message: format!("Failed to parse order data: {e}"),
+			details: None,
+		})?;
+
+		let available_inputs = order_parsed.parse_available_inputs();
+		let requested_outputs = order_parsed.parse_requested_outputs();
+
+		for input in &available_inputs {
+			let chain_id = input.asset.ethereum_chain_id().map_err(|e| {
+				CostProfitError::Calculation(format!("Failed to get input chain ID: {e}"))
+			})?;
+			let ethereum_addr = input.asset.ethereum_address().map_err(|e| {
+				CostProfitError::Calculation(format!("Failed to get input token address: {e}"))
+			})?;
+			let token_address = Address(ethereum_addr.0.to_vec());
+			self.token_manager
+				.get_token_info(chain_id, &token_address)
+				.await?;
+		}
+
+		for output in &requested_outputs {
+			let chain_id = output.asset.ethereum_chain_id().map_err(|e| {
+				CostProfitError::Calculation(format!("Failed to get output chain ID: {e}"))
+			})?;
+			let ethereum_addr = output.asset.ethereum_address().map_err(|e| {
+				CostProfitError::Calculation(format!("Failed to get output token address: {e}"))
+			})?;
+			let token_address = Address(ethereum_addr.0.to_vec());
+			self.token_manager
+				.get_token_info(chain_id, &token_address)
+				.await?;
+
+			Self::validate_callback_calldata(output.calldata.as_deref())?;
+		}
+
+		Self::validate_callback_policy_before_simulation(&requested_outputs, config)
+	}
+
+	fn validate_callback_calldata(calldata: Option<&str>) -> Result<(), CostProfitError> {
+		let Some(calldata) = calldata else {
+			return Ok(());
+		};
+		let hex_payload = calldata.strip_prefix("0x").unwrap_or(calldata);
+		if hex_payload.is_empty() {
+			return Ok(());
+		}
+		if hex_payload.len() % 2 != 0 {
+			return Err(CostProfitError::Calculation(
+				"Output callbackData must be valid hex".to_string(),
+			));
+		}
+		let byte_len = hex_payload.len() / 2;
+		if byte_len > u16::MAX as usize {
+			return Err(CostProfitError::Calculation(format!(
+				"Output callbackData is too large: {byte_len} bytes exceeds {} byte limit",
+				u16::MAX
+			)));
+		}
+		alloy_primitives::hex::decode(hex_payload).map_err(|e| {
+			CostProfitError::Calculation(format!("Output callbackData must be valid hex: {e}"))
+		})?;
+		Ok(())
+	}
+
+	fn validate_callback_policy_before_simulation(
+		outputs: &[OrderOutput],
+		config: &Config,
+	) -> Result<(), CostProfitError> {
+		for output in outputs {
+			let has_callback = output
+				.calldata
+				.as_ref()
+				.is_some_and(|c| !c.is_empty() && c != "0x");
+			if !has_callback {
+				continue;
+			}
+
+			if !config.order.simulate_callbacks {
+				return Err(CostProfitError::Config(
+					"Order has callback data but callback simulation is disabled. \
+					Callbacks are not supported when simulate_callbacks = false in config."
+						.to_string(),
+				));
+			}
+
+			let recipient_interop_hex = output.receiver.to_hex().to_lowercase();
+			let output_chain_id = output.receiver.ethereum_chain_id().map_err(|e| {
+				CostProfitError::Config(format!("Failed to extract chain ID from recipient: {e}"))
+			})?;
+			let recipient_eth_address = output
+				.receiver
+				.ethereum_address()
+				.map(|addr| format!("0x{}", alloy_primitives::hex::encode(addr)))
+				.unwrap_or_else(|_| "unknown".to_string());
+
+			let is_whitelisted = config
+				.order
+				.callback_whitelist
+				.iter()
+				.any(|entry| entry.to_lowercase() == recipient_interop_hex);
+
+			if !is_whitelisted {
+				return Err(CostProfitError::Config(format!(
+					"Callback recipient {recipient_eth_address} on chain {output_chain_id} not in whitelist. Add '{recipient_interop_hex}' to order.callback_whitelist in config (EIP-7930 format)"
+				)));
+			}
+		}
+
+		Ok(())
+	}
+
 	/// Estimates the cost for an order with an optional simulated fill gas override.
 	///
 	/// When `simulated_fill_gas` is provided (from `eth_estimateGas`), it will be used

--- a/crates/solver-core/src/handlers/intent.rs
+++ b/crates/solver-core/src/handlers/intent.rs
@@ -359,6 +359,21 @@ impl IntentHandler {
 					}
 				}
 
+				if let Err(e) = self
+					.cost_profit_service
+					.validate_before_fill_simulation(&order, &config)
+					.await
+				{
+					tracing::warn!("Order failed pre-simulation validation: {}", e);
+					self.event_bus
+						.publish(SolverEvent::Order(OrderEvent::Skipped {
+							order_id: order.id.clone(),
+							reason: format!("Pre-simulation validation failed: {e}"),
+						}))
+						.ok();
+					return Ok(());
+				}
+
 				// Step 1: Generate fill transaction and simulate to get accurate gas estimate
 				// This also validates callbacks won't revert
 				let default_params = ExecutionParams {
@@ -570,7 +585,7 @@ mod tests {
 	use solver_pricing::{MockPricingInterface, PricingService};
 	use solver_storage::{MockStorageInterface, StorageError};
 	use solver_types::utils::tests::builders::{
-		Eip7683OrderDataBuilder, IntentBuilder, OrderBuilder,
+		Eip7683OrderDataBuilder, IntentBuilder, MandateOutputBuilder, OrderBuilder,
 	};
 	use solver_types::{Address, DiscoveryEvent, ExecutionParams, Intent, Order, SolverEvent};
 	use std::collections::HashMap;
@@ -599,6 +614,37 @@ mod tests {
 			.with_id("test_intent_123".to_string())
 			.with_data(serde_json::to_value(&order_data).unwrap())
 			.build()
+	}
+
+	fn create_test_order_from_data(order_data: Eip7683OrderData) -> Order {
+		OrderBuilder::new()
+			.with_id("test_intent_123".to_string())
+			.with_data(serde_json::to_value(&order_data).unwrap())
+			.build()
+	}
+
+	fn address20_to_bytes32(address: [u8; 20]) -> [u8; 32] {
+		let mut bytes = [0u8; 32];
+		bytes[12..].copy_from_slice(&address);
+		bytes
+	}
+
+	fn create_test_order_with_unsupported_output_token() -> Order {
+		let mut order_data = Eip7683OrderDataBuilder::new().build();
+		order_data.outputs[0].token = address20_to_bytes32([0x44; 20]);
+		create_test_order_from_data(order_data)
+	}
+
+	fn create_test_order_with_oversized_callback_data() -> Order {
+		let output = MandateOutputBuilder::new()
+			.chain_id(U256::from(137))
+			.token([0u8; 32])
+			.amount(U256::from(95u64))
+			.recipient([0u8; 32])
+			.call(vec![0xab; u16::MAX as usize + 1])
+			.build();
+		let order_data = Eip7683OrderDataBuilder::new().outputs(vec![output]).build();
+		create_test_order_from_data(order_data)
 	}
 
 	fn create_test_address() -> Address {
@@ -987,6 +1033,162 @@ mod tests {
 
 		let result = handler.handle(intent).await;
 		assert!(result.is_ok());
+	}
+
+	#[tokio::test]
+	async fn test_handle_intent_rejects_unsupported_output_token_before_fill_simulation() {
+		let mut mock_storage = MockStorageInterface::new();
+		let mut mock_order_interface = MockOrderInterface::new();
+		let mut mock_strategy = MockExecutionStrategy::new();
+
+		let intent = create_test_intent();
+		let solver_address = create_test_address();
+
+		mock_storage
+			.expect_exists()
+			.with(eq("intents:0xtest_intent_123"))
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(false) }));
+		mock_storage
+			.expect_set_bytes()
+			.times(1)
+			.returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
+
+		mock_order_interface
+			.expect_validate_and_create_order()
+			.times(1)
+			.returning(move |_, _, _, _, _, _| {
+				Box::pin(async move { Ok(create_test_order_with_unsupported_output_token()) })
+			});
+		mock_order_interface
+			.expect_generate_fill_transaction()
+			.times(0);
+		mock_strategy.expect_should_execute().times(0);
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let order_service = Arc::new(OrderService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_order_interface) as Box<dyn solver_order::OrderInterface>,
+			)]),
+			Box::new(mock_strategy),
+		));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let mut receiver = event_bus.subscribe();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let token_manager = Arc::new(TokenManager::new(
+			Default::default(),
+			delivery.clone(),
+			Arc::new(solver_account::AccountService::new(Box::new(
+				MockAccountInterface::new(),
+			))),
+		));
+		let cost_profit_service = create_mock_cost_profit_service();
+		let (config, static_config) = create_test_config();
+
+		let handler = IntentHandler::new(
+			order_service,
+			storage,
+			state_machine,
+			event_bus,
+			delivery,
+			solver_address,
+			token_manager,
+			cost_profit_service,
+			config,
+			&static_config,
+		);
+
+		handler
+			.handle(intent)
+			.await
+			.expect("handler should skip unsupported token intent without error");
+
+		match receiver.recv().await.unwrap() {
+			SolverEvent::Order(OrderEvent::Skipped { reason, .. }) => {
+				assert!(reason.contains("Token not supported"));
+			},
+			other => panic!("Expected OrderEvent::Skipped, got {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn test_handle_intent_rejects_oversized_callback_before_fill_simulation() {
+		let mut mock_storage = MockStorageInterface::new();
+		let mut mock_order_interface = MockOrderInterface::new();
+		let mut mock_strategy = MockExecutionStrategy::new();
+
+		let intent = create_test_intent();
+		let solver_address = create_test_address();
+
+		mock_storage
+			.expect_exists()
+			.with(eq("intents:0xtest_intent_123"))
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(false) }));
+		mock_storage
+			.expect_set_bytes()
+			.times(1)
+			.returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
+
+		mock_order_interface
+			.expect_validate_and_create_order()
+			.times(1)
+			.returning(move |_, _, _, _, _, _| {
+				Box::pin(async move { Ok(create_test_order_with_oversized_callback_data()) })
+			});
+		mock_order_interface
+			.expect_generate_fill_transaction()
+			.times(0);
+		mock_strategy.expect_should_execute().times(0);
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let order_service = Arc::new(OrderService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_order_interface) as Box<dyn solver_order::OrderInterface>,
+			)]),
+			Box::new(mock_strategy),
+		));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let mut receiver = event_bus.subscribe();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let token_manager = Arc::new(TokenManager::new(
+			Default::default(),
+			delivery.clone(),
+			Arc::new(solver_account::AccountService::new(Box::new(
+				MockAccountInterface::new(),
+			))),
+		));
+		let cost_profit_service = create_mock_cost_profit_service();
+		let (config, static_config) = create_test_config();
+
+		let handler = IntentHandler::new(
+			order_service,
+			storage,
+			state_machine,
+			event_bus,
+			delivery,
+			solver_address,
+			token_manager,
+			cost_profit_service,
+			config,
+			&static_config,
+		);
+
+		handler
+			.handle(intent)
+			.await
+			.expect("handler should skip oversized callback intent without error");
+
+		match receiver.recv().await.unwrap() {
+			SolverEvent::Order(OrderEvent::Skipped { reason, .. }) => {
+				assert!(reason.contains("callbackData is too large"));
+			},
+			other => panic!("Expected OrderEvent::Skipped, got {other:?}"),
+		}
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-simulation validation for orders that checks token metadata resolution, callback policies, and configuration constraints before running fill simulations to improve efficiency.

* **Tests**
  * Added tests to verify invalid orders are properly rejected during validation and skipped before expensive simulation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->