### PR TITLE
h-18-27-30: clamp legacy gas price and improve nonce management

### DIFF
--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -243,6 +243,14 @@ enum NonceCacheAction {
 	AttemptRollback { rejected_nonce: Option<u64> },
 }
 
+fn nonce_too_low_retry_nonce_cache_action() -> NonceCacheAction {
+	// A nonce-too-low result proves this nonce is already consumed or held.
+	// Even if a follow-up pending read is stale, do not reclaim it.
+	NonceCacheAction::AttemptRollback {
+		rejected_nonce: None,
+	}
+}
+
 /// Outcome of a raw-send attempt, after pre-sign persisted the hash.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RawSendVerdict {
@@ -2663,9 +2671,7 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback {
-								rejected_nonce: tx_attempt.nonce,
-							},
+							nonce_too_low_retry_nonce_cache_action(),
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2677,7 +2683,7 @@ impl DeliveryInterface for AlloyDelivery {
 								cache_before = ?cache_before,
 								cache_after = ?cache_after,
 								error = %second_reason,
-								"nonce-too-low retry also returned nonce too low; nonce cache reconciled after scoped rollback"
+								"nonce-too-low retry also returned nonce too low; nonce cache kept forward-only"
 							);
 						} else {
 							tracing::warn!(
@@ -4115,6 +4121,28 @@ mod tests {
 			Some(102),
 			"must not reclaim a mid-sequence nonce while a higher nonce is in flight"
 		);
+	}
+
+	#[test]
+	fn nonce_too_low_retry_rollback_preserves_high_water_on_stale_pending() {
+		let mgr = ResettableNonceManager::new();
+		let signer = Address::ZERO;
+		mgr.set_next_nonce(signer, 100);
+		assert_eq!(mgr.take_next(signer), Some(100));
+		assert_eq!(mgr.peek(signer), Some(101));
+
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			nonce_too_low_retry_nonce_cache_action(),
+			Some(100),
+		);
+		assert_eq!(
+			after,
+			Some(101),
+			"nonce-too-low means the nonce is consumed/held; stale pending must not reclaim it"
+		);
+		assert_eq!(mgr.take_next(signer), Some(101));
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -229,11 +229,18 @@ pub struct AlloyDelivery {
 /// inside callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NonceCacheAction {
-	/// Tx provably rejected pre-pool. Caller should attempt to fetch
-	/// chain pending and call `reset_next_nonce`. If the fetch fails,
-	/// caller MUST keep the cache advanced — we don't roll back without
+	/// Tx provably rejected pre-pool (or never broadcast). Caller should
+	/// attempt to fetch chain pending and roll the cache back. If the fetch
+	/// fails, caller MUST keep the cache advanced — we don't roll back without
 	/// authoritative chain state.
-	AttemptRollback,
+	///
+	/// `rejected_nonce` is the nonce the rejected/never-broadcast tx was
+	/// allocated, when known. It lets the rollback *reclaim* that nonce
+	/// (closing the gap) via `reclaim_rejected_nonce` when it is provably safe
+	/// — i.e. it was the most recently handed-out nonce and the chain has not
+	/// advanced past it. `None` falls back to the forward-only
+	/// `reset_next_nonce` clamp.
+	AttemptRollback { rejected_nonce: Option<u64> },
 }
 
 /// Outcome of a raw-send attempt, after pre-sign persisted the hash.
@@ -407,8 +414,16 @@ fn apply_nonce_cache_action(
 	chain_pending: Option<u64>,
 ) -> Option<u64> {
 	match action {
-		NonceCacheAction::AttemptRollback => match chain_pending {
-			Some(pending) => Some(mgr.reset_next_nonce(signer, pending)),
+		NonceCacheAction::AttemptRollback { rejected_nonce } => match chain_pending {
+			// When the rejected nonce is known, try to reclaim it (close the
+			// gap) — safe only if it was the last nonce handed out and the
+			// chain has not advanced past it; otherwise this clamps forward
+			// exactly like `reset_next_nonce`. When unknown, fall back to the
+			// forward-only clamp.
+			Some(pending) => Some(match rejected_nonce {
+				Some(rejected) => mgr.reclaim_rejected_nonce(signer, rejected, pending).1,
+				None => mgr.reset_next_nonce(signer, pending),
+			}),
 			// No authoritative chain state — KEEP advanced. We never reset
 			// the cache without a successful pending-fetch.
 			None => mgr.peek(signer),
@@ -734,8 +749,11 @@ impl AlloyDelivery {
 	/// Returns the next nonce to use for `from` on `chain_id`, taking it from the
 	/// resettable cache. Every call samples chain `pending`, but normal allocation
 	/// is monotonic: a stale RPC pending nonce must not move the local cache
-	/// backward and reissue a nonce already handed out by this process. Backward
-	/// reset is reserved for the explicit `nonce too low` resync path.
+	/// backward and reissue a nonce already handed out by this process. The only
+	/// way the cache moves below its local high-water mark is reclaiming a
+	/// definitively-rejected nonce that was the last one handed out, via
+	/// `reclaim_rejected_nonce` (safe because that nonce's tx never entered a
+	/// pool); the `nonce too low` resync stays forward-only.
 	async fn next_nonce_for(&self, chain_id: u64, from: Address) -> Result<u64, DeliveryError> {
 		let provider = self.get_provider(chain_id)?;
 		let pending = provider
@@ -1208,7 +1226,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1276,7 +1296,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1724,8 +1746,12 @@ impl DeliveryInterface for AlloyDelivery {
 				}
 
 				// Roll back the nonce: fetch authoritative chain pending; on
-				// Some(pending) reset cache, on None keep it advanced (never
-				// roll back without authoritative state).
+				// Some(pending) reclaim the rejected nonce when it was the last
+				// one handed out (closing the gap), else keep the cache
+				// advanced; on None keep it advanced (never roll back without
+				// authoritative state). Passing the rejected nonce is what lets
+				// a fee-cap/base-fee rejection of a lone in-flight tx reclaim
+				// its nonce instead of wedging the signer (audit finding H-27).
 				let mgr = self.get_nonce_manager(chain_id)?;
 				let cache_before = mgr.peek(from);
 				let pending_result = provider.get_transaction_count(from).pending().await;
@@ -1736,7 +1762,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1863,10 +1891,18 @@ impl DeliveryInterface for AlloyDelivery {
 				}
 
 				// Resync the local nonce cache from chain pending.
-				// `reset_next_nonce` (not `set_next_nonce`) is used so a
-				// chain-pending value BELOW the local cache (the signature
-				// of a ghost broadcast we recovered from) can move the cache
-				// backward — the whole point of the resync.
+				//
+				// `reset_next_nonce` is a forward-only high-water clamp: it moves
+				// the cache UP to `fresh_pending` but never below the local
+				// high-water mark. That is the correct, H-18-safe behavior here.
+				// A `nonce too low` means the chain has advanced to or past our
+				// tx's nonce, so the retry must use the next nonce ABOVE every
+				// nonce this process has already handed out — never a (possibly
+				// stale or load-balanced) `pending` value below an in-flight
+				// nonce, which would reissue it and cause a same-nonce conflict
+				// (the H-18 reuse window). Reclaiming a nonce LEAKED by a
+				// never-broadcast / definitively-rejected tx is handled
+				// separately, at the rejection sites, via `reclaim_rejected_nonce`.
 				let mgr = self.get_nonce_manager(chain_id)?;
 				let fresh_pending = provider
 					.get_transaction_count(from)
@@ -1878,13 +1914,13 @@ impl DeliveryInterface for AlloyDelivery {
 						))
 					})?;
 				let cache_before_resync = mgr.peek(from);
-				mgr.reset_next_nonce(from, fresh_pending);
+				let cache_after_resync = mgr.reset_next_nonce(from, fresh_pending);
 				tracing::debug!(
 					chain_id,
 					signer = %from,
 					chain_pending = fresh_pending,
 					cache_before = ?cache_before_resync,
-					cache_after = fresh_pending,
+					cache_after = cache_after_resync,
 					"Nonce-too-low retry: nonce cache resynced from chain pending"
 				);
 
@@ -1931,7 +1967,9 @@ impl DeliveryInterface for AlloyDelivery {
 							let cache_after = apply_nonce_cache_action(
 								mgr,
 								from,
-								NonceCacheAction::AttemptRollback,
+								NonceCacheAction::AttemptRollback {
+									rejected_nonce: tx_attempt.nonce,
+								},
 								pending_opt,
 							);
 							if let Some(pending) = pending_opt {
@@ -2010,7 +2048,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2075,7 +2115,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2542,7 +2584,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2617,7 +2661,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -3969,14 +4015,23 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_nonce_cache_action_rollback_with_pending_preserves_high_water_cache() {
+	fn apply_nonce_cache_action_rollback_without_rejected_nonce_preserves_high_water_cache() {
 		use NonceCacheAction::*;
 		let mgr = ResettableNonceManager::new();
 		let signer = Address::ZERO;
 		mgr.reset_next_nonce(signer, 101);
 		assert_eq!(mgr.peek(signer), Some(101));
 
-		let after = apply_nonce_cache_action(&mgr, signer, AttemptRollback, Some(100));
+		// No rejected nonce supplied → forward-only clamp; must not move below
+		// the locally allocated high-water nonce.
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: None,
+			},
+			Some(100),
+		);
 		assert_eq!(
 			after,
 			Some(101),
@@ -3992,13 +4047,72 @@ mod tests {
 		let signer = Address::ZERO;
 		mgr.reset_next_nonce(signer, 101);
 
-		let after = apply_nonce_cache_action(&mgr, signer, AttemptRollback, None);
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			None,
+		);
 		assert_eq!(
 			after,
 			Some(101),
 			"no authoritative chain state → cache must NOT be reset"
 		);
 		assert_eq!(mgr.peek(signer), Some(101));
+	}
+
+	#[test]
+	fn apply_nonce_cache_action_rollback_reclaims_rejected_lone_nonce() {
+		// H-27 end-to-end at the policy layer: a lone in-flight tx at nonce 100
+		// is definitively rejected pre-pool. The cache (101) is rolled back so
+		// nonce 100 is reclaimed rather than permanently leaked.
+		use NonceCacheAction::*;
+		let mgr = ResettableNonceManager::new();
+		let signer = Address::ZERO;
+		mgr.set_next_nonce(signer, 100);
+		assert_eq!(mgr.take_next(signer), Some(100)); // allocate 100
+		assert_eq!(mgr.peek(signer), Some(101));
+
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			Some(100),
+		);
+		assert_eq!(after, Some(100), "rejected lone nonce must be reclaimed");
+		// The very next allocation re-hands-out 100 (no permanent gap / wedge).
+		assert_eq!(mgr.take_next(signer), Some(100));
+	}
+
+	#[test]
+	fn apply_nonce_cache_action_rollback_keeps_cache_when_higher_nonce_in_flight() {
+		// A newer nonce (101) is still in flight, so reclaiming the rejected
+		// nonce 100 would risk reissuing 101 — the cache must stay advanced.
+		use NonceCacheAction::*;
+		let mgr = ResettableNonceManager::new();
+		let signer = Address::ZERO;
+		mgr.set_next_nonce(signer, 100);
+		assert_eq!(mgr.take_next(signer), Some(100));
+		assert_eq!(mgr.take_next(signer), Some(101));
+		assert_eq!(mgr.peek(signer), Some(102));
+
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			Some(100),
+		);
+		assert_eq!(
+			after,
+			Some(102),
+			"must not reclaim a mid-sequence nonce while a higher nonce is in flight"
+		);
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -1209,9 +1209,9 @@ impl DeliveryInterface for AlloyDelivery {
 					.await;
 				}
 
-				// Rollback: fetch authoritative chain pending; on Some(pending)
-				// reset the cache, on None keep it advanced (no authoritative
-				// state — never roll back without it).
+				// Rollback: fetch authoritative chain pending; on success apply
+				// scoped reclaim/forward-only reconciliation, on failure keep it
+				// advanced (no authoritative state — never roll back without it).
 				let failed_nonce = first_attempt
 					.as_ref()
 					.and_then(|a| a.nonce)
@@ -1240,7 +1240,7 @@ impl DeliveryInterface for AlloyDelivery {
 						cache_before = ?cache_before,
 						cache_after = ?cache_after,
 						error = %err_msg,
-						"local signing failed before broadcast; nonce cache rolled back to chain pending"
+						"local signing failed before broadcast; nonce cache reconciled after scoped rollback"
 					);
 				} else {
 					tracing::error!(
@@ -1283,8 +1283,9 @@ impl DeliveryInterface for AlloyDelivery {
 				// Signed envelope exists locally but ledger durability cannot
 				// be proven — refuse to broadcast. Roll back the nonce since
 				// nothing went out: fetch authoritative chain pending; on
-				// Some(pending) reset the cache, on None keep it advanced
-				// (never roll back without authoritative state).
+				// success apply scoped reclaim/forward-only reconciliation,
+				// on failure keep it advanced (never roll back without
+				// authoritative state).
 				let failed_nonce = planned_attempt.nonce.unwrap();
 				let mgr = self.get_nonce_manager(chain_id)?;
 				let cache_before = mgr.peek(from);
@@ -1310,7 +1311,7 @@ impl DeliveryInterface for AlloyDelivery {
 						cache_before = ?cache_before,
 						cache_after = ?cache_after,
 						error = %persist_err,
-						"pre-broadcast hash persist failed; refusing to broadcast; nonce cache rolled back to chain pending"
+						"pre-broadcast hash persist failed; refusing to broadcast; nonce cache reconciled after scoped rollback"
 					);
 				} else {
 					tracing::error!(
@@ -1776,7 +1777,7 @@ impl DeliveryInterface for AlloyDelivery {
 						cache_before = ?cache_before,
 						cache_after = ?cache_after,
 						error = %reason,
-						"raw send definitively rejected; nonce cache rolled back to chain pending"
+						"raw send definitively rejected; nonce cache reconciled after scoped rollback"
 					);
 				} else {
 					tracing::warn!(
@@ -1981,7 +1982,7 @@ impl DeliveryInterface for AlloyDelivery {
 									cache_before = ?cache_before,
 									cache_after = ?cache_after,
 									error = %record_err_msg,
-									"nonce-too-low retry: failed to record retry planned attempt; refusing to broadcast; nonce cache rolled back to chain pending"
+									"nonce-too-low retry: failed to record retry planned attempt; refusing to broadcast; nonce cache reconciled after scoped rollback"
 								);
 							} else {
 								tracing::error!(
@@ -2035,8 +2036,9 @@ impl DeliveryInterface for AlloyDelivery {
 							.await;
 						}
 
-						// Rollback: fetch authoritative chain pending; on
-						// Some(pending) reset cache, on None keep it advanced.
+						// Rollback: fetch authoritative chain pending; on success
+						// apply scoped reclaim/forward-only reconciliation, on
+						// failure keep it advanced.
 						let mgr = self.get_nonce_manager(chain_id)?;
 						let cache_before = mgr.peek(from);
 						let pending_result = provider.get_transaction_count(from).pending().await;
@@ -2062,7 +2064,7 @@ impl DeliveryInterface for AlloyDelivery {
 								cache_before = ?cache_before,
 								cache_after = ?cache_after,
 								error = %sign_err_msg,
-								"local signing failed on nonce-too-low retry; nonce cache rolled back to chain pending"
+								"local signing failed on nonce-too-low retry; nonce cache reconciled after scoped rollback"
 							);
 						} else {
 							tracing::error!(
@@ -2129,7 +2131,7 @@ impl DeliveryInterface for AlloyDelivery {
 								cache_before = ?cache_before,
 								cache_after = ?cache_after,
 								error = %persist_err,
-								"nonce-too-low retry: pre-broadcast hash persist failed; refusing to broadcast; nonce cache rolled back to chain pending"
+								"nonce-too-low retry: pre-broadcast hash persist failed; refusing to broadcast; nonce cache reconciled after scoped rollback"
 							);
 						} else {
 							tracing::error!(
@@ -2598,7 +2600,7 @@ impl DeliveryInterface for AlloyDelivery {
 								cache_before = ?cache_before,
 								cache_after = ?cache_after,
 								error = %retry_reason,
-								"nonce-too-low retry definitively rejected; nonce cache rolled back to chain pending"
+								"nonce-too-low retry definitively rejected; nonce cache reconciled after scoped rollback"
 							);
 						} else {
 							tracing::warn!(
@@ -2675,7 +2677,7 @@ impl DeliveryInterface for AlloyDelivery {
 								cache_before = ?cache_before,
 								cache_after = ?cache_after,
 								error = %second_reason,
-								"nonce-too-low retry also returned nonce too low; nonce cache rolled back to chain pending"
+								"nonce-too-low retry also returned nonce too low; nonce cache reconciled after scoped rollback"
 							);
 						} else {
 							tracing::warn!(

--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -4,7 +4,7 @@
 //! supporting blockchain transaction submission and monitoring using the Alloy library.
 
 use crate::implementations::evm::fees::{
-	FeePolicyConfig, FeePolicyRegistry, SolverEip1559Estimator,
+	clamp_legacy_gas_price_to_cap, FeePolicyConfig, FeePolicyRegistry, SolverEip1559Estimator,
 };
 // Re-import directly because the schema validator below builds a transient
 // `FeePolicyRegistry` purely to surface field-level wei-parse errors. Going
@@ -2712,13 +2712,15 @@ impl DeliveryInterface for AlloyDelivery {
 						"Failed to get fee history ({e}) and legacy gas price fallback ({gas_err})"
 					))
 				})?;
+				let capped_gp = clamp_legacy_gas_price_to_cap(gp, &policy);
 				tracing::warn!(
 					chain_id,
 					error = %e,
 					gas_price = gp,
+					capped_gas_price = capped_gp,
 					"Falling back to legacy gas price after feeHistory failure"
 				);
-				return Ok(FeeParams::legacy(chain_id, gp));
+				return Ok(FeeParams::legacy(chain_id, capped_gp));
 			},
 		};
 
@@ -2750,8 +2752,14 @@ impl DeliveryInterface for AlloyDelivery {
 						let gp = provider.get_gas_price().await.map_err(|e| {
 							DeliveryError::Network(format!("Failed to get legacy gas price: {e}"))
 						})?;
-						let params = FeeParams::legacy(chain_id, gp);
-						tracing::debug!(chain_id, gas_price = gp, "Resolved legacy fee params");
+						let capped_gp = clamp_legacy_gas_price_to_cap(gp, &policy);
+						let params = FeeParams::legacy(chain_id, capped_gp);
+						tracing::debug!(
+							chain_id,
+							gas_price = gp,
+							capped_gas_price = capped_gp,
+							"Resolved legacy fee params"
+						);
 						self.fee_params_cache
 							.insert(chain_id, params.clone(), now)
 							.await;
@@ -3891,7 +3899,7 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_nonce_cache_action_rollback_with_pending_resets_cache() {
+	fn apply_nonce_cache_action_rollback_with_pending_preserves_high_water_cache() {
 		use NonceCacheAction::*;
 		let mgr = ResettableNonceManager::new();
 		let signer = Address::ZERO;
@@ -3901,10 +3909,10 @@ mod tests {
 		let after = apply_nonce_cache_action(&mgr, signer, AttemptRollback, Some(100));
 		assert_eq!(
 			after,
-			Some(100),
-			"cache must reset to authoritative pending"
+			Some(101),
+			"cache must not move below locally allocated high-water nonce"
 		);
-		assert_eq!(mgr.peek(signer), Some(100));
+		assert_eq!(mgr.peek(signer), Some(101));
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/fees.rs
+++ b/crates/solver-delivery/src/implementations/evm/fees.rs
@@ -266,6 +266,12 @@ impl SolverEip1559Estimator {
 	}
 }
 
+pub(crate) fn clamp_legacy_gas_price_to_cap(gas_price: u128, policy: &ChainFeePolicy) -> u128 {
+	policy
+		.gas_price_cap
+		.map_or(gas_price, |cap| gas_price.min(cap))
+}
+
 /// Trait impl so `SolverEip1559Estimator` can be passed to alloy's
 /// `Eip1559Estimator::Custom(...)` if a future caller wants to use
 /// alloy's `estimate_eip1559_fees_with(...)` wrapper. Today our
@@ -571,6 +577,22 @@ mod tests {
 		// significantly exceed 2.5 gwei.
 		let est = estimator.estimate(10_000_000_000, &[vec![100_000_000u128]]);
 		assert!(est.max_fee_per_gas <= 2_500_000_000.max(est.max_priority_fee_per_gas));
+	}
+
+	#[test]
+	fn gas_price_cap_clamps_legacy_fallback_price() {
+		let policy = ChainFeePolicy {
+			speed: FeeSpeed::Fast,
+			min_priority_fee_per_gas: Some(100_000_000),
+			priority_fee_fallback: 100_000_000,
+			quote_cost_strategy: FeeCostStrategy::BufferedEffective125,
+			gas_price_cap: Some(2_500_000_000),
+		};
+
+		assert_eq!(
+			super::clamp_legacy_gas_price_to_cap(10_000_000_000, &policy),
+			2_500_000_000
+		);
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/fees.rs
+++ b/crates/solver-delivery/src/implementations/evm/fees.rs
@@ -596,6 +596,38 @@ mod tests {
 	}
 
 	#[test]
+	fn gas_price_cap_passes_through_legacy_price_when_below_cap() {
+		let policy = ChainFeePolicy {
+			speed: FeeSpeed::Fast,
+			min_priority_fee_per_gas: Some(100_000_000),
+			priority_fee_fallback: 100_000_000,
+			quote_cost_strategy: FeeCostStrategy::BufferedEffective125,
+			gas_price_cap: Some(2_500_000_000),
+		};
+
+		assert_eq!(
+			super::clamp_legacy_gas_price_to_cap(1_000_000_000, &policy),
+			1_000_000_000
+		);
+	}
+
+	#[test]
+	fn gas_price_cap_passes_through_legacy_price_when_unset() {
+		let policy = ChainFeePolicy {
+			speed: FeeSpeed::Fast,
+			min_priority_fee_per_gas: Some(100_000_000),
+			priority_fee_fallback: 100_000_000,
+			quote_cost_strategy: FeeCostStrategy::BufferedEffective125,
+			gas_price_cap: None,
+		};
+
+		assert_eq!(
+			super::clamp_legacy_gas_price_to_cap(10_000_000_000, &policy),
+			10_000_000_000
+		);
+	}
+
+	#[test]
 	fn fee_policy_quote_cost_strategy_changes_cost_not_max_fee() {
 		// Submit-side `max_fee_per_gas` is decoupled from the quote-side
 		// `cost_per_gas`. Switching strategy moves the quote cost without

--- a/crates/solver-delivery/src/implementations/evm/nonce.rs
+++ b/crates/solver-delivery/src/implementations/evm/nonce.rs
@@ -56,14 +56,18 @@ impl ResettableNonceManager {
 		*entry
 	}
 
-	/// Replace the next-to-hand-out nonce for `address` exactly.
-	/// Use only after reading authoritative chain state; unlike
-	/// `set_next_nonce`, this may move the local cache backward to recover
-	/// from ghost broadcasts that advanced only the in-process counter.
+	/// Replace the next-to-hand-out nonce for `address` using authoritative
+	/// chain state, clamped by the local high-water mark. This avoids
+	/// reissuing a nonce already handed out by this process when multiple
+	/// same-signer submissions are in flight.
 	pub fn reset_next_nonce(&self, address: Address, next: u64) -> u64 {
 		let mut cache = self.cache.lock().expect("nonce cache mutex poisoned");
-		cache.insert(address, next);
-		next
+		let reset = cache
+			.get(&address)
+			.copied()
+			.map_or(next, |local| local.max(next));
+		cache.insert(address, reset);
+		reset
 	}
 
 	/// Reconcile the local next nonce with chain `pending`.
@@ -171,11 +175,16 @@ pub fn classify_submission_outcome(message: &str) -> SubmissionOutcome {
 	}
 
 	// 3. Definitely rejected pre-pool. Safe to roll back the cache.
+	let fee_cap_below_base_fee = lower.contains("max fee per gas less than block base fee")
+		|| lower.contains("fee cap less than block base fee")
+		|| lower.contains("max fee per gas below block base fee");
+
 	if lower.contains("insufficient funds")
 		|| lower.contains("transaction underpriced")
 		|| lower.contains("intrinsic gas too low")
 		|| lower.contains("exceeds block gas limit")
 		|| lower.contains("gas required exceeds")
+		|| fee_cap_below_base_fee
 		// Nonce upper-bound (the lower-bound `nonce too low` was handled above)
 		|| lower.contains("nonce too high")
 		// Signature / sender / chain pre-validation
@@ -287,19 +296,33 @@ mod tests {
 	}
 
 	#[test]
-	fn reset_next_nonce_can_recover_from_local_cache_ahead_of_chain() {
+	fn reset_next_nonce_does_not_reissue_locally_allocated_nonces() {
 		let mgr = ResettableNonceManager::new();
 		mgr.set_next_nonce(ADDR, 139);
 		assert_eq!(mgr.take_next(ADDR), Some(139));
 		assert_eq!(mgr.take_next(ADDR), Some(140));
 		assert_eq!(mgr.peek(ADDR), Some(141));
 
-		// Chain pending is still 139 because the locally handed-out txs were
-		// ghost broadcasts. A real resync must be allowed to move backward.
-		assert_eq!(mgr.reset_next_nonce(ADDR, 139), 139);
+		// Chain pending is still 139, but the local cache has already handed
+		// out nonces through 140. Rollback must not move below that local
+		// high-water mark or concurrent submitters can reissue an in-flight
+		// nonce.
+		assert_eq!(mgr.reset_next_nonce(ADDR, 139), 141);
 
-		assert_eq!(mgr.take_next(ADDR), Some(139));
-		assert_eq!(mgr.peek(ADDR), Some(140));
+		assert_eq!(mgr.take_next(ADDR), Some(141));
+		assert_eq!(mgr.peek(ADDR), Some(142));
+	}
+
+	#[test]
+	fn reset_next_nonce_preserves_local_high_water_when_chain_pending_lags() {
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 10);
+		assert_eq!(mgr.take_next(ADDR), Some(10));
+		assert_eq!(mgr.take_next(ADDR), Some(11));
+		assert_eq!(mgr.peek(ADDR), Some(12));
+
+		assert_eq!(mgr.reset_next_nonce(ADDR, 9), 12);
+		assert_eq!(mgr.peek(ADDR), Some(12));
 	}
 
 	#[test]
@@ -415,6 +438,18 @@ mod tests {
 		// Mixed case
 		assert_eq!(
 			classify_submission_outcome("ERROR: Insufficient Funds"),
+			DefinitelyRejected
+		);
+		assert_eq!(
+			classify_submission_outcome("max fee per gas less than block base fee"),
+			DefinitelyRejected
+		);
+		assert_eq!(
+			classify_submission_outcome("fee cap less than block base fee"),
+			DefinitelyRejected
+		);
+		assert_eq!(
+			classify_submission_outcome("max fee per gas below block base fee"),
 			DefinitelyRejected
 		);
 	}

--- a/crates/solver-delivery/src/implementations/evm/nonce.rs
+++ b/crates/solver-delivery/src/implementations/evm/nonce.rs
@@ -107,8 +107,8 @@ impl ResettableNonceManager {
 	/// arbitrary resync but unable to *reclaim* a nonce — this method moves the
 	/// cache back to `rejected_nonce`, but **only when it is provably safe**:
 	///
-	/// 1. `chain_pending <= rejected_nonce`: the chain has not advanced past the
-	///    rejected nonce, confirming the tx did not land out-of-band; and
+	/// 1. `chain_pending == rejected_nonce`: the chain is ready to accept that
+	///    exact nonce, confirming no lower nonce gap needs recovery; and
 	/// 2. the local cache is exactly `rejected_nonce + 1`: the rejected nonce was
 	///    the most recently handed-out nonce, so nothing newer is in flight that
 	///    rolling back would strand.
@@ -117,11 +117,9 @@ impl ResettableNonceManager {
 	/// allocation re-hands-it-out, closing the nonce gap a pre-pool rejection
 	/// would otherwise leak (the wedge described in audit finding H-27).
 	/// Otherwise the cache is left advanced — moving forward to `chain_pending`
-	/// if the chain is ahead — because a higher nonce is already in flight or
-	/// the chain shows the nonce consumed, and reusing it would risk a
-	/// same-nonce conflict. That is the conservative, never-reuse choice;
-	/// recovery of any resulting gap is left to the bump sweeper / nonce-too-low
-	/// resync.
+	/// if the chain is ahead — because a higher nonce is already in flight, the
+	/// chain shows the nonce consumed, or pending is lower than the rejected
+	/// future nonce. That is the conservative, never-reuse choice.
 	///
 	/// Returns `(before, after)` for tracing.
 	pub fn reclaim_rejected_nonce(
@@ -134,15 +132,17 @@ impl ResettableNonceManager {
 		let before = cache.get(&address).copied();
 		let after = match before {
 			// Safe to reclaim: the rejected nonce was the top of the local
-			// allocation and the chain has not consumed it.
+			// allocation and chain pending is exactly that nonce. If pending is
+			// lower, there is a gap below the rejected nonce; without per-lower-
+			// nonce ownership, jumping back would risk reuse.
 			Some(local)
-				if chain_pending <= rejected_nonce && local == rejected_nonce.saturating_add(1) =>
+				if chain_pending == rejected_nonce && local == rejected_nonce.saturating_add(1) =>
 			{
 				rejected_nonce
 			},
-			// A higher nonce is in flight, or the chain advanced past the
-			// rejected nonce — keep the cache advanced (honoring forward chain
-			// movement) and never reuse an in-flight nonce.
+			// A higher nonce is in flight, the chain advanced past the rejected
+			// nonce, or pending is below the future rejected nonce — keep the
+			// cache advanced and never reuse an in-flight nonce.
 			Some(local) => local.max(chain_pending),
 			None => chain_pending,
 		};
@@ -459,6 +459,20 @@ mod tests {
 		assert_eq!(mgr.peek(ADDR), Some(6));
 
 		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 6), (Some(6), 6));
+		assert_eq!(mgr.take_next(ADDR), Some(6));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_does_not_reclaim_future_nonce_above_pending() {
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.peek(ADDR), Some(6));
+
+		// A lower pending nonce means there is a gap before the rejected nonce.
+		// Without per-lower-nonce in-flight ownership, jumping below or back to
+		// the future rejected nonce is unsafe; keep the local cache advanced.
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 3), (Some(6), 6));
 		assert_eq!(mgr.take_next(ADDR), Some(6));
 	}
 

--- a/crates/solver-delivery/src/implementations/evm/nonce.rs
+++ b/crates/solver-delivery/src/implementations/evm/nonce.rs
@@ -12,10 +12,19 @@
 //! 3. The error from `send_transaction` does NOT prove the tx was rejected
 //!    pre-pool (i.e. the outcome is `Replacement` or `Ambiguous`).
 //!
-//! Conversely: cache rollback (via `reset_next_nonce`) is only safe when:
+//! Conversely: cache rollback is only safe when:
 //! - The submission error is in `SubmissionOutcome::DefinitelyRejected`, AND
 //! - A fresh chain-pending read succeeds. If the read fails, the caller MUST
 //!   keep the cache advanced — we never reset without authoritative chain state.
+//!
+//! Two rollback primitives exist, with different safety profiles:
+//! - `reset_next_nonce`: forward-only high-water clamp. Safe for an arbitrary
+//!   resync, but cannot *reclaim* a nonce a rejection leaked.
+//! - `reclaim_rejected_nonce`: moves the cache back to the rejected nonce, but
+//!   only when that nonce was the most recently handed-out one and the chain
+//!   has not advanced past it — otherwise it falls back to the forward-only
+//!   behavior. This closes the nonce gap left by a pre-pool rejection without
+//!   ever reissuing a nonce that is still in flight.
 //!
 //! Ambiguous transport errors (timeout, 5xx, malformed JSON) and replacement-
 //! class errors keep the cache advanced — the transaction may have propagated
@@ -87,6 +96,58 @@ impl ResettableNonceManager {
 		};
 		cache.insert(address, reconciled);
 		(before, reconciled)
+	}
+
+	/// Reclaim a nonce that was allocated to a transaction which was then
+	/// definitively rejected pre-pool (the tx never entered any mempool, so the
+	/// nonce was never consumed on-chain).
+	///
+	/// This is the rollback counterpart to [`Self::reset_next_nonce`]. Where
+	/// `reset_next_nonce` is a forward-only high-water clamp — safe for an
+	/// arbitrary resync but unable to *reclaim* a nonce — this method moves the
+	/// cache back to `rejected_nonce`, but **only when it is provably safe**:
+	///
+	/// 1. `chain_pending <= rejected_nonce`: the chain has not advanced past the
+	///    rejected nonce, confirming the tx did not land out-of-band; and
+	/// 2. the local cache is exactly `rejected_nonce + 1`: the rejected nonce was
+	///    the most recently handed-out nonce, so nothing newer is in flight that
+	///    rolling back would strand.
+	///
+	/// When both hold, the cache is set to `rejected_nonce` so the next
+	/// allocation re-hands-it-out, closing the nonce gap a pre-pool rejection
+	/// would otherwise leak (the wedge described in audit finding H-27).
+	/// Otherwise the cache is left advanced — moving forward to `chain_pending`
+	/// if the chain is ahead — because a higher nonce is already in flight or
+	/// the chain shows the nonce consumed, and reusing it would risk a
+	/// same-nonce conflict. That is the conservative, never-reuse choice;
+	/// recovery of any resulting gap is left to the bump sweeper / nonce-too-low
+	/// resync.
+	///
+	/// Returns `(before, after)` for tracing.
+	pub fn reclaim_rejected_nonce(
+		&self,
+		address: Address,
+		rejected_nonce: u64,
+		chain_pending: u64,
+	) -> (Option<u64>, u64) {
+		let mut cache = self.cache.lock().expect("nonce cache mutex poisoned");
+		let before = cache.get(&address).copied();
+		let after = match before {
+			// Safe to reclaim: the rejected nonce was the top of the local
+			// allocation and the chain has not consumed it.
+			Some(local)
+				if chain_pending <= rejected_nonce && local == rejected_nonce.saturating_add(1) =>
+			{
+				rejected_nonce
+			},
+			// A higher nonce is in flight, or the chain advanced past the
+			// rejected nonce — keep the cache advanced (honoring forward chain
+			// movement) and never reuse an in-flight nonce.
+			Some(local) => local.max(chain_pending),
+			None => chain_pending,
+		};
+		cache.insert(address, after);
+		(before, after)
 	}
 
 	/// Take the next nonce and advance the counter.
@@ -351,6 +412,61 @@ mod tests {
 
 		assert_eq!(mgr.take_next(ADDR), Some(142));
 		assert_eq!(mgr.peek(ADDR), Some(143));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_reclaims_lone_in_flight_nonce() {
+		// H-27 scenario: a single in-flight tx is rejected pre-pool. The local
+		// cache is one past the rejected nonce and the chain has not consumed
+		// it, so the nonce must be reclaimed (not leaked).
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5)); // allocate nonce 5
+		assert_eq!(mgr.peek(ADDR), Some(6));
+
+		// Tx at nonce 5 is DefinitelyRejected; chain pending is still 5.
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (Some(6), 5));
+
+		// Nonce 5 is re-handed-out instead of being permanently skipped.
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.peek(ADDR), Some(6));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_does_not_reclaim_when_higher_nonce_in_flight() {
+		// A newer nonce was allocated after the rejected one — reclaiming the
+		// middle nonce would risk reissuing an in-flight nonce, so the cache
+		// must stay advanced.
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.take_next(ADDR), Some(6));
+		assert_eq!(mgr.peek(ADDR), Some(7));
+
+		// Nonce 5 rejected, but 6 is still in flight (cache at 7, not 6).
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (Some(7), 7));
+		assert_eq!(mgr.peek(ADDR), Some(7));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_does_not_reclaim_when_chain_advanced_past_it() {
+		// The chain pending is already past the rejected nonce, so the nonce
+		// was consumed out-of-band; never reclaim it. The cache also moves
+		// forward to honor the chain.
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.peek(ADDR), Some(6));
+
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 6), (Some(6), 6));
+		assert_eq!(mgr.take_next(ADDR), Some(6));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_on_empty_cache_seeds_from_chain() {
+		let mgr = ResettableNonceManager::new();
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (None, 5));
+		assert_eq!(mgr.peek(ADDR), Some(5));
 	}
 
 	#[test]


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy gas-price fallbacks are now capped by the active fee policy to produce consistent, bounded fee suggestions.
  * Nonce cache handling improved: it avoids moving below locally issued nonces and can reclaim a single definitively rejected nonce when safe, reducing stuck or conflicting submissions.
  * Fee-error classification expanded to better detect “max fee below block base fee” rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->