### PR TITLE
fix(nonce): reclaim definitively-rejected nonce; keep resync forward-only (H-27, H-18)

### DIFF
--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -229,11 +229,18 @@ pub struct AlloyDelivery {
 /// inside callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NonceCacheAction {
-	/// Tx provably rejected pre-pool. Caller should attempt to fetch
-	/// chain pending and call `reset_next_nonce`. If the fetch fails,
-	/// caller MUST keep the cache advanced — we don't roll back without
+	/// Tx provably rejected pre-pool (or never broadcast). Caller should
+	/// attempt to fetch chain pending and roll the cache back. If the fetch
+	/// fails, caller MUST keep the cache advanced — we don't roll back without
 	/// authoritative chain state.
-	AttemptRollback,
+	///
+	/// `rejected_nonce` is the nonce the rejected/never-broadcast tx was
+	/// allocated, when known. It lets the rollback *reclaim* that nonce
+	/// (closing the gap) via `reclaim_rejected_nonce` when it is provably safe
+	/// — i.e. it was the most recently handed-out nonce and the chain has not
+	/// advanced past it. `None` falls back to the forward-only
+	/// `reset_next_nonce` clamp.
+	AttemptRollback { rejected_nonce: Option<u64> },
 }
 
 /// Outcome of a raw-send attempt, after pre-sign persisted the hash.
@@ -407,8 +414,16 @@ fn apply_nonce_cache_action(
 	chain_pending: Option<u64>,
 ) -> Option<u64> {
 	match action {
-		NonceCacheAction::AttemptRollback => match chain_pending {
-			Some(pending) => Some(mgr.reset_next_nonce(signer, pending)),
+		NonceCacheAction::AttemptRollback { rejected_nonce } => match chain_pending {
+			// When the rejected nonce is known, try to reclaim it (close the
+			// gap) — safe only if it was the last nonce handed out and the
+			// chain has not advanced past it; otherwise this clamps forward
+			// exactly like `reset_next_nonce`. When unknown, fall back to the
+			// forward-only clamp.
+			Some(pending) => Some(match rejected_nonce {
+				Some(rejected) => mgr.reclaim_rejected_nonce(signer, rejected, pending).1,
+				None => mgr.reset_next_nonce(signer, pending),
+			}),
 			// No authoritative chain state — KEEP advanced. We never reset
 			// the cache without a successful pending-fetch.
 			None => mgr.peek(signer),
@@ -734,8 +749,11 @@ impl AlloyDelivery {
 	/// Returns the next nonce to use for `from` on `chain_id`, taking it from the
 	/// resettable cache. Every call samples chain `pending`, but normal allocation
 	/// is monotonic: a stale RPC pending nonce must not move the local cache
-	/// backward and reissue a nonce already handed out by this process. Backward
-	/// reset is reserved for the explicit `nonce too low` resync path.
+	/// backward and reissue a nonce already handed out by this process. The only
+	/// way the cache moves below its local high-water mark is reclaiming a
+	/// definitively-rejected nonce that was the last one handed out, via
+	/// `reclaim_rejected_nonce` (safe because that nonce's tx never entered a
+	/// pool); the `nonce too low` resync stays forward-only.
 	async fn next_nonce_for(&self, chain_id: u64, from: Address) -> Result<u64, DeliveryError> {
 		let provider = self.get_provider(chain_id)?;
 		let pending = provider
@@ -1208,7 +1226,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1276,7 +1296,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1724,8 +1746,12 @@ impl DeliveryInterface for AlloyDelivery {
 				}
 
 				// Roll back the nonce: fetch authoritative chain pending; on
-				// Some(pending) reset cache, on None keep it advanced (never
-				// roll back without authoritative state).
+				// Some(pending) reclaim the rejected nonce when it was the last
+				// one handed out (closing the gap), else keep the cache
+				// advanced; on None keep it advanced (never roll back without
+				// authoritative state). Passing the rejected nonce is what lets
+				// a fee-cap/base-fee rejection of a lone in-flight tx reclaim
+				// its nonce instead of wedging the signer (audit finding H-27).
 				let mgr = self.get_nonce_manager(chain_id)?;
 				let cache_before = mgr.peek(from);
 				let pending_result = provider.get_transaction_count(from).pending().await;
@@ -1736,7 +1762,9 @@ impl DeliveryInterface for AlloyDelivery {
 				let cache_after = apply_nonce_cache_action(
 					mgr,
 					from,
-					NonceCacheAction::AttemptRollback,
+					NonceCacheAction::AttemptRollback {
+						rejected_nonce: tx_attempt.nonce,
+					},
 					pending_opt,
 				);
 				if let Some(pending) = pending_opt {
@@ -1863,10 +1891,18 @@ impl DeliveryInterface for AlloyDelivery {
 				}
 
 				// Resync the local nonce cache from chain pending.
-				// `reset_next_nonce` (not `set_next_nonce`) is used so a
-				// chain-pending value BELOW the local cache (the signature
-				// of a ghost broadcast we recovered from) can move the cache
-				// backward — the whole point of the resync.
+				//
+				// `reset_next_nonce` is a forward-only high-water clamp: it moves
+				// the cache UP to `fresh_pending` but never below the local
+				// high-water mark. That is the correct, H-18-safe behavior here.
+				// A `nonce too low` means the chain has advanced to or past our
+				// tx's nonce, so the retry must use the next nonce ABOVE every
+				// nonce this process has already handed out — never a (possibly
+				// stale or load-balanced) `pending` value below an in-flight
+				// nonce, which would reissue it and cause a same-nonce conflict
+				// (the H-18 reuse window). Reclaiming a nonce LEAKED by a
+				// never-broadcast / definitively-rejected tx is handled
+				// separately, at the rejection sites, via `reclaim_rejected_nonce`.
 				let mgr = self.get_nonce_manager(chain_id)?;
 				let fresh_pending = provider
 					.get_transaction_count(from)
@@ -1878,13 +1914,13 @@ impl DeliveryInterface for AlloyDelivery {
 						))
 					})?;
 				let cache_before_resync = mgr.peek(from);
-				mgr.reset_next_nonce(from, fresh_pending);
+				let cache_after_resync = mgr.reset_next_nonce(from, fresh_pending);
 				tracing::debug!(
 					chain_id,
 					signer = %from,
 					chain_pending = fresh_pending,
 					cache_before = ?cache_before_resync,
-					cache_after = fresh_pending,
+					cache_after = cache_after_resync,
 					"Nonce-too-low retry: nonce cache resynced from chain pending"
 				);
 
@@ -1931,7 +1967,9 @@ impl DeliveryInterface for AlloyDelivery {
 							let cache_after = apply_nonce_cache_action(
 								mgr,
 								from,
-								NonceCacheAction::AttemptRollback,
+								NonceCacheAction::AttemptRollback {
+									rejected_nonce: tx_attempt.nonce,
+								},
 								pending_opt,
 							);
 							if let Some(pending) = pending_opt {
@@ -2010,7 +2048,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2075,7 +2115,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2542,7 +2584,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -2617,7 +2661,9 @@ impl DeliveryInterface for AlloyDelivery {
 						let cache_after = apply_nonce_cache_action(
 							mgr,
 							from,
-							NonceCacheAction::AttemptRollback,
+							NonceCacheAction::AttemptRollback {
+								rejected_nonce: tx_attempt.nonce,
+							},
 							pending_opt,
 						);
 						if let Some(pending) = pending_opt {
@@ -3969,14 +4015,23 @@ mod tests {
 	}
 
 	#[test]
-	fn apply_nonce_cache_action_rollback_with_pending_preserves_high_water_cache() {
+	fn apply_nonce_cache_action_rollback_without_rejected_nonce_preserves_high_water_cache() {
 		use NonceCacheAction::*;
 		let mgr = ResettableNonceManager::new();
 		let signer = Address::ZERO;
 		mgr.reset_next_nonce(signer, 101);
 		assert_eq!(mgr.peek(signer), Some(101));
 
-		let after = apply_nonce_cache_action(&mgr, signer, AttemptRollback, Some(100));
+		// No rejected nonce supplied → forward-only clamp; must not move below
+		// the locally allocated high-water nonce.
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: None,
+			},
+			Some(100),
+		);
 		assert_eq!(
 			after,
 			Some(101),
@@ -3992,13 +4047,72 @@ mod tests {
 		let signer = Address::ZERO;
 		mgr.reset_next_nonce(signer, 101);
 
-		let after = apply_nonce_cache_action(&mgr, signer, AttemptRollback, None);
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			None,
+		);
 		assert_eq!(
 			after,
 			Some(101),
 			"no authoritative chain state → cache must NOT be reset"
 		);
 		assert_eq!(mgr.peek(signer), Some(101));
+	}
+
+	#[test]
+	fn apply_nonce_cache_action_rollback_reclaims_rejected_lone_nonce() {
+		// H-27 end-to-end at the policy layer: a lone in-flight tx at nonce 100
+		// is definitively rejected pre-pool. The cache (101) is rolled back so
+		// nonce 100 is reclaimed rather than permanently leaked.
+		use NonceCacheAction::*;
+		let mgr = ResettableNonceManager::new();
+		let signer = Address::ZERO;
+		mgr.set_next_nonce(signer, 100);
+		assert_eq!(mgr.take_next(signer), Some(100)); // allocate 100
+		assert_eq!(mgr.peek(signer), Some(101));
+
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			Some(100),
+		);
+		assert_eq!(after, Some(100), "rejected lone nonce must be reclaimed");
+		// The very next allocation re-hands-out 100 (no permanent gap / wedge).
+		assert_eq!(mgr.take_next(signer), Some(100));
+	}
+
+	#[test]
+	fn apply_nonce_cache_action_rollback_keeps_cache_when_higher_nonce_in_flight() {
+		// A newer nonce (101) is still in flight, so reclaiming the rejected
+		// nonce 100 would risk reissuing 101 — the cache must stay advanced.
+		use NonceCacheAction::*;
+		let mgr = ResettableNonceManager::new();
+		let signer = Address::ZERO;
+		mgr.set_next_nonce(signer, 100);
+		assert_eq!(mgr.take_next(signer), Some(100));
+		assert_eq!(mgr.take_next(signer), Some(101));
+		assert_eq!(mgr.peek(signer), Some(102));
+
+		let after = apply_nonce_cache_action(
+			&mgr,
+			signer,
+			AttemptRollback {
+				rejected_nonce: Some(100),
+			},
+			Some(100),
+		);
+		assert_eq!(
+			after,
+			Some(102),
+			"must not reclaim a mid-sequence nonce while a higher nonce is in flight"
+		);
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/nonce.rs
+++ b/crates/solver-delivery/src/implementations/evm/nonce.rs
@@ -12,10 +12,19 @@
 //! 3. The error from `send_transaction` does NOT prove the tx was rejected
 //!    pre-pool (i.e. the outcome is `Replacement` or `Ambiguous`).
 //!
-//! Conversely: cache rollback (via `reset_next_nonce`) is only safe when:
+//! Conversely: cache rollback is only safe when:
 //! - The submission error is in `SubmissionOutcome::DefinitelyRejected`, AND
 //! - A fresh chain-pending read succeeds. If the read fails, the caller MUST
 //!   keep the cache advanced — we never reset without authoritative chain state.
+//!
+//! Two rollback primitives exist, with different safety profiles:
+//! - `reset_next_nonce`: forward-only high-water clamp. Safe for an arbitrary
+//!   resync, but cannot *reclaim* a nonce a rejection leaked.
+//! - `reclaim_rejected_nonce`: moves the cache back to the rejected nonce, but
+//!   only when that nonce was the most recently handed-out one and the chain
+//!   has not advanced past it — otherwise it falls back to the forward-only
+//!   behavior. This closes the nonce gap left by a pre-pool rejection without
+//!   ever reissuing a nonce that is still in flight.
 //!
 //! Ambiguous transport errors (timeout, 5xx, malformed JSON) and replacement-
 //! class errors keep the cache advanced — the transaction may have propagated
@@ -87,6 +96,58 @@ impl ResettableNonceManager {
 		};
 		cache.insert(address, reconciled);
 		(before, reconciled)
+	}
+
+	/// Reclaim a nonce that was allocated to a transaction which was then
+	/// definitively rejected pre-pool (the tx never entered any mempool, so the
+	/// nonce was never consumed on-chain).
+	///
+	/// This is the rollback counterpart to [`Self::reset_next_nonce`]. Where
+	/// `reset_next_nonce` is a forward-only high-water clamp — safe for an
+	/// arbitrary resync but unable to *reclaim* a nonce — this method moves the
+	/// cache back to `rejected_nonce`, but **only when it is provably safe**:
+	///
+	/// 1. `chain_pending <= rejected_nonce`: the chain has not advanced past the
+	///    rejected nonce, confirming the tx did not land out-of-band; and
+	/// 2. the local cache is exactly `rejected_nonce + 1`: the rejected nonce was
+	///    the most recently handed-out nonce, so nothing newer is in flight that
+	///    rolling back would strand.
+	///
+	/// When both hold, the cache is set to `rejected_nonce` so the next
+	/// allocation re-hands-it-out, closing the nonce gap a pre-pool rejection
+	/// would otherwise leak (the wedge described in audit finding H-27).
+	/// Otherwise the cache is left advanced — moving forward to `chain_pending`
+	/// if the chain is ahead — because a higher nonce is already in flight or
+	/// the chain shows the nonce consumed, and reusing it would risk a
+	/// same-nonce conflict. That is the conservative, never-reuse choice;
+	/// recovery of any resulting gap is left to the bump sweeper / nonce-too-low
+	/// resync.
+	///
+	/// Returns `(before, after)` for tracing.
+	pub fn reclaim_rejected_nonce(
+		&self,
+		address: Address,
+		rejected_nonce: u64,
+		chain_pending: u64,
+	) -> (Option<u64>, u64) {
+		let mut cache = self.cache.lock().expect("nonce cache mutex poisoned");
+		let before = cache.get(&address).copied();
+		let after = match before {
+			// Safe to reclaim: the rejected nonce was the top of the local
+			// allocation and the chain has not consumed it.
+			Some(local)
+				if chain_pending <= rejected_nonce && local == rejected_nonce.saturating_add(1) =>
+			{
+				rejected_nonce
+			},
+			// A higher nonce is in flight, or the chain advanced past the
+			// rejected nonce — keep the cache advanced (honoring forward chain
+			// movement) and never reuse an in-flight nonce.
+			Some(local) => local.max(chain_pending),
+			None => chain_pending,
+		};
+		cache.insert(address, after);
+		(before, after)
 	}
 
 	/// Take the next nonce and advance the counter.
@@ -351,6 +412,61 @@ mod tests {
 
 		assert_eq!(mgr.take_next(ADDR), Some(142));
 		assert_eq!(mgr.peek(ADDR), Some(143));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_reclaims_lone_in_flight_nonce() {
+		// H-27 scenario: a single in-flight tx is rejected pre-pool. The local
+		// cache is one past the rejected nonce and the chain has not consumed
+		// it, so the nonce must be reclaimed (not leaked).
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5)); // allocate nonce 5
+		assert_eq!(mgr.peek(ADDR), Some(6));
+
+		// Tx at nonce 5 is DefinitelyRejected; chain pending is still 5.
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (Some(6), 5));
+
+		// Nonce 5 is re-handed-out instead of being permanently skipped.
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.peek(ADDR), Some(6));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_does_not_reclaim_when_higher_nonce_in_flight() {
+		// A newer nonce was allocated after the rejected one — reclaiming the
+		// middle nonce would risk reissuing an in-flight nonce, so the cache
+		// must stay advanced.
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.take_next(ADDR), Some(6));
+		assert_eq!(mgr.peek(ADDR), Some(7));
+
+		// Nonce 5 rejected, but 6 is still in flight (cache at 7, not 6).
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (Some(7), 7));
+		assert_eq!(mgr.peek(ADDR), Some(7));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_does_not_reclaim_when_chain_advanced_past_it() {
+		// The chain pending is already past the rejected nonce, so the nonce
+		// was consumed out-of-band; never reclaim it. The cache also moves
+		// forward to honor the chain.
+		let mgr = ResettableNonceManager::new();
+		mgr.set_next_nonce(ADDR, 5);
+		assert_eq!(mgr.take_next(ADDR), Some(5));
+		assert_eq!(mgr.peek(ADDR), Some(6));
+
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 6), (Some(6), 6));
+		assert_eq!(mgr.take_next(ADDR), Some(6));
+	}
+
+	#[test]
+	fn reclaim_rejected_nonce_on_empty_cache_seeds_from_chain() {
+		let mgr = ResettableNonceManager::new();
+		assert_eq!(mgr.reclaim_rejected_nonce(ADDR, 5, 5), (None, 5));
+		assert_eq!(mgr.peek(ADDR), Some(5));
 	}
 
 	#[test]


### PR DESCRIPTION
Stacked on #378 (`h-18-27-30-fee-nonce-hardening`). Closes the two gaps raised in review of #378.

## H-27 — reclaim the leaked nonce (was: only partially fixed)
The #378 rollback used the forward-only `reset_next_nonce` clamp (`max(cache, pending)`), which is a **no-op for a lone in-flight tx**: cache is `N+1`, chain `pending` is `N`, so `max(N+1, N) = N+1` and the rejected nonce `N` is never reclaimed → permanent nonce gap / signer wedge (exactly the H-27 impact).

- Add `ResettableNonceManager::reclaim_rejected_nonce(addr, rejected_nonce, chain_pending)`: moves the cache back to `rejected_nonce` **only when it is provably safe** — `chain_pending <= rejected_nonce` (chain hasn't consumed it) **and** `local == rejected_nonce + 1` (it was the last nonce handed out, so nothing newer is in flight). Otherwise it clamps forward exactly like `reset_next_nonce`. This closes the gap **without ever reissuing an in-flight nonce**.
- `NonceCacheAction::AttemptRollback` now carries `rejected_nonce: Option<u64>`; every rollback site passes `tx_attempt.nonce` (the nonce of the rejected/never-sent tx at that point). The safety guard makes reclamation correct at all sites; `None` falls back to the forward-only clamp.

## H-18 — keep the resync forward-only (correct as-is; comment was wrong)
A `nonce too low` means the chain has advanced **to or past** our tx's nonce, so the retry must use the next nonce **above** everything this process has handed out. The forward-only `reset_next_nonce` introduced by #378 is therefore the **correct, reuse-safe** behavior — only its comment falsely claimed a backward move. Corrected the comment and the trace (now logs the actual clamped value), and documented that leaked-nonce reclamation is handled at the rejection sites by `reclaim_rejected_nonce`.

> Note: an earlier draft of this PR routed the resync through the backward-capable `reconcile_with_chain_pending`. An adversarial self-review showed that re-opens the H-18 reuse window under concurrent same-signer submits + a lagging/load-balanced `pending` read (it could move the cache below an in-flight nonce and reissue it). That change was reverted; the resync stays forward-only.

## Tests
- `reclaim_rejected_nonce`: lone-reclaim, higher-nonce-in-flight (no reclaim), chain-advanced (no reclaim), empty-cache.
- `apply_nonce_cache_action`: reclaim path, forward-only preserve, no-pending keep-advanced.
- Existing `reset_next_nonce_preserves_local_high_water_when_chain_pending_lags` pins the forward-only no-reuse property the resync relies on.

`cargo test -p solver-delivery` → 141 passed. `cargo clippy -p solver-delivery --all-targets` clean. `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)