### PR TITLE
fix(quote): default live fill estimate off + bound stored quotes (H-05, H-13)

### DIFF
--- a/crates/solver-config/src/builders/config.rs
+++ b/crates/solver-config/src/builders/config.rs
@@ -205,7 +205,8 @@ impl ConfigBuilder {
 			api: self.api,
 			gas: Some(GasConfig {
 				flows: HashMap::new(),
-				live_fill_estimate_enabled: true,
+				// Default OFF on the public quote path (audit finding H-05).
+				live_fill_estimate_enabled: false,
 				live_post_fill_estimate_chain_ids: HashSet::new(),
 				max_concurrent_live_fill_estimates_per_chain:
 					crate::DEFAULT_MAX_CONCURRENT_LIVE_FILL_ESTIMATES_PER_CHAIN,

--- a/crates/solver-config/src/lib.rs
+++ b/crates/solver-config/src/lib.rs
@@ -191,6 +191,11 @@ fn default_true() -> bool {
 	true
 }
 
+/// Returns the default value for boolean flags (false).
+fn default_false() -> bool {
+	false
+}
+
 /// Configuration for account management.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AccountConfig {
@@ -397,9 +402,11 @@ pub struct GasConfig {
 	pub flows: HashMap<String, GasFlowUnits>,
 	/// When true, quote-time pricing performs `eth_estimateGas` for the fill leg
 	/// and uses the result instead of `flows.<key>.fill`. Other legs stay static.
-	/// Defaults to true; flip to false via the admin API to disable the live path
-	/// on a chain where eth_estimateGas is unreliable.
-	#[serde(default = "default_true")]
+	/// Defaults to `false`: the public quote endpoint must not perform an
+	/// unauthenticated per-request `eth_estimateGas` by default (audit finding
+	/// H-05). Enable it explicitly (behind auth / rate limiting / the per-chain
+	/// concurrency cap) via the admin API.
+	#[serde(default = "default_false")]
 	pub live_fill_estimate_enabled: bool,
 	/// Set of chain IDs on which quote-time post-fill gas estimation
 	/// uses the stateOverride-based live path. Empty (default) = disabled
@@ -729,6 +736,14 @@ pub struct QuoteConfig {
 	/// Maximum concurrent public quote requests.
 	#[serde(default = "default_quote_max_concurrent_requests")]
 	pub max_concurrent_requests: usize,
+	/// Maximum number of generated quotes this process retains in storage at
+	/// once. The public quote endpoint persists a `StoredQuote` per accepted
+	/// request; without a ceiling a quote flood (especially from many distinct
+	/// source IPs, each under the per-IP rate limit) grows persistent storage
+	/// unbounded (audit finding H-13). When the cap is exceeded the oldest
+	/// quotes are evicted early (they would expire on their TTL regardless).
+	#[serde(default = "default_quote_max_stored_quotes")]
+	pub max_stored_quotes: usize,
 }
 
 impl Default for QuoteConfig {
@@ -738,6 +753,7 @@ impl Default for QuoteConfig {
 			fill_deadline_seconds: default_fill_deadline_seconds(),
 			expires_seconds: default_expires_seconds(),
 			max_concurrent_requests: default_quote_max_concurrent_requests(),
+			max_stored_quotes: default_quote_max_stored_quotes(),
 		}
 	}
 }
@@ -745,6 +761,11 @@ impl Default for QuoteConfig {
 pub const DEFAULT_API_RATE_LIMIT_REQUESTS_PER_MINUTE: u32 = 600;
 pub const DEFAULT_API_RATE_LIMIT_BURST: u32 = 100;
 pub const DEFAULT_QUOTE_MAX_CONCURRENT_REQUESTS: usize = 32;
+/// Default ceiling on retained `StoredQuote` records per process. Generous
+/// enough not to interfere with legitimate traffic (at 600 req/min/IP and a
+/// 60s validity TTL a single IP holds at most ~600), while bounding the
+/// storage a multi-IP flood can accumulate.
+pub const DEFAULT_QUOTE_MAX_STORED_QUOTES: usize = 50_000;
 
 fn default_rate_limiting_enabled() -> bool {
 	true
@@ -760,6 +781,10 @@ fn default_api_rate_limit_burst() -> u32 {
 
 fn default_quote_max_concurrent_requests() -> usize {
 	DEFAULT_QUOTE_MAX_CONCURRENT_REQUESTS
+}
+
+fn default_quote_max_stored_quotes() -> usize {
+	DEFAULT_QUOTE_MAX_STORED_QUOTES
 }
 
 /// Returns the default quote validity duration in seconds.

--- a/crates/solver-service/src/apis/quote/generation.rs
+++ b/crates/solver-service/src/apis/quote/generation.rs
@@ -1911,6 +1911,7 @@ mod tests {
 				fill_deadline_seconds: 300,
 				expires_seconds: 600,
 				max_concurrent_requests: solver_config::DEFAULT_QUOTE_MAX_CONCURRENT_REQUESTS,
+				max_stored_quotes: solver_config::DEFAULT_QUOTE_MAX_STORED_QUOTES,
 			}),
 		};
 

--- a/crates/solver-service/src/apis/quote/mod.rs
+++ b/crates/solver-service/src/apis/quote/mod.rs
@@ -80,8 +80,63 @@ use solver_types::{
 	CostContext, GetQuoteRequest, GetQuoteResponse, Quote, QuoteError, StorageKey, StoredQuote,
 };
 
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tracing::info;
+
+/// Process-wide ceiling on retained `StoredQuote` records (audit finding H-13).
+///
+/// The public `/quotes` endpoint persists a `StoredQuote` per accepted request.
+/// Even with the per-IP rate limit and the quote concurrency cap, a flood from
+/// many distinct source IPs can otherwise grow persistent storage without bound
+/// (each entry only disappears on its validity TTL). This limiter tracks stored
+/// quote ids in FIFO insertion order and, once the configured capacity is
+/// exceeded, reports the oldest ids for eviction so storage stays bounded. The
+/// evicted quotes would expire on their TTL regardless; the cap just enforces
+/// the ceiling early under load.
+///
+/// Scope note: the limiter is per process (a multi-replica deployment bounds
+/// each replica independently) and its capacity is fixed on first use.
+#[derive(Debug)]
+struct QuoteRetentionLimiter {
+	capacity: usize,
+	ids: Mutex<VecDeque<String>>,
+}
+
+impl QuoteRetentionLimiter {
+	fn new(capacity: usize) -> Self {
+		Self {
+			// A zero cap would evict every quote immediately, breaking the
+			// retrieve-by-id flow; clamp to at least 1.
+			capacity: capacity.max(1),
+			ids: Mutex::new(VecDeque::new()),
+		}
+	}
+
+	/// Record newly stored quote ids and return the ids that must be evicted to
+	/// stay within `capacity` (oldest first).
+	fn register<I: IntoIterator<Item = String>>(&self, new_ids: I) -> Vec<String> {
+		let mut ids = self.ids.lock().expect("quote retention mutex poisoned");
+		let mut evicted = Vec::new();
+		for id in new_ids {
+			ids.push_back(id);
+			while ids.len() > self.capacity {
+				if let Some(old) = ids.pop_front() {
+					evicted.push(old);
+				}
+			}
+		}
+		evicted
+	}
+}
+
+/// Returns the process-wide quote retention limiter, initializing it with
+/// `capacity` on first use.
+fn quote_retention_limiter(capacity: usize) -> &'static QuoteRetentionLimiter {
+	static LIMITER: OnceLock<QuoteRetentionLimiter> = OnceLock::new();
+	LIMITER.get_or_init(|| QuoteRetentionLimiter::new(capacity))
+}
 
 /// Processes a quote request and returns available quote options.
 ///
@@ -188,8 +243,15 @@ pub async fn process_quote_request(
 		.await?;
 	log_stage("generate_quotes");
 
-	// Persist quotes and cost contexts (including settlement_name internally)
-	store_quotes(solver, &quote_pairs, &cost_context).await;
+	// Persist quotes and cost contexts (including settlement_name internally),
+	// bounded by the configured retention ceiling (H-13).
+	let max_stored_quotes = config
+		.api
+		.as_ref()
+		.and_then(|api| api.quote.as_ref())
+		.map(|q| q.max_stored_quotes)
+		.unwrap_or(solver_config::DEFAULT_QUOTE_MAX_STORED_QUOTES);
+	store_quotes(solver, &quote_pairs, &cost_context, max_stored_quotes).await;
 	log_stage("store_quotes");
 
 	let quotes: Vec<Quote> = quote_pairs.into_iter().map(|(q, _)| q).collect();
@@ -210,6 +272,7 @@ async fn store_quotes(
 	solver: &SolverEngine,
 	quotes: &[(Quote, Option<String>)],
 	cost_context: &CostContext,
+	max_stored_quotes: usize,
 ) {
 	let storage = solver.storage();
 	let now = std::time::SystemTime::now()
@@ -217,6 +280,7 @@ async fn store_quotes(
 		.unwrap_or_default()
 		.as_secs();
 
+	let mut stored_ids: Vec<String> = Vec::with_capacity(quotes.len());
 	for (quote, settlement_name) in quotes {
 		// Calculate TTL from valid_until timestamp
 		let ttl = if quote.valid_until > now {
@@ -256,7 +320,25 @@ async fn store_quotes(
 				ttl,
 				quote.valid_until
 			);
+			stored_ids.push(quote.quote_id.clone());
 		}
+	}
+
+	// Enforce the process-wide retention ceiling (H-13): evict the oldest
+	// quotes once the cap is exceeded so a quote flood cannot grow storage
+	// without bound. Eviction failures are non-fatal (the TTL still applies).
+	let evicted = quote_retention_limiter(max_stored_quotes).register(stored_ids);
+	for id in &evicted {
+		if let Err(e) = storage.remove(StorageKey::Quotes.as_str(), id).await {
+			tracing::debug!("Failed to evict over-capacity quote {}: {}", id, e);
+		}
+	}
+	if !evicted.is_empty() {
+		tracing::debug!(
+			evicted = evicted.len(),
+			cap = max_stored_quotes,
+			"Evicted oldest quotes to respect retention cap"
+		);
 	}
 }
 
@@ -307,6 +389,49 @@ pub async fn quote_exists(quote_id: &str, solver: &SolverEngine) -> Result<bool,
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn retention_limiter_evicts_oldest_beyond_capacity() {
+		let limiter = QuoteRetentionLimiter::new(3);
+		// First three fit under the cap → nothing evicted.
+		assert!(limiter
+			.register(["a", "b", "c"].iter().map(|s| s.to_string()))
+			.is_empty());
+		// Two more exceed the cap of 3 → the two oldest are evicted, oldest first.
+		let evicted = limiter.register(["d", "e"].iter().map(|s| s.to_string()));
+		assert_eq!(evicted, vec!["a".to_string(), "b".to_string()]);
+	}
+
+	#[test]
+	fn retention_limiter_capacity_one_evicts_each_previous() {
+		let limiter = QuoteRetentionLimiter::new(1);
+		assert!(limiter
+			.register(std::iter::once("a".to_string()))
+			.is_empty());
+		assert_eq!(
+			limiter.register(std::iter::once("b".to_string())),
+			vec!["a".to_string()]
+		);
+		assert_eq!(
+			limiter.register(std::iter::once("c".to_string())),
+			vec!["b".to_string()]
+		);
+	}
+
+	#[test]
+	fn retention_limiter_clamps_zero_capacity_to_one() {
+		// A zero cap must not evict the only quote it just stored (that would
+		// break retrieve-by-id immediately); capacity is clamped to >= 1.
+		let limiter = QuoteRetentionLimiter::new(0);
+		assert!(limiter
+			.register(std::iter::once("a".to_string()))
+			.is_empty());
+		assert_eq!(
+			limiter.register(std::iter::once("b".to_string())),
+			vec!["a".to_string()]
+		);
+	}
+
 	use alloy_primitives::Address as AlloyAddress;
 	use solver_account::AccountService;
 	use solver_config::{ApiConfig, ConfigBuilder, QuoteConfig, SettlementConfig};
@@ -563,6 +688,7 @@ mod tests {
 				fill_deadline_seconds: 300,
 				expires_seconds: 600,
 				max_concurrent_requests: solver_config::DEFAULT_QUOTE_MAX_CONCURRENT_REQUESTS,
+				max_stored_quotes: solver_config::DEFAULT_QUOTE_MAX_STORED_QUOTES,
 			}),
 		};
 
@@ -835,8 +961,8 @@ mod tests {
 		let quotes = vec![(create_test_quote(), None)];
 		let cost_context = create_test_cost_context();
 
-		// Test the actual store_quotes function
-		store_quotes(&solver, &quotes, &cost_context).await;
+		// Test the actual store_quotes function (large cap → no eviction)
+		store_quotes(&solver, &quotes, &cost_context, usize::MAX).await;
 
 		// Verify the quote was stored by trying to retrieve it using the public API
 		let result = get_quote_by_id(TEST_QUOTE_ID, &solver).await;
@@ -855,7 +981,7 @@ mod tests {
 		let cost_context = create_test_cost_context();
 
 		// Test the actual store_quotes function with expired quote
-		store_quotes(&solver, &quotes, &cost_context).await;
+		store_quotes(&solver, &quotes, &cost_context, usize::MAX).await;
 
 		// Verify the quote was still stored (memory storage ignores TTL)
 		// Use the public API to retrieve it

--- a/crates/solver-service/src/apis/quote/signing/payloads/permit2.rs
+++ b/crates/solver-service/src/apis/quote/signing/payloads/permit2.rs
@@ -345,6 +345,7 @@ mod tests {
 				fill_deadline_seconds: 300, // 5 minutes
 				expires_seconds: 600,       // 10 minutes
 				max_concurrent_requests: solver_config::DEFAULT_QUOTE_MAX_CONCURRENT_REQUESTS,
+				max_stored_quotes: solver_config::DEFAULT_QUOTE_MAX_STORED_QUOTES,
 			}),
 		};
 

--- a/crates/solver-service/src/auth/admin/types.rs
+++ b/crates/solver-service/src/auth/admin/types.rs
@@ -464,12 +464,14 @@ impl UpdateFeeConfigContents {
 	}
 }
 
-/// `live_fill_estimate_enabled` defaults to `true` when omitted from the
-/// signed payload, matching `OperatorGasConfig`'s default. This keeps existing
-/// admin clients (which haven't started signing the new field yet) from
-/// accidentally turning live fill estimation off on the next gas-config update.
+/// `live_fill_estimate_enabled` defaults to `false` when omitted from the
+/// signed payload, matching `OperatorGasConfig`'s default. A signed gas-config
+/// update that omits the field therefore leaves live fill estimation OFF (the
+/// off-by-default posture of audit finding H-05) rather than silently enabling
+/// the unauthenticated `eth_estimateGas` path; clients opt in explicitly by
+/// signing `live_fill_estimate_enabled: true`.
 fn default_live_fill_estimate_enabled() -> bool {
-	true
+	false
 }
 
 /// UpdateGasConfig action contents

--- a/crates/solver-service/src/config_merge.rs
+++ b/crates/solver-service/src/config_merge.rs
@@ -2480,7 +2480,10 @@ pub fn config_to_operator_config(config: &Config) -> Result<OperatorConfig, Merg
 			resource_lock: OperatorGasFlowUnits::default(),
 			permit2_escrow: OperatorGasFlowUnits::default(),
 			eip3009_escrow: OperatorGasFlowUnits::default(),
-			live_fill_estimate_enabled: true,
+			// Off by default to match OperatorGasConfig's default (H-05): a
+			// missing gas section must not enable the unauthenticated live
+			// eth_estimateGas path.
+			live_fill_estimate_enabled: false,
 			live_post_fill_estimate_chain_ids: HashSet::new(),
 		});
 
@@ -3568,6 +3571,21 @@ mod tests {
 
 		let op_config = merge_to_operator_config(overrides, &TESTNET_SEED).expect("build ok");
 		assert!(!op_config.gas.live_fill_estimate_enabled);
+	}
+
+	#[test]
+	fn bootstrap_defaults_live_fill_estimate_enabled_off() {
+		// H-05 regression: with no override, the seed default must leave live
+		// fill estimation OFF on the public quote path. (Pins the default so a
+		// future flip back to `true` fails this test.)
+		let mut overrides = test_seed_overrides();
+		overrides.live_fill_estimate_enabled = None;
+
+		let op_config = merge_to_operator_config(overrides, &TESTNET_SEED).expect("build ok");
+		assert!(
+			!op_config.gas.live_fill_estimate_enabled,
+			"live fill estimate must default OFF on the public quote path (H-05)"
+		);
 	}
 
 	fn test_tx_bump_config() -> solver_types::OperatorTxBumpConfig {

--- a/crates/solver-service/src/seeds/types.rs
+++ b/crates/solver-service/src/seeds/types.rs
@@ -231,7 +231,10 @@ pub const COMMON_DEFAULTS: SeedDefaults = SeedDefaults {
 	},
 
 	// Live gas estimation flags
-	live_fill_estimate_enabled: true,
+	// Default OFF: the public quote endpoint must not perform an
+	// unauthenticated per-request `eth_estimateGas` by default (audit finding
+	// H-05). Opt in via bootstrap config / signed admin UpdateGasConfig.
+	live_fill_estimate_enabled: false,
 	// Default empty: post-fill override path is opt-in per chain. Operators
 	// add chain IDs via the bootstrap config (`live_post_fill_estimate_chain_ids`)
 	// or via signed admin UpdateGasConfig at runtime.

--- a/crates/solver-types/src/operator_config.rs
+++ b/crates/solver-types/src/operator_config.rs
@@ -455,7 +455,10 @@ fn default_broadcaster_finality_blocks() -> u64 {
 }
 
 fn default_live_fill_estimate_enabled() -> bool {
-	true
+	// Default OFF: the public quote endpoint must not perform an
+	// unauthenticated, per-request `eth_estimateGas` by default (audit finding
+	// H-05). Opt in explicitly behind auth / rate limiting / the concurrency cap.
+	false
 }
 
 fn default_live_post_fill_estimate_chain_ids() -> HashSet<u64> {
@@ -476,7 +479,13 @@ pub struct OperatorGasConfig {
 
 	/// When true, quote-time pricing performs `eth_estimateGas` for the fill
 	/// leg and uses the result instead of the configured per-flow `fill` units.
-	/// Other legs (open/claim) stay static. Defaults to `true`.
+	/// Other legs (open/claim) stay static.
+	///
+	/// Defaults to `false`: the quote endpoint is public/unauthenticated, and a
+	/// default-on live `eth_estimateGas` per request is an RPC-amplification
+	/// vector (audit finding H-05). Operators who want live fill estimation
+	/// should enable it explicitly and pair it with authentication and/or the
+	/// per-chain concurrency cap and request rate limiting.
 	#[serde(default = "default_live_fill_estimate_enabled")]
 	pub live_fill_estimate_enabled: bool,
 
@@ -933,6 +942,24 @@ impl Default for OperatorAdminConfig {
 mod tests {
 	use super::*;
 	use std::str::FromStr;
+
+	#[test]
+	fn operator_gas_config_defaults_live_fill_estimate_off() {
+		// H-05 regression: when the gas config omits `live_fill_estimate_enabled`
+		// it must deserialize to `false` so the public quote path does not
+		// perform an unauthenticated `eth_estimateGas` by default.
+		let json = serde_json::json!({
+			"resource_lock": {"open": 1, "fill": 1, "claim": 1},
+			"permit2_escrow": {"open": 1, "fill": 1, "claim": 1},
+			"eip3009_escrow": {"open": 1, "fill": 1, "claim": 1}
+		});
+		let cfg: OperatorGasConfig =
+			serde_json::from_value(json).expect("OperatorGasConfig should deserialize");
+		assert!(
+			!cfg.live_fill_estimate_enabled,
+			"live_fill_estimate_enabled must default to false (H-05)"
+		);
+	}
 
 	fn test_address() -> Address {
 		Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap()


### PR DESCRIPTION
Stacked on #377 (`h-04-05-13-api-hardening`). Closes the two remaining gaps raised in review of #377.

## H-05 — default the live fill estimate OFF on the public quote path
#377 added a per-chain concurrency cap + default-on rate limiting, but `live_fill_estimate_enabled` still defaulted **true**, so a stock public solver still performed an unauthenticated destination-chain `eth_estimateGas` per `/quotes` request. This defaults it to **false** at **every** materialization site so the default is consistent and can't be silently re-enabled:
- `OperatorGasConfig` serde default (`operator_config.rs`)
- seed defaults (`seeds/types.rs`)
- config builder (`builders/config.rs`)
- **admin `UpdateGasConfig` serde default** (`auth/admin/types.rs`) — a signed gas update that omits the field no longer flips it back on
- runtime `GasConfig` serde default (`solver-config/lib.rs`, now `default_false`)
- the `gas: None` fallback in `config_to_operator_config` (`config_merge.rs`)

The concurrency cap still bounds it for operators who opt in; defaulting off removes the amplification primitive for stock deployments (the finding's primary recommendation). Operators should enable it behind auth / rate limiting.

## H-13 — bound retained `StoredQuote` records
Every accepted quote persists a `StoredQuote`, previously bounded only by per-IP rate limiting — a flood from many distinct source IPs grows storage unbounded. Adds `QuoteConfig.max_stored_quotes` (default **50_000**) and a process-wide FIFO `QuoteRetentionLimiter`: it tracks stored quote ids and, once the cap is exceeded, evicts the oldest from storage (they would expire on their TTL regardless).

Correctness:
- only **successfully-stored** ids are counted (failed `store_with_ttl` excluded), so live quotes aren't evicted prematurely;
- the `std::Mutex` critical section is synchronous — never held across the `storage.remove().await`;
- capacity clamped to `>= 1` (a zero cap would evict the only quote);
- scope is honestly documented: per-process (a multi-replica deployment bounds each replica independently), capacity fixed on first use (`max_stored_quotes` is not runtime-mutable).

## Review
Authored, then ran an adversarial self-review which flagged: the admin default still being `true` (fixed), a dead-but-inconsistent `true` fallback (fixed), and a missing default-pinning regression test (added). 

## Tests
- Retention limiter: FIFO eviction, capacity-1, zero-cap clamp.
- Regression: H-05 default OFF pinned at both `merge_to_operator_config` (no override) and the `OperatorGasConfig` serde default.
- Existing `store_quotes` tests updated for the new signature.

`cargo test` green (solver-types 284, solver-config 33, solver-service 656); `cargo clippy --all-targets` clean on touched crates; `cargo check --workspace --all-targets` green; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)