### PR TITLE
feat: add resource lock configuration and validation for solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ Token arrays may be empty at boot and can be populated later via admin APIs.
   "gas_buffer_bps": 1500,
   "commission_bps": 20,
   "rate_buffer_bps": 14,
+  "resource_lock_enabled": false,
   "networks": [
     {
       "chain_id": 11155420,
@@ -491,6 +492,8 @@ Token arrays may be empty at boot and can be populated later via admin APIs.
 ```
 
 Optional fee overrides can be set at the top level: `min_profitability_pct` (decimal string), `gas_buffer_bps`, `commission_bps`, and `rate_buffer_bps` (basis points).
+
+`resource_lock_enabled` is optional and defaults to `false`. Leave it disabled in production until ResourceLock reservation semantics are implemented. When disabled, the solver rejects ResourceLock quotes, direct `/orders` submissions, and discovered ResourceLock intents before fill. Local Compact demos and e2e runs must opt in explicitly.
 
 For per-chain EIP-1559 fee tuning (priority floor, fallback, percentile speed, gas-price cap), see [docs/fee-policy.md](docs/fee-policy.md). The solver auto-generates sensible defaults — you only need a `fee_policy` block in your bootstrap config if you want to override them.
 
@@ -1371,7 +1374,7 @@ cargo run -p solver-demo -- intent test <post-orders-file>
 **Supported Options:**
 
 - `--swap-type`: `exact-input` or `exact-output`
-- `--settlement`: `escrow` or `compact` (resource locks)
+- `--settlement`: `escrow` or `compact` (resource locks; requires `resource_lock_enabled: true`)
 - `--auth`: `permit2` or `eip3009` (for off-chain submission)
 - `--callback-recipient`: Address to receive callback after fill (optional)
 - `--callback-data`: Hex-encoded data to pass to callback (optional)

--- a/api-spec/orders-api.yaml
+++ b/api-spec/orders-api.yaml
@@ -35,7 +35,7 @@ paths:
 
         Supported order types:
         - `oif-escrow-v0`: Permit2-based escrow orders
-        - `oif-resource-lock-v0`: TheCompact resource lock orders
+        - `oif-resource-lock-v0`: TheCompact resource lock orders. Disabled by default unless the solver is configured with `resource_lock_enabled: true`.
         - `oif-3009-v0`: EIP-3009 gasless transfer orders
 
         Note: This endpoint requires a configured discovery service (offchain_eip7683).
@@ -309,7 +309,7 @@ components:
 
     OifResourceLockV0:
       type: object
-      description: Resource lock order via TheCompact (v0)
+      description: Resource lock order via TheCompact (v0). Solvers reject this order type unless `resource_lock_enabled` is true.
       required:
         - type
         - payload

--- a/api-spec/quotes-api.yaml
+++ b/api-spec/quotes-api.yaml
@@ -18,7 +18,7 @@ info:
 
     - **Permit2 Escrow** (oif-escrow-v0): Universal token approvals via Permit2
     - **EIP-3009 Escrow** (oif-3009-v0): Native gasless transfers for supported tokens
-    - **Resource Lock** (oif-resource-lock-v0): TheCompact allocations for resource locking
+    - **Resource Lock** (oif-resource-lock-v0): TheCompact allocations for resource locking. Disabled by default unless the solver is configured with `resource_lock_enabled: true`.
   version: 1.0.0
 servers:
   - url: http://localhost:3000/api/v1
@@ -427,7 +427,7 @@ components:
 
     OifResourceLockV0:
       type: object
-      description: Resource lock order via TheCompact (v0)
+      description: Resource lock order via TheCompact (v0). Solvers reject this order type unless `resource_lock_enabled` is true.
       required:
         - type
         - payload

--- a/config/demo.json
+++ b/config/demo.json
@@ -210,7 +210,8 @@
   "solver": {
     "id": "oif-solver-demo",
     "min_profitability_pct": "1.0",
-    "monitoring_timeout_seconds": 28800
+    "monitoring_timeout_seconds": 28800,
+    "resource_lock_enabled": true
   },
   "storage": {
     "cleanup_interval_seconds": 60,

--- a/crates/solver-config/src/builders/config.rs
+++ b/crates/solver-config/src/builders/config.rs
@@ -168,6 +168,7 @@ impl ConfigBuilder {
 				monitoring_timeout_seconds: self.monitoring_timeout_seconds,
 				deny_list: self.deny_list,
 				ingress_mode: SolverIngressMode::Active,
+				resource_lock_enabled: false,
 			},
 			networks: self.networks.unwrap_or_default(),
 			storage: StorageConfig {

--- a/crates/solver-config/src/lib.rs
+++ b/crates/solver-config/src/lib.rs
@@ -113,6 +113,10 @@ pub struct SolverConfig {
 	/// Runtime ingress mode controlling whether new solver intake is accepted.
 	#[serde(default)]
 	pub ingress_mode: SolverIngressMode,
+	/// Whether ResourceLock orders are accepted.
+	/// Defaults off until ResourceLock reservation semantics are implemented.
+	#[serde(default)]
+	pub resource_lock_enabled: bool,
 }
 
 /// Runtime ingress mode for accepting new solver work.
@@ -135,6 +139,10 @@ impl SolverIngressMode {
 impl SolverConfig {
 	pub fn is_intake_disabled(&self) -> bool {
 		self.ingress_mode.is_intake_disabled()
+	}
+
+	pub fn is_resource_lock_enabled(&self) -> bool {
+		self.resource_lock_enabled
 	}
 }
 
@@ -1219,6 +1227,14 @@ mod tests {
 	}
 
 	#[test]
+	fn test_resource_lock_enabled_defaults_to_false() {
+		let config = ConfigBuilder::new().build();
+
+		assert!(!config.solver.resource_lock_enabled);
+		assert!(!config.solver.is_resource_lock_enabled());
+	}
+
+	#[test]
 	fn test_settlement_fee_buffer_bps_defaults_to_1000() {
 		let config = ConfigBuilder::new().build();
 
@@ -1237,6 +1253,33 @@ mod tests {
 
 		assert_eq!(solver.ingress_mode, SolverIngressMode::IntakeDisabled);
 		assert!(solver.is_intake_disabled());
+	}
+
+	#[test]
+	fn test_resource_lock_enabled_deserializes_default_false() {
+		let solver: SolverConfig = serde_json::from_value(json!({
+			"id": "test-solver",
+			"min_profitability_pct": "1",
+			"monitoring_timeout_seconds": 30
+		}))
+		.expect("solver config should deserialize");
+
+		assert!(!solver.resource_lock_enabled);
+		assert!(!solver.is_resource_lock_enabled());
+	}
+
+	#[test]
+	fn test_resource_lock_enabled_deserializes_true() {
+		let solver: SolverConfig = serde_json::from_value(json!({
+			"id": "test-solver",
+			"min_profitability_pct": "1",
+			"monitoring_timeout_seconds": 30,
+			"resource_lock_enabled": true
+		}))
+		.expect("solver config should deserialize");
+
+		assert!(solver.resource_lock_enabled);
+		assert!(solver.is_resource_lock_enabled());
 	}
 
 	fn base_config_json(

--- a/crates/solver-core/src/handlers/intent.rs
+++ b/crates/solver-core/src/handlers/intent.rs
@@ -15,8 +15,9 @@ use solver_order::OrderService;
 use solver_settlement::admission::estimate_required_expiry_window_seconds;
 use solver_storage::StorageService;
 use solver_types::{
-	current_timestamp, truncate_id, with_0x_prefix, Address, DiscoveryEvent, Eip7683OrderData,
-	ExecutionDecision, ExecutionParams, Intent, OrderEvent, SolverEvent, StorageKey,
+	current_timestamp, standards::eip7683::LockType, truncate_id, with_0x_prefix, Address,
+	DiscoveryEvent, Eip7683OrderData, ExecutionDecision, ExecutionParams, Intent, OrderEvent,
+	SolverEvent, StorageKey,
 };
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
@@ -152,6 +153,24 @@ impl IntentHandler {
 				.publish(SolverEvent::Discovery(DiscoveryEvent::IntentRejected {
 					intent_id: intent.id,
 					reason: "Solver intake is disabled".to_string(),
+				}))
+				.ok();
+			return Ok(());
+		}
+
+		if intent.lock_type == LockType::ResourceLock.as_str()
+			&& !config.solver.is_resource_lock_enabled()
+		{
+			tracing::warn!(
+				intent_id = %intent.id,
+				"Intent rejected because ResourceLock orders are disabled"
+			);
+			self.event_bus
+				.publish(SolverEvent::Discovery(DiscoveryEvent::IntentRejected {
+					intent_id: intent.id,
+					reason:
+						"ResourceLock orders are disabled by this solver until reservation support is implemented"
+							.to_string(),
 				}))
 				.ok();
 			return Ok(());
@@ -584,6 +603,7 @@ mod tests {
 	use solver_order::{MockExecutionStrategy, MockOrderInterface};
 	use solver_pricing::{MockPricingInterface, PricingService};
 	use solver_storage::{MockStorageInterface, StorageError};
+	use solver_types::standards::eip7683::LockType;
 	use solver_types::utils::tests::builders::{
 		Eip7683OrderDataBuilder, IntentBuilder, MandateOutputBuilder, OrderBuilder,
 	};
@@ -1636,6 +1656,152 @@ mod tests {
 			event,
 			SolverEvent::Discovery(DiscoveryEvent::IntentRejected { intent_id: id, reason })
 				if id == intent_id && reason.contains("intake")
+		));
+	}
+
+	#[tokio::test]
+	async fn test_handle_intent_rejects_resource_lock_before_storage_when_disabled() {
+		let mut mock_storage = MockStorageInterface::new();
+		mock_storage.expect_exists().times(0);
+		mock_storage.expect_set_bytes().times(0);
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let order_service = Arc::new(OrderService::new(
+			HashMap::new(),
+			Box::new(MockExecutionStrategy::new()),
+		));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let mut event_receiver = event_bus.subscribe();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let token_manager = Arc::new(TokenManager::new(
+			Default::default(),
+			delivery.clone(),
+			Arc::new(solver_account::AccountService::new(Box::new(
+				MockAccountInterface::new(),
+			))),
+		));
+		let cost_profit_service = create_mock_cost_profit_service();
+		let (config, static_config) = create_test_config();
+		let intent = IntentBuilder::new()
+			.with_lock_type(LockType::ResourceLock.to_string())
+			.build();
+		let intent_id = intent.id.clone();
+
+		let handler = IntentHandler::new(
+			order_service,
+			storage,
+			state_machine,
+			event_bus,
+			delivery,
+			create_test_address(),
+			token_manager,
+			cost_profit_service,
+			config,
+			&static_config,
+		);
+
+		handler
+			.handle(intent)
+			.await
+			.expect("handler should not error");
+
+		let event = tokio::time::timeout(Duration::from_millis(100), event_receiver.recv())
+			.await
+			.expect("expected rejection event")
+			.expect("event bus should return event");
+
+		assert!(matches!(
+			event,
+			SolverEvent::Discovery(DiscoveryEvent::IntentRejected { intent_id: id, reason })
+				if id == intent_id && reason.contains("ResourceLock orders are disabled")
+		));
+	}
+
+	#[tokio::test]
+	async fn test_handle_intent_allows_resource_lock_when_enabled() {
+		let mut mock_storage = MockStorageInterface::new();
+		let mut mock_order_interface = MockOrderInterface::new();
+
+		let intent = IntentBuilder::new()
+			.with_lock_type(LockType::ResourceLock.to_string())
+			.build();
+		let intent_id = intent.id.clone();
+		let solver_address = create_test_address();
+
+		mock_storage
+			.expect_exists()
+			.with(eq("intents:0xtest_intent_123"))
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(false) }));
+
+		mock_storage
+			.expect_set_bytes()
+			.times(1)
+			.returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
+
+		mock_order_interface
+			.expect_validate_and_create_order()
+			.times(1)
+			.withf(|_, _, lock_type, _, _, _| lock_type == LockType::ResourceLock.as_str())
+			.returning(|_, _, _, _, _, _| {
+				Box::pin(async move {
+					Err(solver_order::OrderError::ValidationFailed(
+						"resource lock reached validation".to_string(),
+					))
+				})
+			});
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let order_service = Arc::new(OrderService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_order_interface) as Box<dyn solver_order::OrderInterface>,
+			)]),
+			Box::new(MockExecutionStrategy::new()),
+		));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let mut event_receiver = event_bus.subscribe();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let token_manager = Arc::new(TokenManager::new(
+			Default::default(),
+			delivery.clone(),
+			Arc::new(solver_account::AccountService::new(Box::new(
+				MockAccountInterface::new(),
+			))),
+		));
+		let cost_profit_service = create_mock_cost_profit_service();
+		let (config, static_config) = create_test_config();
+		config.write().await.solver.resource_lock_enabled = true;
+
+		let handler = IntentHandler::new(
+			order_service,
+			storage,
+			state_machine,
+			event_bus,
+			delivery,
+			solver_address,
+			token_manager,
+			cost_profit_service,
+			config,
+			&static_config,
+		);
+
+		handler
+			.handle(intent)
+			.await
+			.expect("handler should not error");
+
+		let event = tokio::time::timeout(Duration::from_millis(100), event_receiver.recv())
+			.await
+			.expect("expected validation failure event")
+			.expect("event bus should return event");
+
+		assert!(matches!(
+			event,
+			SolverEvent::Discovery(DiscoveryEvent::IntentRejected { intent_id: id, reason })
+				if id == intent_id && reason.contains("resource lock reached validation")
 		));
 	}
 

--- a/crates/solver-demo/src/operations/init/mod.rs
+++ b/crates/solver-demo/src/operations/init/mod.rs
@@ -1207,6 +1207,7 @@ mod tests {
 			rate_buffer_bps: None,
 			monitoring_timeout_seconds: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			rebalance: None,
 			live_fill_estimate_enabled: None,
 			live_post_fill_estimate_chain_ids: None,

--- a/crates/solver-e2e-tests/src/lib.rs
+++ b/crates/solver-e2e-tests/src/lib.rs
@@ -1970,6 +1970,7 @@ fn build_seed_overrides(
 		rate_buffer_bps: None,
 		monitoring_timeout_seconds: None,
 		deny_list: deny_list_path,
+		resource_lock_enabled: Some(options.enable_compact_simple_allocator),
 		rebalance: None,
 		live_fill_estimate_enabled: None,
 		live_post_fill_estimate_chain_ids: None,

--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -1756,6 +1756,7 @@ mod tests {
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 60,
 				deny_list: None,
+				resource_lock_enabled: false,
 			},
 			admin: OperatorAdminConfig {
 				enabled: true,

--- a/crates/solver-service/src/apis/quote/generation.rs
+++ b/crates/solver-service/src/apis/quote/generation.rs
@@ -454,6 +454,12 @@ impl QuoteGenerator {
 		let quote_id = Uuid::new_v4().to_string();
 		let (order, settlement_name) = match custody_decision {
 			CustodyDecision::ResourceLock { lock } => {
+				if !config.solver.is_resource_lock_enabled() {
+					return Err(QuoteError::InvalidRequest(
+						"ResourceLock orders are disabled by this solver until reservation support is implemented"
+							.to_string(),
+					));
+				}
 				let order = self
 					.generate_resource_lock_order(request, config, lock)
 					.await?;
@@ -2764,23 +2770,10 @@ mod tests {
 			.await;
 
 		match result {
-			Ok((quote, _settlement_name)) => {
-				assert!(!quote.quote_id.is_empty());
-				assert_eq!(quote.provider, Some("oif-solver".to_string()));
-				assert!(quote.valid_until > 0);
-				assert!(quote.eta.is_some());
-				// Check that the order is ResourceLock based on the custody decision
-				match &quote.order {
-					OifOrder::OifResourceLockV0 { payload } => {
-						assert_eq!(payload.signature_type, SignatureType::Eip712);
-					},
-					_ => panic!("Expected OifResourceLockV0 order"),
-				}
+			Err(QuoteError::InvalidRequest(message)) => {
+				assert!(message.contains("ResourceLock orders are disabled"));
 			},
-			Err(e) => {
-				// Expected if domain configuration is incomplete
-				assert!(matches!(e, QuoteError::InvalidRequest(_)));
-			},
+			other => panic!("expected ResourceLock disabled error, got {other:?}"),
 		}
 	}
 

--- a/crates/solver-service/src/apis/rebalance.rs
+++ b/crates/solver-service/src/apis/rebalance.rs
@@ -1062,6 +1062,7 @@ mod tests {
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 60,
 				deny_list: None,
+				resource_lock_enabled: false,
 			},
 			admin: OperatorAdminConfig {
 				enabled: true,

--- a/crates/solver-service/src/config_merge.rs
+++ b/crates/solver-service/src/config_merge.rs
@@ -502,6 +502,7 @@ pub fn merge_to_operator_config(
 			rate_buffer_bps,
 			monitoring_timeout_seconds,
 			deny_list: initializer.deny_list.clone(),
+			resource_lock_enabled: initializer.resource_lock_enabled.unwrap_or(false),
 		},
 		admin,
 		orders_auth_enabled: initializer.orders_auth_enabled.unwrap_or(false),
@@ -1217,6 +1218,7 @@ fn build_solver_config_from_operator(
 		} else {
 			SolverIngressMode::Active
 		},
+		resource_lock_enabled: operator_config.solver.resource_lock_enabled,
 	}
 }
 
@@ -2549,6 +2551,7 @@ pub fn config_to_operator_config(config: &Config) -> Result<OperatorConfig, Merg
 			rate_buffer_bps: config.solver.rate_buffer_bps,
 			monitoring_timeout_seconds: config.solver.monitoring_timeout_seconds,
 			deny_list: config.solver.deny_list.clone(),
+			resource_lock_enabled: config.solver.resource_lock_enabled,
 		},
 		admin,
 		orders_auth_enabled,
@@ -3509,6 +3512,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -3566,6 +3570,29 @@ mod tests {
 
 		let op_config = merge_to_operator_config(overrides, &TESTNET_SEED).expect("build ok");
 		assert!(!op_config.gas.live_fill_estimate_enabled);
+	}
+
+	#[test]
+	fn bootstrap_config_defaults_resource_lock_disabled() {
+		let overrides = test_seed_overrides();
+
+		let op_config = merge_to_operator_config(overrides, &TESTNET_SEED).expect("build ok");
+
+		assert!(!op_config.solver.resource_lock_enabled);
+	}
+
+	#[test]
+	fn bootstrap_config_overrides_resource_lock_enabled() {
+		let mut overrides = test_seed_overrides();
+		overrides.resource_lock_enabled = Some(true);
+
+		let op_config =
+			merge_to_operator_config(overrides.clone(), &TESTNET_SEED).expect("build ok");
+		let config = merge_config(overrides, &TESTNET_SEED).expect("runtime config");
+
+		assert!(op_config.solver.resource_lock_enabled);
+		assert!(config.solver.resource_lock_enabled);
+		assert!(config.solver.is_resource_lock_enabled());
 	}
 
 	fn test_tx_bump_config() -> solver_types::OperatorTxBumpConfig {
@@ -3831,6 +3858,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -3893,6 +3921,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -3949,6 +3978,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -3996,6 +4026,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4089,6 +4120,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: Some(Decimal::from_str("2.5").unwrap()), // Override: 2.5%
 			gas_buffer_bps: Some(1500),                                     // Override: 15%
 			settlement_fee_buffer_bps: Some(2000),                          // Override: 20%
@@ -4319,6 +4351,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4387,6 +4420,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4480,6 +4514,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4548,6 +4583,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4622,6 +4658,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4748,6 +4785,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4882,6 +4920,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -4954,6 +4993,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5020,6 +5060,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5121,6 +5162,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5231,6 +5273,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5400,6 +5443,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5541,6 +5585,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5646,6 +5691,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5773,6 +5819,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5929,6 +5976,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -5978,6 +6026,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -6041,6 +6090,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -6097,6 +6147,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -6171,6 +6222,7 @@ mod tests {
 			}),
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,
@@ -6366,6 +6418,7 @@ mod tests {
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 30,
 				deny_list: None,
+				resource_lock_enabled: false,
 			},
 			admin: OperatorAdminConfig::default(),
 			orders_auth_enabled: false,
@@ -6458,6 +6511,10 @@ mod tests {
 		assert_eq!(
 			op_config.solver.settlement_fee_buffer_bps,
 			config.solver.settlement_fee_buffer_bps
+		);
+		assert_eq!(
+			op_config.solver.resource_lock_enabled,
+			config.solver.resource_lock_enabled
 		);
 		assert_eq!(
 			op_config.solver.commission_bps,
@@ -7389,6 +7446,7 @@ mod tests {
 			admin: None,
 			orders_auth_enabled: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			min_profitability_pct: None,
 			gas_buffer_bps: None,
 			settlement_fee_buffer_bps: None,

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -36,9 +36,10 @@ use solver_storage::{
 	StoreConfig,
 };
 use solver_types::{
-	api::PostOrderRequest, standards::eip7683::interfaces::StandardOrder, APIError, Address,
-	ApiErrorType, GetOrderResponse, GetQuoteRequest, GetQuoteResponse, OperatorConfig, Order,
-	OrderIdCallback, Transaction,
+	api::PostOrderRequest,
+	standards::eip7683::{interfaces::StandardOrder, LockType},
+	APIError, Address, ApiErrorType, GetOrderResponse, GetQuoteRequest, GetQuoteResponse,
+	OperatorConfig, Order, OrderIdCallback, Transaction,
 };
 use std::{convert::TryInto, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
@@ -776,6 +777,20 @@ async fn validate_intent_request(
 	let lock_type = intent.order.get_lock_type();
 	let lock_type_str = lock_type.as_str();
 
+	{
+		let config = state.config.read().await;
+		if matches!(lock_type, LockType::ResourceLock) && !config.solver.is_resource_lock_enabled()
+		{
+			return Err(APIError::BadRequest {
+				error_type: ApiErrorType::OrderValidationFailed,
+				message:
+					"ResourceLock orders are disabled by this solver until reservation support is implemented"
+						.to_string(),
+				details: None,
+			});
+		}
+	}
+
 	// Convert to StandardOrder and encode
 	let standard_order =
 		StandardOrder::try_from(&intent.order).map_err(|e| APIError::BadRequest {
@@ -1013,7 +1028,8 @@ mod tests {
 			"solver": {
 				"id": "test-solver",
 				"monitoring_timeout_seconds": 30,
-				"min_profitability_pct": 1.0
+				"min_profitability_pct": 1.0,
+				"resource_lock_enabled": true
 			},
 			"storage": {
 				"primary": "memory",
@@ -1215,7 +1231,9 @@ mod tests {
 			.add_rpc_endpoint(RpcEndpoint::http_only("http://localhost:8545".to_string()))
 			.build();
 		let networks = NetworksConfigBuilder::new().add_network(1, network).build();
-		ConfigBuilder::new().networks(networks).build()
+		let mut config = ConfigBuilder::new().networks(networks).build();
+		config.solver.resource_lock_enabled = true;
+		config
 	}
 
 	fn invalid_resource_lock_request() -> PostOrderRequest {
@@ -1270,6 +1288,46 @@ mod tests {
 			signature: Bytes::from(vec![0u8; 65]),
 			quote_id: None,
 			origin_submission: None,
+		}
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn validate_intent_rejects_resource_lock_when_disabled_before_rpc() {
+		let config = ConfigBuilder::new().build();
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery.expect_eth_call().times(0);
+		let mut delivery_impls: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		delivery_impls.insert(1, Arc::new(mock_delivery) as Arc<dyn DeliveryInterface>);
+		let solver = build_test_solver_engine_with_delivery(config.clone(), delivery_impls).await;
+		let http_client = Client::builder()
+			.no_proxy()
+			.build()
+			.expect("failed to build client");
+		let state = AppState {
+			solver,
+			config: Arc::new(RwLock::new(config)),
+			http_client,
+			discovery_url: None,
+			jwt_service: None,
+			siwe_nonce_store: None,
+			signature_validation: Arc::new(SignatureValidationService::new()),
+		};
+		let intent = invalid_resource_lock_request();
+
+		let error = super::validate_intent_request(&intent, &state, "eip7683")
+			.await
+			.expect_err("resource lock should be rejected when disabled");
+
+		match error {
+			APIError::BadRequest {
+				error_type,
+				message,
+				..
+			} => {
+				assert_eq!(error_type, ApiErrorType::OrderValidationFailed);
+				assert!(message.contains("ResourceLock orders are disabled"));
+			},
+			other => panic!("unexpected error: {other:?}"),
 		}
 	}
 

--- a/crates/solver-types/src/operator_config.rs
+++ b/crates/solver-types/src/operator_config.rs
@@ -567,6 +567,10 @@ pub struct OperatorSolverConfig {
 	/// When set, any intent whose sender or recipient appears in the list is rejected.
 	#[serde(default)]
 	pub deny_list: Option<String>,
+
+	/// Whether ResourceLock orders are accepted by this solver.
+	#[serde(default)]
+	pub resource_lock_enabled: bool,
 }
 
 fn default_gas_buffer_bps() -> u32 {
@@ -1148,6 +1152,7 @@ mod tests {
 				rate_buffer_bps: 14,
 				monitoring_timeout_seconds: 28800,
 				deny_list: None,
+				resource_lock_enabled: false,
 			},
 			admin: OperatorAdminConfig {
 				enabled: true,
@@ -1270,5 +1275,30 @@ mod tests {
 		let parsed: OperatorSolverConfig = serde_json::from_value(json).unwrap();
 
 		assert_eq!(parsed.settlement_fee_buffer_bps, 1000);
+	}
+
+	#[test]
+	fn test_operator_solver_config_defaults_resource_lock_enabled_false() {
+		let json = serde_json::json!({
+			"min_profitability_pct": "1",
+			"monitoring_timeout_seconds": 28800
+		});
+
+		let parsed: OperatorSolverConfig = serde_json::from_value(json).unwrap();
+
+		assert!(!parsed.resource_lock_enabled);
+	}
+
+	#[test]
+	fn test_operator_solver_config_parses_resource_lock_enabled_true() {
+		let json = serde_json::json!({
+			"min_profitability_pct": "1",
+			"monitoring_timeout_seconds": 28800,
+			"resource_lock_enabled": true
+		});
+
+		let parsed: OperatorSolverConfig = serde_json::from_value(json).unwrap();
+
+		assert!(parsed.resource_lock_enabled);
 	}
 }

--- a/crates/solver-types/src/seed_overrides.rs
+++ b/crates/solver-types/src/seed_overrides.rs
@@ -125,6 +125,11 @@ pub struct SeedOverrides {
 	#[serde(default)]
 	pub deny_list: Option<String>,
 
+	/// Enables ResourceLock order intake and quote generation.
+	/// Defaults to false until ResourceLock reservation semantics are implemented.
+	#[serde(default)]
+	pub resource_lock_enabled: Option<bool>,
+
 	/// Optional cross-chain rebalancing configuration.
 	/// If provided, enables the rebalance monitor and admin endpoints.
 	#[serde(default)]
@@ -736,6 +741,7 @@ mod tests {
 			settlement: None,
 			routing_defaults: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			rebalance: None,
 			live_fill_estimate_enabled: None,
 			live_post_fill_estimate_chain_ids: None,
@@ -776,6 +782,7 @@ mod tests {
 			settlement: None,
 			routing_defaults: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			rebalance: None,
 			live_fill_estimate_enabled: None,
 			live_post_fill_estimate_chain_ids: None,
@@ -821,6 +828,7 @@ mod tests {
 			settlement: None,
 			routing_defaults: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			rebalance: None,
 			live_fill_estimate_enabled: None,
 			live_post_fill_estimate_chain_ids: None,
@@ -906,6 +914,7 @@ mod tests {
 			settlement: None,
 			routing_defaults: None,
 			deny_list: None,
+			resource_lock_enabled: None,
 			rebalance: None,
 			live_fill_estimate_enabled: None,
 			live_post_fill_estimate_chain_ids: None,
@@ -927,8 +936,8 @@ mod tests {
 	#[test]
 	fn test_parse_fee_config_fields() {
 		let json = r#"{
-            "networks": [
-                {
+	            "networks": [
+	                {
                     "chain_id": 10,
                     "tokens": [
                         {"symbol": "USDC", "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", "decimals": 6}
@@ -952,6 +961,25 @@ mod tests {
 		assert_eq!(config.settlement_fee_buffer_bps, Some(2000));
 		assert_eq!(config.commission_bps, Some(20));
 		assert_eq!(config.rate_buffer_bps, Some(14));
+	}
+
+	#[test]
+	fn test_parse_resource_lock_enabled() {
+		let json = r#"{
+	            "networks": [
+	                {
+	                    "chain_id": 10,
+	                    "tokens": [
+	                        {"symbol": "USDC", "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85", "decimals": 6}
+	                    ]
+	                }
+	            ],
+	            "resource_lock_enabled": true
+	        }"#;
+
+		let config: SeedOverrides = serde_json::from_str(json).unwrap();
+
+		assert_eq!(config.resource_lock_enabled, Some(true));
 	}
 
 	#[test]
@@ -979,6 +1007,7 @@ mod tests {
 		assert_eq!(config.settlement_fee_buffer_bps, None);
 		assert_eq!(config.commission_bps, None);
 		assert_eq!(config.rate_buffer_bps, None);
+		assert_eq!(config.resource_lock_enabled, None);
 	}
 
 	#[test]

--- a/docs/config-storage.md
+++ b/docs/config-storage.md
@@ -106,6 +106,7 @@ Bootstrap config specifies which networks your solver will support. Networks can
 |-------|----------|-------------|
 | `solver_id` | No | Unique solver identifier. If provided, enables idempotent seeding and derives the EIP-712 admin domain salt that binds admin signatures to this solver instance. If omitted, a UUID is generated. |
 | `monitoring_timeout_seconds` | No | Top-level solver monitoring timeout in seconds. Controls how long post-fill settlement monitoring keeps polling for claim readiness. Valid range: `30` to `1209600` seconds. Defaults to seed/common default (`28800`). Long-latency broadcaster routes may need values like `864000` (10 days). |
+| `resource_lock_enabled` | No | Enables ResourceLock quote generation and intake. Defaults to `false`; leave disabled until ResourceLock reservation semantics are implemented. |
 | `networks` | Yes | Array of networks to support |
 | `networks[].chain_id` | Yes | Chain ID (seeded or non-seeded) |
 | `networks[].tokens` | Yes | Tokens for this network (can be empty at boot) |


### PR DESCRIPTION
# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `resource_lock_enabled` configuration flag to enable ResourceLock order intake and quote generation (disabled by default). ResourceLock orders and quotes are now rejected unless explicitly enabled.

* **Documentation**
  * Updated bootstrap configuration guide, API specifications, and configuration documentation to describe the new ResourceLock enablement flag and its required opt-in behavior for local demos and e2e runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->