### PR TITLE
fix: bound prepare (openFor) gas limit to avoid full-block eth_estimateGas failures

### DIFF
--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -173,6 +173,12 @@ pub struct GasUnits {
 	pub claim_units: u64,
 }
 
+pub(crate) const DEFAULT_OPEN_GAS_UNITS: u64 = 150_000;
+pub(crate) const DEFAULT_FILL_GAS_UNITS: u64 = 150_000;
+pub(crate) const DEFAULT_POST_FILL_GAS_UNITS: u64 = 300_000;
+pub(crate) const DEFAULT_PRE_CLAIM_GAS_UNITS: u64 = 0;
+pub(crate) const DEFAULT_CLAIM_GAS_UNITS: u64 = 150_000;
+
 /// Wei-denominated cost split for the OIF contract gas legs.
 ///
 /// The chain boundaries follow the OIF settler/filler topology:
@@ -677,17 +683,8 @@ impl CostProfitService {
 		// without joining across events.
 		tracing::Span::current().record("chain_id", dest_chain_id);
 
-		let (open_units, fill_units, post_fill_units, pre_claim_units, claim_units) =
-			estimate_gas_units_from_flow_keys(flow_keys, config, 150000, 150000, 300000, 0, 150000);
-
 		// Get gas units for cost calculation
-		let mut gas_units = GasUnits {
-			open_units,
-			fill_units,
-			post_fill_units,
-			pre_claim_units,
-			claim_units,
-		};
+		let mut gas_units = estimate_quote_gas_units_from_flow_keys(flow_keys, config);
 
 		// Optional: live-estimate destination-chain legs against the destination
 		// chain so quote-time costs track the transactions the solver will send.
@@ -3029,6 +3026,30 @@ pub fn estimate_gas_units_from_flow_keys(
 		fallback_pre_claim,
 		fallback_claim,
 	)
+}
+
+pub(crate) fn estimate_quote_gas_units_from_flow_keys(
+	flow_keys: &[String],
+	config: &Config,
+) -> GasUnits {
+	let (open_units, fill_units, post_fill_units, pre_claim_units, claim_units) =
+		estimate_gas_units_from_flow_keys(
+			flow_keys,
+			config,
+			DEFAULT_OPEN_GAS_UNITS,
+			DEFAULT_FILL_GAS_UNITS,
+			DEFAULT_POST_FILL_GAS_UNITS,
+			DEFAULT_PRE_CLAIM_GAS_UNITS,
+			DEFAULT_CLAIM_GAS_UNITS,
+		);
+
+	GasUnits {
+		open_units,
+		fill_units,
+		post_fill_units,
+		pre_claim_units,
+		claim_units,
+	}
 }
 
 #[cfg(test)]

--- a/crates/solver-core/src/handlers/intent.rs
+++ b/crates/solver-core/src/handlers/intent.rs
@@ -4,7 +4,9 @@
 //! and determining execution strategy through the order service.
 
 use crate::engine::{
-	context::ContextBuilder, cost_profit::CostProfitService, event_bus::EventBus,
+	context::ContextBuilder,
+	cost_profit::{estimate_quote_gas_units_from_flow_keys, CostProfitService},
+	event_bus::EventBus,
 	token_manager::TokenManager,
 };
 use crate::state::OrderStateMachine;
@@ -613,10 +615,8 @@ fn apply_prepare_gas_limit_from_config(order: &mut Order, source: &str, config: 
 	}
 
 	let flow_keys = vec![lock_type.as_str().to_string()];
-	let (open_units, _, _, _, _) = crate::engine::cost_profit::estimate_gas_units_from_flow_keys(
-		&flow_keys, config, 150_000, 150_000, 300_000, 0, 150_000,
-	);
-	order_data.gas_limit_overrides.prepare_gas_limit = Some(prepare_gas_cap(open_units));
+	let gas_units = estimate_quote_gas_units_from_flow_keys(&flow_keys, config);
+	order_data.gas_limit_overrides.prepare_gas_limit = Some(prepare_gas_cap(gas_units.open_units));
 	if let Ok(updated_data) = serde_json::to_value(&order_data) {
 		order.data = updated_data;
 	}
@@ -769,6 +769,23 @@ mod tests {
 		assert_eq!(
 			order_data.gas_limit_overrides.prepare_gas_limit,
 			Some(162_818)
+		);
+	}
+
+	#[test]
+	fn prepare_gas_limit_uses_quote_open_units_source() {
+		let config = create_test_config_with_gas_open("permit2_escrow", 146_306);
+		let flow_keys = vec!["permit2_escrow".to_string()];
+		let quote_open_units =
+			estimate_quote_gas_units_from_flow_keys(&flow_keys, &config).open_units;
+		let mut order = create_test_order_with_lock_type(LockType::Permit2Escrow);
+
+		apply_prepare_gas_limit_from_config(&mut order, "off-chain", &config);
+
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data).unwrap();
+		assert_eq!(
+			order_data.gas_limit_overrides.prepare_gas_limit,
+			Some(prepare_gas_cap(quote_open_units))
 		);
 	}
 

--- a/crates/solver-core/src/handlers/intent.rs
+++ b/crates/solver-core/src/handlers/intent.rs
@@ -16,8 +16,8 @@ use solver_settlement::admission::estimate_required_expiry_window_seconds;
 use solver_storage::StorageService;
 use solver_types::{
 	current_timestamp, standards::eip7683::LockType, truncate_id, with_0x_prefix, Address,
-	DiscoveryEvent, Eip7683OrderData, ExecutionDecision, ExecutionParams, Intent, OrderEvent,
-	SolverEvent, StorageKey,
+	DiscoveryEvent, Eip7683OrderData, ExecutionDecision, ExecutionParams, Intent, Order,
+	OrderEvent, SolverEvent, StorageKey,
 };
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
@@ -347,7 +347,9 @@ impl IntentHandler {
 			)
 			.await
 		{
-			Ok(order) => {
+			Ok(mut order) => {
+				apply_prepare_gas_limit_from_config(&mut order, &intent.source, &config);
+
 				// Settlement-aware acceptance gate:
 				// Skip orders that do not leave enough time to reach claim/finalize safely.
 				if let Ok(order_data) =
@@ -495,7 +497,6 @@ impl IntentHandler {
 
 				// Update order's gas_limit_overrides with simulated gas before storing
 				// This ensures the actual fill transaction uses the simulated gas limit
-				let mut order = order;
 				if let Some(simulated_gas) = simulated_fill_gas {
 					if let Ok(mut order_data) =
 						serde_json::from_value::<Eip7683OrderData>(order.data.clone())
@@ -590,6 +591,37 @@ impl IntentHandler {
 	}
 }
 
+fn prepare_gas_cap(open_units: u64) -> u64 {
+	// Quote economics use the tight configured open units; execution needs bounded headroom for
+	// Permit2 cold nonce-bitmap writes and the configured input/output order caps.
+	open_units.saturating_mul(125).saturating_add(99) / 100
+}
+
+fn apply_prepare_gas_limit_from_config(order: &mut Order, source: &str, config: &Config) {
+	if source != "off-chain" {
+		return;
+	}
+
+	let Ok(mut order_data) = serde_json::from_value::<Eip7683OrderData>(order.data.clone()) else {
+		return;
+	};
+	let Some(lock_type) = order_data.lock_type else {
+		return;
+	};
+	if matches!(lock_type, LockType::ResourceLock) {
+		return;
+	}
+
+	let flow_keys = vec![lock_type.as_str().to_string()];
+	let (open_units, _, _, _, _) = crate::engine::cost_profit::estimate_gas_units_from_flow_keys(
+		&flow_keys, config, 150_000, 150_000, 300_000, 0, 150_000,
+	);
+	order_data.gas_limit_overrides.prepare_gas_limit = Some(prepare_gas_cap(open_units));
+	if let Ok(updated_data) = serde_json::to_value(&order_data) {
+		order.data = updated_data;
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -603,7 +635,7 @@ mod tests {
 	use solver_order::{MockExecutionStrategy, MockOrderInterface};
 	use solver_pricing::{MockPricingInterface, PricingService};
 	use solver_storage::{MockStorageInterface, StorageError};
-	use solver_types::standards::eip7683::LockType;
+	use solver_types::standards::eip7683::{GasLimitOverrides, LockType};
 	use solver_types::utils::tests::builders::{
 		Eip7683OrderDataBuilder, IntentBuilder, MandateOutputBuilder, OrderBuilder,
 	};
@@ -674,6 +706,245 @@ mod tests {
 	fn create_test_config() -> (Arc<RwLock<Config>>, Config) {
 		let config = ConfigBuilder::new().build();
 		(Arc::new(RwLock::new(config.clone())), config)
+	}
+
+	fn create_test_config_with_gas_open(flow_key: &str, open: u64) -> Config {
+		let mut config = ConfigBuilder::new().build();
+		let mut gas = solver_config::GasConfig {
+			flows: HashMap::new(),
+			live_fill_estimate_enabled: true,
+			live_post_fill_estimate_chain_ids: HashSet::new(),
+			max_concurrent_live_fill_estimates_per_chain:
+				solver_config::DEFAULT_MAX_CONCURRENT_LIVE_FILL_ESTIMATES_PER_CHAIN,
+		};
+		gas.flows.insert(
+			flow_key.to_string(),
+			solver_config::GasFlowUnits {
+				open: Some(open),
+				fill: Some(150_000),
+				post_fill: Some(300_000),
+				pre_claim: Some(0),
+				claim: Some(150_000),
+			},
+		);
+		config.gas = Some(gas);
+		config
+	}
+
+	fn create_test_order_with_lock_type(lock_type: LockType) -> Order {
+		let mut order_data = Eip7683OrderDataBuilder::new().build();
+		order_data.lock_type = Some(lock_type);
+		order_data.gas_limit_overrides = GasLimitOverrides::default();
+		create_test_order_from_data(order_data)
+	}
+
+	#[test]
+	fn prepare_gas_cap_adds_execution_headroom() {
+		assert_eq!(prepare_gas_cap(146_306), 182_883);
+		assert_eq!(prepare_gas_cap(130_254), 162_818);
+	}
+
+	#[test]
+	fn apply_prepare_gas_limit_sets_permit2_open_units_for_offchain_order() {
+		let config = create_test_config_with_gas_open("permit2_escrow", 146_306);
+		let mut order = create_test_order_with_lock_type(LockType::Permit2Escrow);
+
+		apply_prepare_gas_limit_from_config(&mut order, "off-chain", &config);
+
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data).unwrap();
+		assert_eq!(
+			order_data.gas_limit_overrides.prepare_gas_limit,
+			Some(182_883)
+		);
+	}
+
+	#[test]
+	fn apply_prepare_gas_limit_sets_eip3009_open_units_for_offchain_order() {
+		let config = create_test_config_with_gas_open("eip3009_escrow", 130_254);
+		let mut order = create_test_order_with_lock_type(LockType::Eip3009Escrow);
+
+		apply_prepare_gas_limit_from_config(&mut order, "off-chain", &config);
+
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data).unwrap();
+		assert_eq!(
+			order_data.gas_limit_overrides.prepare_gas_limit,
+			Some(162_818)
+		);
+	}
+
+	#[test]
+	fn apply_prepare_gas_limit_ignores_onchain_orders() {
+		let config = create_test_config_with_gas_open("permit2_escrow", 146_306);
+		let mut order = create_test_order_with_lock_type(LockType::Permit2Escrow);
+
+		apply_prepare_gas_limit_from_config(&mut order, "on-chain", &config);
+
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data).unwrap();
+		assert_eq!(order_data.gas_limit_overrides.prepare_gas_limit, None);
+	}
+
+	#[test]
+	fn apply_prepare_gas_limit_skips_resource_lock() {
+		let config = create_test_config_with_gas_open("resource_lock", 123_456);
+		let mut order = create_test_order_with_lock_type(LockType::ResourceLock);
+
+		apply_prepare_gas_limit_from_config(&mut order, "off-chain", &config);
+
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data).unwrap();
+		assert_eq!(order_data.gas_limit_overrides.prepare_gas_limit, None);
+	}
+
+	async fn assert_handle_stores_prepare_gas_limit_for_quote_id(quote_id: Option<String>) {
+		let mut mock_storage = MockStorageInterface::new();
+		let mut mock_order_interface = MockOrderInterface::new();
+		let mut mock_strategy = MockExecutionStrategy::new();
+
+		let intent = IntentBuilder::new()
+			.with_source("off-chain")
+			.with_quote_id(quote_id.clone())
+			.build();
+		let solver_address = create_test_address();
+
+		mock_storage
+			.expect_exists()
+			.with(eq("intents:0xtest_intent_123"))
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(false) }));
+
+		if let Some(ref quote_id) = quote_id {
+			let quote_key = format!("quotes:{quote_id}");
+			mock_storage
+				.expect_get_bytes()
+				.times(1)
+				.returning(move |key| {
+					assert_eq!(key, quote_key);
+					let key = key.to_string();
+					Box::pin(async move { Err(StorageError::NotFound(key)) })
+				});
+		}
+
+		mock_storage
+			.expect_set_bytes()
+			.withf(|key: &str, _: &Vec<u8>, _, _| key.starts_with("intents:"))
+			.times(1)
+			.returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
+
+		mock_storage
+			.expect_set_bytes()
+			.withf(|key: &str, bytes: &Vec<u8>, _, _| {
+				if !key.starts_with("orders:") {
+					return false;
+				}
+				let Ok(order) = serde_json::from_slice::<Order>(bytes) else {
+					return false;
+				};
+				if order.execution_params.is_none() {
+					return false;
+				}
+				let Ok(order_data) = serde_json::from_value::<Eip7683OrderData>(order.data.clone())
+				else {
+					return false;
+				};
+				order_data.gas_limit_overrides.prepare_gas_limit == Some(182_883)
+			})
+			.times(1)
+			.returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
+
+		mock_order_interface
+			.expect_validate_and_create_order()
+			.times(1)
+			.returning(move |_, _, _, _, _, _| {
+				Box::pin(
+					async move { Ok(create_test_order_with_lock_type(LockType::Permit2Escrow)) },
+				)
+			});
+		mock_order_interface
+			.expect_generate_fill_transaction()
+			.times(1)
+			.returning(|_, _| {
+				Box::pin(async move {
+					Ok(solver_types::Transaction {
+						to: Some(solver_types::Address(vec![0u8; 20])),
+						data: vec![],
+						value: U256::ZERO,
+						chain_id: 137,
+						nonce: None,
+						gas_limit: Some(200000),
+						gas_price: None,
+						max_fee_per_gas: None,
+						max_priority_fee_per_gas: None,
+					})
+				})
+			});
+
+		mock_strategy
+			.expect_should_execute()
+			.times(1)
+			.returning(|_, _| {
+				Box::pin(async move {
+					ExecutionDecision::Execute(ExecutionParams {
+						gas_price: U256::from(20000000000u64),
+						priority_fee: Some(U256::from(1000u64)),
+					})
+				})
+			});
+
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let order_service = Arc::new(OrderService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_order_interface) as Box<dyn solver_order::OrderInterface>,
+			)]),
+			Box::new(mock_strategy),
+		));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let token_manager = Arc::new(TokenManager::new(
+			Default::default(),
+			delivery.clone(),
+			Arc::new(solver_account::AccountService::new(Box::new(
+				MockAccountInterface::new(),
+			))),
+		));
+		let cost_profit_service = if quote_id.is_some() {
+			let mut mock_quote_storage = MockStorageInterface::new();
+			mock_quote_storage.expect_get_bytes().returning(|key| {
+				let key = key.to_string();
+				Box::pin(async move { Err(StorageError::NotFound(key)) })
+			});
+			create_mock_cost_profit_service_with_storage(mock_quote_storage)
+		} else {
+			create_mock_cost_profit_service()
+		};
+		let static_config = create_test_config_with_gas_open("permit2_escrow", 146_306);
+		let config = Arc::new(RwLock::new(static_config.clone()));
+
+		let handler = IntentHandler::new(
+			order_service,
+			storage,
+			state_machine,
+			event_bus,
+			delivery,
+			solver_address,
+			token_manager,
+			cost_profit_service,
+			config,
+			&static_config,
+		);
+
+		let result = handler.handle(intent).await;
+		assert!(result.is_ok());
+	}
+
+	#[tokio::test]
+	async fn handle_direct_offchain_intent_stores_prepare_gas_limit() {
+		assert_handle_stores_prepare_gas_limit_for_quote_id(None).await;
+	}
+
+	#[tokio::test]
+	async fn handle_quote_offchain_intent_stores_prepare_gas_limit() {
+		assert_handle_stores_prepare_gas_limit_for_quote_id(Some("quote-123".to_string())).await;
 	}
 
 	fn create_test_config_with_broadcaster() -> Arc<RwLock<Config>> {
@@ -820,6 +1091,12 @@ mod tests {
 	}
 
 	fn create_mock_cost_profit_service() -> Arc<CostProfitService> {
+		create_mock_cost_profit_service_with_storage(MockStorageInterface::new())
+	}
+
+	fn create_mock_cost_profit_service_with_storage(
+		mock_storage: MockStorageInterface,
+	) -> Arc<CostProfitService> {
 		// Create mock pricing service with expected method responses
 		let mut mock_pricing = MockPricingInterface::new();
 
@@ -963,7 +1240,7 @@ mod tests {
 			pricing_service,
 			delivery_service,
 			token_manager,
-			Arc::new(StorageService::new(Box::new(MockStorageInterface::new()))),
+			Arc::new(StorageService::new(Box::new(mock_storage))),
 			settlement_service,
 		))
 	}

--- a/crates/solver-order/src/implementations/standards/_7683.rs
+++ b/crates/solver-order/src/implementations/standards/_7683.rs
@@ -1003,8 +1003,8 @@ mod tests {
 	fn default_output_settler_bytes32() -> alloy_primitives::B256 {
 		let mut bytes = [0u8; 32];
 		bytes[12..32].copy_from_slice(&[
-			0x5C, 0x69, 0xbE, 0xe7, 0x01, 0xef, 0x81, 0x4a, 0x2B, 0x6a, 0x3E, 0xDD, 0x4B, 0x16,
-			0x52, 0xCB, 0x9c, 0xc5, 0xaA, 0x6f,
+			0x5c, 0x69, 0xbe, 0xe7, 0x01, 0xef, 0x81, 0x4a, 0x2b, 0x6a, 0x3e, 0xdd, 0x4b, 0x16,
+			0x52, 0xcb, 0x9c, 0xc5, 0xaa, 0x6f,
 		]);
 		alloy_primitives::B256::from(bytes)
 	}
@@ -1134,6 +1134,7 @@ mod tests {
 		order_data.raw_order_data = Some(format!("0x{}", hex::encode(test_order.abi_encode())));
 		order_data.sponsor = Some("0x1111111111111111111111111111111111111111".to_string());
 		order_data.signature = Some("0x22222222".to_string());
+		order_data.gas_limit_overrides.prepare_gas_limit = Some(182_883);
 
 		let intent = create_test_intent(order_data.clone(), "off-chain");
 		let order = OrderBuilder::new()
@@ -1156,6 +1157,7 @@ mod tests {
 		let tx = result.unwrap().unwrap();
 		assert_eq!(tx.chain_id, 1);
 		assert_eq!(tx.to, Some(Address(vec![0x11; 20])));
+		assert_eq!(tx.gas_limit, Some(182_883));
 		assert!(!tx.data.is_empty());
 	}
 


### PR DESCRIPTION
## Summary

Off-chain escrow orders were failing at execution because the prepare (`openFor`) transaction was submitted with **no gas limit**. That forced the RPC's `eth_estimateGas` to run an affordability check against the full block gas cap (~60M gas), demanding the signer hold ~0.064 ETH up front for a transaction that actually uses ~141k gas. Orders were rejected before they could be sent — surfacing as a misleading "needs 60M gas" error.

This PR gives the prepare transaction a bounded, config-derived gas limit so the RPC no longer performs the block-cap affordability check.

## Root cause

- During EIP-7683 validation, `solver-order` canonicalizes `gas_limit_overrides = GasLimitOverrides::default()` so a crafted `intent_data` cannot dictate gas limits (a deliberate security measure). This leaves `prepare_gas_limit = None`.
- `generate_prepare_transaction` builds the `openFor` tx with `gas_limit: order_data.gas_limit_overrides.prepare_gas_limit` → `None`.
- In `solver-delivery`, when `gas_limit.is_none()` the alloy path calls `provider.estimate_gas(...)`, which on Ethereum triggers an affordability check against the block gas limit.
- Quote-time live estimation only covers the **fill** / **post-fill** legs (`gas.live_fill_estimate_enabled`); it never sets prepare/open gas. So this failure is independent of that flag.

## Fix

In `solver-core`, after validation strips untrusted overrides and before the order is stored / `Preparing` is emitted, set an internal `prepare_gas_limit` for off-chain escrow orders:

- Derive the base from `estimate_quote_gas_units_from_flow_keys` — the same shared helper (and `DEFAULT_*_GAS_UNITS` constants) that quote pricing uses — so quote economics and the prepare cap read the `open` units from one source **by construction**, not by two call sites happening to pass the same literals.
- Apply 25% headroom — `ceil(open * 1.25)` — because the configured value is a tight economic estimate, while a tx gas limit needs slack for cold Permit2 nonce-bitmap writes and the configured input/output caps. e.g. Permit2 `146,306 → 182,883`; EIP-3009 `130,254 → 162,818`.
- On-chain orders and `ResourceLock` flows are left untouched.

The security canonicalization in `solver-order` is preserved — user-supplied gas hints remain ignored.

## Testing

- `cargo test -p solver-core handlers::intent` — headroom math, permit2/eip3009 values, on-chain & resource-lock skips, end-to-end `IntentHandler::handle` for both **direct** and **quote** submissions, and `prepare_gas_limit_uses_quote_open_units_source` (pins quote/prepare to the same `open` source).
- `cargo test -p solver-order generate_prepare_transaction` — asserts the bounded limit propagates into the built `openFor` tx.
- `cargo clippy --all-targets -- -D warnings` clean on `solver-core` and `solver-order`; `cargo fmt --all -- --check` clean.
