### PR TITLE
fix: clamp quote expiry to settlement admission window

### DIFF
--- a/crates/solver-service/src/apis/quote/generation.rs
+++ b/crates/solver-service/src/apis/quote/generation.rs
@@ -619,14 +619,26 @@ impl QuoteGenerator {
 
 		let order = match lock_type {
 			LockType::Permit2Escrow => {
-				self.generate_permit2_order(request, config, input_oracle, output_oracle)
-					.await?
+				self.generate_permit2_order(
+					request,
+					config,
+					Some(selected_settlement),
+					input_oracle,
+					output_oracle,
+				)
+				.await?
 			},
 			// Permit2Escrow and Eip3009Escrow are the only variants that reach
 			// here; the early-return guard above rules out all other lock types.
 			_ => {
-				self.generate_eip3009_order(request, config, input_oracle, output_oracle)
-					.await?
+				self.generate_eip3009_order(
+					request,
+					config,
+					Some(selected_settlement),
+					input_oracle,
+					output_oracle,
+				)
+				.await?
 			},
 		};
 
@@ -637,6 +649,7 @@ impl QuoteGenerator {
 		&self,
 		request: &GetQuoteRequest,
 		config: &Config,
+		settlement_name: Option<&str>,
 		input_oracle: solver_types::Address,
 		output_oracle: solver_types::Address,
 	) -> Result<OifOrder, QuoteError> {
@@ -651,8 +664,13 @@ impl QuoteGenerator {
 		let domain_object = self.build_permit2_domain_object(config, chain_id).await?;
 
 		// Generate the message object without pre-computed digest
-		let message_obj =
-			self.build_permit2_message_object(request, config, input_oracle, output_oracle)?;
+		let message_obj = self.build_permit2_message_object(
+			request,
+			config,
+			settlement_name,
+			input_oracle,
+			output_oracle,
+		)?;
 
 		let order = OifOrder::OifEscrowV0 {
 			payload: OrderPayload {
@@ -671,33 +689,13 @@ impl QuoteGenerator {
 		&self,
 		request: &GetQuoteRequest,
 		config: &Config,
+		settlement_name: Option<&str>,
 		input_oracle: solver_types::Address,
 		output_oracle: solver_types::Address,
 	) -> Result<OifOrder, QuoteError> {
 		use alloy_primitives::hex;
 
 		let current_time = chrono::Utc::now().timestamp() as u64;
-
-		// Calculate separate deadlines
-		// fillDeadline: Time to fill outputs on destination chains (default 5 minutes)
-		let fill_deadline_timestamp = if let Some(min_valid_until) = request.intent.min_valid_until
-		{
-			// If user specifies min_valid_until, use it as fillDeadline
-			min_valid_until
-		} else {
-			let fill_deadline_seconds = self.get_fill_deadline_seconds(config);
-			current_time + fill_deadline_seconds
-		};
-
-		// expires: Time to finalize/claim on origin chain (default 10 minutes, must be > fillDeadline)
-		let expires_timestamp = if let Some(min_valid_until) = request.intent.min_valid_until {
-			// If user specifies min_valid_until, add buffer for expires
-			min_valid_until
-				+ (self.get_expires_seconds(config) - self.get_fill_deadline_seconds(config))
-		} else {
-			let expires_seconds = self.get_expires_seconds(config);
-			current_time + expires_seconds
-		};
 
 		// Get input chain to find the input settler address (the 'to' field)
 		let first_input = &request.intent.inputs[0];
@@ -717,10 +715,32 @@ impl QuoteGenerator {
 			.asset
 			.ethereum_address()
 			.map_err(|e| QuoteError::InvalidRequest(format!("Invalid token address: {e}")))?;
+		let output_chain_ids = request
+			.intent
+			.outputs
+			.iter()
+			.map(|output| {
+				output.asset.ethereum_chain_id().map_err(|e| {
+					QuoteError::InvalidRequest(format!("Invalid output chain ID: {e}"))
+				})
+			})
+			.collect::<Result<Vec<_>, _>>()?;
+		let timing = crate::apis::quote::timing::quote_timing_for_settlement(
+			config,
+			settlement_name,
+			&input_oracle,
+			input_chain_id,
+			&output_chain_ids,
+		);
+		let timestamps = timing.timestamps(current_time, request.intent.min_valid_until);
 
 		// Set fillDeadline for order
-		let fill_deadline = fill_deadline_timestamp as u32;
-		let expires = expires_timestamp as u32;
+		let fill_deadline: u32 = timestamps.fill_deadline.try_into().map_err(|_| {
+			QuoteError::InvalidRequest("Computed fill deadline exceeds uint32".to_string())
+		})?;
+		let expires: u32 = timestamps.expires.try_into().map_err(|_| {
+			QuoteError::InvalidRequest("Computed order expiry exceeds uint32".to_string())
+		})?;
 
 		let ((nonce_u64, order_identifier), domain_object, domain_separator) = tokio::try_join!(
 			self.compute_eip3009_order_identifier(
@@ -1115,27 +1135,6 @@ impl QuoteGenerator {
 
 		let current_time = chrono::Utc::now().timestamp() as u64;
 
-		// Calculate separate deadlines
-		// fillDeadline: Time to fill outputs on destination chains (default 5 minutes)
-		let fill_deadline_timestamp = if let Some(min_valid_until) = request.intent.min_valid_until
-		{
-			// If user specifies min_valid_until, use it as fillDeadline
-			min_valid_until
-		} else {
-			let fill_deadline_seconds = self.get_fill_deadline_seconds(config);
-			current_time + fill_deadline_seconds
-		};
-
-		// expires: Time for BatchCompact signature/claim on origin chain (default 10 minutes, must be > fillDeadline)
-		let expires = if let Some(min_valid_until) = request.intent.min_valid_until {
-			// If user specifies min_valid_until, add buffer for expires
-			min_valid_until
-				+ (self.get_expires_seconds(config) - self.get_fill_deadline_seconds(config))
-		} else {
-			let expires_seconds = self.get_expires_seconds(config);
-			current_time + expires_seconds
-		};
-
 		let nonce = chrono::Utc::now().timestamp_millis() as u64; // Use milliseconds timestamp as nonce for uniqueness (matching direct intent flow)
 
 		// Get user address
@@ -1173,6 +1172,26 @@ impl QuoteGenerator {
 			settlement = selected_input_settlement,
 			"Selected settlement for resource-lock input chain"
 		);
+		let output_chain_ids = request
+			.intent
+			.outputs
+			.iter()
+			.map(|output| {
+				output.asset.ethereum_chain_id().map_err(|e| {
+					QuoteError::InvalidRequest(format!("Invalid output chain ID: {e}"))
+				})
+			})
+			.collect::<Result<Vec<_>, _>>()?;
+		let timing = crate::apis::quote::timing::quote_timing_for_settlement(
+			config,
+			Some(selected_input_settlement),
+			&input_oracle,
+			origin_chain_id,
+			&output_chain_ids,
+		);
+		let timestamps = timing.timestamps(current_time, request.intent.min_valid_until);
+		let fill_deadline_timestamp = timestamps.fill_deadline;
+		let expires = timestamps.expires;
 
 		// Convert inputs to the format expected by TheCompact
 		// For ResourceLock orders, we need to build the proper token IDs and amounts
@@ -1622,14 +1641,20 @@ impl QuoteGenerator {
 		&self,
 		request: &GetQuoteRequest,
 		config: &Config,
+		settlement_name: Option<&str>,
 		input_oracle: solver_types::Address,
 		output_oracle: solver_types::Address,
 	) -> Result<serde_json::Value, QuoteError> {
 		use crate::apis::quote::permit2::build_permit2_batch_witness_digest;
 
 		// Generate the complete message structure
-		let (_final_digest, message_obj) =
-			build_permit2_batch_witness_digest(request, config, input_oracle, output_oracle)?;
+		let (_final_digest, message_obj) = build_permit2_batch_witness_digest(
+			request,
+			config,
+			settlement_name,
+			input_oracle,
+			output_oracle,
+		)?;
 
 		// Extract only the EIP-712 message fields (no metadata like "signing", "digest")
 		let permitted = message_obj
@@ -1700,61 +1725,6 @@ impl QuoteGenerator {
 			.and_then(|api| api.quote.as_ref())
 			.map(|quote| quote.validity_seconds)
 			.unwrap_or_else(|| QuoteConfig::default().validity_seconds)
-	}
-
-	/// Gets the fill deadline duration from configuration.
-	///
-	/// Returns the configured fill deadline seconds from api.quote config or default.
-	fn get_fill_deadline_seconds(&self, config: &Config) -> u64 {
-		config
-			.api
-			.as_ref()
-			.and_then(|api| api.quote.as_ref())
-			.map(|quote| quote.fill_deadline_seconds)
-			.unwrap_or_else(|| QuoteConfig::default().fill_deadline_seconds)
-	}
-
-	/// Gets the expires duration from configuration.
-	///
-	/// Returns the configured expires seconds from api.quote config.
-	///
-	/// If api.quote is not configured, this falls back to the larger of:
-	/// - QuoteConfig default expires
-	/// - settlement implementation `intent_min_expiry_seconds` (when present)
-	///
-	/// This keeps quote expiry aligned with settlement admission guards so
-	/// broadcaster intents are not rejected immediately for short windows.
-	fn get_expires_seconds(&self, config: &Config) -> u64 {
-		let fill_deadline = self.get_fill_deadline_seconds(config);
-		if let Some(expires_seconds) = config
-			.api
-			.as_ref()
-			.and_then(|api| api.quote.as_ref())
-			.map(|quote| quote.expires_seconds)
-		{
-			// Clamp to fill deadline so quotes never expire before they can be filled.
-			return expires_seconds.max(fill_deadline);
-		}
-
-		let default_expires = QuoteConfig::default().expires_seconds;
-		let settlement_min_expiry: u64 = config
-			.settlement
-			.implementations
-			.values()
-			.filter_map(|implementation| {
-				implementation
-					.as_object()
-					.and_then(|table| table.get("intent_min_expiry_seconds"))
-					.and_then(|value| value.as_i64())
-					.filter(|seconds| *seconds >= 0)
-					.map(|seconds| seconds as u64)
-			})
-			.max()
-			.unwrap_or(0);
-
-		let admission_safe_expires =
-			settlement_min_expiry.saturating_add(self.get_fill_deadline_seconds(config));
-		default_expires.max(admission_safe_expires)
 	}
 
 	/// Generates EIP-712 types definition for Permit2 orders
@@ -2430,7 +2400,7 @@ mod tests {
 		let request = create_test_request();
 
 		let result = generator
-			.generate_eip3009_order(&request, &config, input_oracle, output_oracle)
+			.generate_eip3009_order(&request, &config, None, input_oracle, output_oracle)
 			.await;
 
 		match result {
@@ -2465,6 +2435,34 @@ mod tests {
 				assert!(matches!(e, QuoteError::InvalidRequest(_)));
 			},
 		}
+	}
+
+	#[tokio::test]
+	async fn test_generate_eip3009_order_clamps_expiry_to_broadcaster_minimum() {
+		let generator = create_eip3009_success_generator();
+		let mut config = create_test_config();
+		add_broadcaster_min_expiry_to_test_config(&mut config, "test");
+		let mut request = create_test_request();
+		let now = chrono::Utc::now().timestamp() as u64;
+		request.intent.min_valid_until = Some(now + 600);
+		let input_oracle = solver_types::Address(vec![0xaa; 20]);
+		let output_oracle = solver_types::Address(vec![0xdd; 20]);
+
+		let order = generator
+			.generate_eip3009_order(&request, &config, Some("test"), input_oracle, output_oracle)
+			.await
+			.expect("expected EIP-3009 order generation");
+
+		let OifOrder::Oif3009V0 { metadata, .. } = order else {
+			panic!("Expected Oif3009V0 order");
+		};
+		let expires = metadata["expires"].as_u64().expect("metadata expires");
+
+		assert!(
+			expires >= now + 691_200,
+			"expected expires to leave broadcaster settlement window, expires_in={}s",
+			expires.saturating_sub(now)
+		);
 	}
 
 	#[tokio::test]
@@ -2524,6 +2522,33 @@ mod tests {
 			.expect("at least one output should be present");
 		assert!(first_output["chainId"].is_u64());
 		assert_eq!(first_output["chainId"], 137);
+	}
+
+	#[tokio::test]
+	async fn test_build_compact_message_clamps_expiry_to_broadcaster_minimum() {
+		let generator = create_test_generator();
+		let mut config = create_test_config();
+		add_broadcaster_min_expiry_to_test_config(&mut config, "test");
+		let mut request = create_test_request();
+		let now = chrono::Utc::now().timestamp() as u64;
+		request.intent.min_valid_until = Some(now + 600);
+		let params = serde_json::json!({"test": "value"});
+
+		let result = generator
+			.build_compact_message(&request, &config, &params)
+			.await
+			.expect("expected Compact message");
+		let expires = result["expires"]
+			.as_str()
+			.expect("expires string")
+			.parse::<u64>()
+			.expect("expires integer");
+
+		assert!(
+			expires >= now + 691_200,
+			"expected expires to leave broadcaster settlement window, expires_in={}s",
+			expires.saturating_sub(now)
+		);
 	}
 
 	#[test]
@@ -2886,6 +2911,62 @@ mod tests {
 		QuoteGenerator::new(settlement_service, delivery_service)
 	}
 
+	fn create_eip3009_success_generator() -> QuoteGenerator {
+		use alloy_sol_types::{sol, SolCall};
+
+		sol! {
+			function name() external view returns (string);
+			function DOMAIN_SEPARATOR() external view returns (bytes32);
+		}
+
+		let name_selector = nameCall {}.abi_encode()[0..4].to_vec();
+		let name_response = Bytes::from(nameCall::abi_encode_returns(&"USD Coin".to_string()));
+		let domain_separator_selector = DOMAIN_SEPARATORCall {}.abi_encode()[0..4].to_vec();
+		let domain_separator_response = Bytes::from(vec![0x44; 32]);
+		let order_identifier_response = Bytes::from(vec![0x55; 32]);
+
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery.expect_eth_call().returning(move |tx| {
+			let name_selector = name_selector.clone();
+			let name_response = name_response.clone();
+			let domain_separator_selector = domain_separator_selector.clone();
+			let domain_separator_response = domain_separator_response.clone();
+			let order_identifier_response = order_identifier_response.clone();
+			Box::pin(async move {
+				if tx.data.starts_with(&name_selector) {
+					return Ok(name_response);
+				}
+				if tx.data.starts_with(&domain_separator_selector) {
+					return Ok(domain_separator_response);
+				}
+				Ok(order_identifier_response)
+			})
+		});
+
+		create_test_generator_with_mock_delivery(1, mock_delivery)
+	}
+
+	fn add_broadcaster_min_expiry_to_test_config(config: &mut Config, implementation_name: &str) {
+		config.settlement.implementations.insert(
+			implementation_name.to_string(),
+			serde_json::json!({
+				"intent_min_expiry_seconds": 691_200,
+				"oracles": {
+					"input": {
+						"1": ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+					},
+					"output": {
+						"137": ["0xdddddddddddddddddddddddddddddddddddddddd"]
+					}
+				},
+				"routes": {
+					"1": [137]
+				}
+			}),
+		);
+		config.settlement.primary = implementation_name.to_string();
+	}
+
 	fn create_exact_input_request(
 		input_amount: Option<&str>,
 		output_amount: Option<&str>,
@@ -3166,7 +3247,7 @@ mod tests {
 			.expect("Should have settlement for test chains");
 
 		let result = generator
-			.generate_permit2_order(&request, &config, input_oracle, output_oracle)
+			.generate_permit2_order(&request, &config, None, input_oracle, output_oracle)
 			.await;
 
 		match result {
@@ -4041,8 +4122,13 @@ mod tests {
 		let input_oracle = solver_types::Address(vec![0xaa; 20]);
 		let output_oracle = solver_types::Address(vec![0xbb; 20]);
 
-		let result =
-			generator.build_permit2_message_object(&request, &config, input_oracle, output_oracle);
+		let result = generator.build_permit2_message_object(
+			&request,
+			&config,
+			None,
+			input_oracle,
+			output_oracle,
+		);
 
 		match result {
 			Ok(message) => {

--- a/crates/solver-service/src/apis/quote/mod.rs
+++ b/crates/solver-service/src/apis/quote/mod.rs
@@ -66,6 +66,7 @@ pub mod custody;
 pub mod generation;
 pub mod registry;
 pub mod signing;
+pub(crate) mod timing;
 pub mod validation;
 
 use self::generation::QuoteGenerator;
@@ -758,6 +759,29 @@ mod tests {
 			.build()
 	}
 
+	fn add_broadcaster_min_expiry_to_quote_processing_config(
+		config: &mut solver_config::Config,
+		min_expiry_seconds: u64,
+	) {
+		config.settlement.implementations.insert(
+			"test".to_string(),
+			serde_json::json!({
+				"oracles": {
+					"input": {
+						"1": ["0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+					},
+					"output": {
+						"137": ["0xdddddddddddddddddddddddddddddddddddddddd"]
+					}
+				},
+				"routes": {
+					"1": [137]
+				},
+				"intent_min_expiry_seconds": min_expiry_seconds
+			}),
+		);
+	}
+
 	fn create_quote_processing_settlement_service() -> Arc<SettlementService> {
 		let mut input_oracles = HashMap::new();
 		let mut output_oracles = HashMap::new();
@@ -1178,5 +1202,36 @@ mod tests {
 		assert_eq!(response.quotes[0].provider.as_deref(), Some("oif-solver"));
 		assert_eq!(response.quotes[0].eta, Some(96));
 		assert!(!response.quotes[0].quote_id.is_empty());
+	}
+
+	#[tokio::test]
+	async fn test_process_quote_request_clamps_permit2_expiry_to_broadcaster_window() {
+		let solver = create_quote_processing_solver_engine();
+		let request = create_quote_processing_request();
+		let mut config = solver.dynamic_config().read().await.clone();
+		add_broadcaster_min_expiry_to_quote_processing_config(&mut config, 3_600);
+
+		let before = current_timestamp();
+		let result = process_quote_request(request, &solver, &config).await;
+
+		assert!(
+			result.is_ok(),
+			"expected quote generation to succeed: {result:?}"
+		);
+
+		let response = result.unwrap();
+		let quote = &response.quotes[0];
+		match &quote.order {
+			OifOrder::OifEscrowV0 { payload } => {
+				let expires = payload.message["witness"]["expires"]
+					.as_u64()
+					.expect("Permit2 witness expires should be numeric");
+				assert!(
+					expires >= before + 3_900,
+					"expires={expires} should cover fill_deadline_seconds + broadcaster minimum"
+				);
+			},
+			other => panic!("expected Permit2 escrow quote, got {other:?}"),
+		}
 	}
 }

--- a/crates/solver-service/src/apis/quote/signing/payloads/permit2.rs
+++ b/crates/solver-service/src/apis/quote/signing/payloads/permit2.rs
@@ -21,7 +21,7 @@
 use crate::apis::quote::registry::PROTOCOL_REGISTRY;
 use alloy_primitives::{keccak256, B256, U256};
 use serde_json::json;
-use solver_config::{Config, QuoteConfig};
+use solver_config::Config;
 use solver_types::utils::{
 	bytes20_to_alloy_address, DOMAIN_TYPE, MANDATE_OUTPUT_TYPE, NAME_PERMIT2, PERMIT2_WITNESS_TYPE,
 	PERMIT_BATCH_WITNESS_TYPE, TOKEN_PERMISSIONS_TYPE,
@@ -31,52 +31,10 @@ use solver_types::{
 	GetQuoteRequest, QuoteError,
 };
 
-fn settlement_min_expiry_seconds(config: &Config) -> u64 {
-	config
-		.settlement
-		.implementations
-		.values()
-		.filter_map(|implementation| {
-			implementation
-				.as_object()
-				.and_then(|table| table.get("intent_min_expiry_seconds"))
-				.and_then(|value| value.as_i64())
-				.filter(|seconds| *seconds >= 0)
-				.map(|seconds| seconds as u64)
-		})
-		.max()
-		.unwrap_or(0)
-}
-
-fn quote_fill_deadline_seconds(config: &Config) -> u64 {
-	config
-		.api
-		.as_ref()
-		.and_then(|api| api.quote.as_ref())
-		.map(|quote| quote.fill_deadline_seconds)
-		.unwrap_or_else(|| QuoteConfig::default().fill_deadline_seconds)
-}
-
-fn quote_expires_seconds(config: &Config) -> u64 {
-	if let Some(expires_seconds) = config
-		.api
-		.as_ref()
-		.and_then(|api| api.quote.as_ref())
-		.map(|quote| quote.expires_seconds)
-	{
-		return expires_seconds;
-	}
-
-	let admission_safe_expires =
-		settlement_min_expiry_seconds(config).saturating_add(quote_fill_deadline_seconds(config));
-	QuoteConfig::default()
-		.expires_seconds
-		.max(admission_safe_expires)
-}
-
 pub fn build_permit2_batch_witness_digest(
 	request: &GetQuoteRequest,
 	config: &Config,
+	settlement_name: Option<&str>,
 	input_oracle: solver_types::Address,
 	output_oracle: solver_types::Address,
 ) -> Result<(B256, serde_json::Value), QuoteError> {
@@ -149,6 +107,7 @@ pub fn build_permit2_batch_witness_digest(
 		})?;
 
 	// Use the pre-selected oracle address
+	let input_oracle_for_timing = input_oracle.clone();
 	let input_oracle = bytes20_to_alloy_address(&input_oracle.0)
 		.map_err(|e| QuoteError::InvalidRequest(format!("Invalid oracle address: {e}")))?;
 	let output_oracle_address = bytes20_to_alloy_address(&output_oracle.0)
@@ -161,27 +120,19 @@ pub fn build_permit2_batch_witness_digest(
 	let now_secs = chrono::Utc::now().timestamp() as u64;
 	let nonce_ms: U256 = U256::from((chrono::Utc::now().timestamp_millis()) as u128);
 
-	// Calculate separate deadlines
-	// deadline (Permit2 openFor deadline): Time to open the order (default 5 minutes, matches fillDeadline)
-	let fill_deadline_timestamp = if let Some(min_valid_until) = request.intent.min_valid_until {
-		// If user specifies min_valid_until, use it as fillDeadline
-		min_valid_until
-	} else {
-		now_secs + quote_fill_deadline_seconds(config)
-	};
+	let timing = crate::apis::quote::timing::quote_timing_for_settlement(
+		config,
+		settlement_name,
+		&input_oracle_for_timing,
+		origin_chain_id,
+		&[dest_chain_id],
+	);
+	let timestamps = timing.timestamps(now_secs, request.intent.min_valid_until);
 
-	// expires (witness expires): Time to finalize/claim on origin chain (default 10 minutes, must be > fillDeadline)
-	let expires_timestamp = if let Some(min_valid_until) = request.intent.min_valid_until {
-		// If user specifies min_valid_until, add buffer for expires
-		let fill_deadline_seconds = quote_fill_deadline_seconds(config);
-		let expires_seconds = quote_expires_seconds(config);
-		min_valid_until + (expires_seconds - fill_deadline_seconds)
-	} else {
-		now_secs + quote_expires_seconds(config)
-	};
-
-	let deadline_secs: U256 = U256::from(fill_deadline_timestamp);
-	let expires_secs: u32 = expires_timestamp as u32;
+	let deadline_secs: U256 = U256::from(timestamps.fill_deadline);
+	let expires_secs: u32 = timestamps.expires.try_into().map_err(|_| {
+		QuoteError::InvalidRequest("Computed order expiry exceeds uint32".to_string())
+	})?;
 
 	// Type hashes
 	let domain_type_hash = keccak256(DOMAIN_TYPE.as_bytes());
@@ -415,6 +366,27 @@ mod tests {
 		}
 	}
 
+	fn add_broadcaster_min_expiry(config: &mut Config) {
+		config.settlement.implementations.insert(
+			"broadcaster".to_string(),
+			serde_json::json!({
+				"intent_min_expiry_seconds": 691_200,
+				"oracles": {
+					"input": {
+						"1": ["0x1999999999999999999999999999999999999999"]
+					},
+					"output": {
+						"137": ["0x2999999999999999999999999999999999999999"]
+					}
+				},
+				"routes": {
+					"1": [137]
+				}
+			}),
+		);
+		config.settlement.primary = "broadcaster".to_string();
+	}
+
 	#[test]
 	fn test_build_permit2_batch_witness_digest_success() {
 		let config = create_test_config();
@@ -427,6 +399,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -486,6 +459,7 @@ mod tests {
 		let (digest, message_json) = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		)
@@ -527,6 +501,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -560,6 +535,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -593,6 +569,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -639,6 +616,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -669,6 +647,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -694,6 +673,43 @@ mod tests {
 	}
 
 	#[test]
+	fn test_build_permit2_batch_witness_digest_clamps_expiry_to_broadcaster_minimum() {
+		let mut config = create_test_config();
+		add_broadcaster_min_expiry(&mut config);
+		let mut request = create_test_quote_request();
+		let now = chrono::Utc::now().timestamp() as u64;
+		let min_valid_until = now + 600;
+		request.intent.min_valid_until = Some(min_valid_until);
+		let input_oracle_address =
+			parse_address("0x1999999999999999999999999999999999999999").unwrap();
+		let output_oracle_address =
+			parse_address("0x2999999999999999999999999999999999999999").unwrap();
+
+		let (_digest, message_json) = build_permit2_batch_witness_digest(
+			&request,
+			&config,
+			Some("broadcaster"),
+			input_oracle_address,
+			output_oracle_address,
+		)
+		.expect("Expected successful digest generation");
+
+		let deadline = message_json["deadline"]
+			.as_str()
+			.unwrap()
+			.parse::<u64>()
+			.unwrap();
+		let expires = message_json["witness"]["expires"].as_u64().unwrap();
+
+		assert_eq!(deadline, min_valid_until);
+		assert!(
+			expires >= now + 691_200,
+			"expected expires to leave broadcaster settlement window, expires_in={}s",
+			expires.saturating_sub(now)
+		);
+	}
+
+	#[test]
 	fn test_build_permit2_batch_witness_digest_deterministic() {
 		let config = create_test_config();
 		let request = create_test_quote_request();
@@ -706,6 +722,7 @@ mod tests {
 		let result1 = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address.clone(),
 			output_oracle_address.clone(),
 		);
@@ -716,6 +733,7 @@ mod tests {
 		let result2 = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);
@@ -745,6 +763,7 @@ mod tests {
 		let result = build_permit2_batch_witness_digest(
 			&request,
 			&config,
+			None,
 			input_oracle_address,
 			output_oracle_address,
 		);

--- a/crates/solver-service/src/apis/quote/timing.rs
+++ b/crates/solver-service/src/apis/quote/timing.rs
@@ -1,0 +1,179 @@
+use solver_config::{Config, QuoteConfig};
+use solver_settlement::{estimate_required_expiry_window_for_route, RouteExpiryInputs};
+use solver_types::Address;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct QuoteTiming {
+	pub validity_seconds: u64,
+	pub fill_deadline_seconds: u64,
+	pub expires_seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct QuoteTimestamps {
+	pub fill_deadline: u64,
+	pub expires: u64,
+}
+
+impl QuoteTiming {
+	pub(crate) fn timestamps(&self, now: u64, min_valid_until: Option<u64>) -> QuoteTimestamps {
+		let fill_deadline =
+			min_valid_until.unwrap_or_else(|| now.saturating_add(self.fill_deadline_seconds));
+		let expiry_after_fill = self
+			.expires_seconds
+			.saturating_sub(self.fill_deadline_seconds);
+		let expires = min_valid_until
+			.map(|deadline| deadline.saturating_add(expiry_after_fill))
+			.unwrap_or_else(|| now.saturating_add(self.expires_seconds));
+
+		QuoteTimestamps {
+			fill_deadline,
+			expires,
+		}
+	}
+}
+
+pub(crate) fn quote_timing_for_settlement(
+	config: &Config,
+	settlement_name: Option<&str>,
+	input_oracle: &Address,
+	origin_chain_id: u64,
+	output_chain_ids: &[u64],
+) -> QuoteTiming {
+	let quote_config = config.api.as_ref().and_then(|api| api.quote.as_ref());
+	let defaults = QuoteConfig::default();
+	let fill_deadline_seconds = quote_config
+		.map(|quote| quote.fill_deadline_seconds)
+		.unwrap_or(defaults.fill_deadline_seconds);
+	let configured_expires_seconds = quote_config
+		.map(|quote| quote.expires_seconds)
+		.unwrap_or(defaults.expires_seconds);
+	let required_window = estimate_required_expiry_window_for_route(
+		&RouteExpiryInputs {
+			input_oracle: input_oracle.clone(),
+			origin_chain_id,
+			output_chain_ids: output_chain_ids.to_vec(),
+		},
+		&config.settlement.implementations,
+		config.settlement.settlement_poll_interval_seconds,
+		settlement_name,
+	)
+	.map(|(window, _breakdown)| window)
+	.unwrap_or(0);
+	let admission_safe_expires = required_window.saturating_add(fill_deadline_seconds);
+
+	QuoteTiming {
+		validity_seconds: quote_config
+			.map(|quote| quote.validity_seconds)
+			.unwrap_or(defaults.validity_seconds),
+		fill_deadline_seconds,
+		expires_seconds: configured_expires_seconds
+			.max(fill_deadline_seconds)
+			.max(admission_safe_expires),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use solver_config::{
+		ApiConfig, ApiImplementations, Config, ConfigBuilder, QuoteConfig, SettlementConfig,
+	};
+	use solver_types::utils::parse_address;
+	use std::collections::HashMap;
+
+	fn api_with_default_quote() -> ApiConfig {
+		ApiConfig {
+			enabled: true,
+			host: "0.0.0.0".to_string(),
+			port: 3000,
+			timeout_seconds: 30,
+			max_request_size: 1024 * 1024,
+			implementations: ApiImplementations::default(),
+			rate_limiting: None,
+			cors: None,
+			auth: None,
+			quote: Some(QuoteConfig::default()),
+		}
+	}
+
+	fn config_with_broadcaster(broadcaster: serde_json::Value) -> Config {
+		ConfigBuilder::new()
+			.api(Some(api_with_default_quote()))
+			.settlement(SettlementConfig {
+				implementations: HashMap::from([("broadcaster".to_string(), broadcaster)]),
+				primary: "broadcaster".to_string(),
+				settlement_poll_interval_seconds: 3,
+			})
+			.build()
+	}
+
+	fn input_oracle() -> solver_types::Address {
+		parse_address("0x1111111111111111111111111111111111111111").unwrap()
+	}
+
+	fn broadcaster_with_explicit_min() -> serde_json::Value {
+		serde_json::json!({
+			"intent_min_expiry_seconds": 691_200,
+			"oracles": {
+				"input": { "1": ["0x1111111111111111111111111111111111111111"] },
+				"output": { "42161": ["0x2222222222222222222222222222222222222222"] }
+			},
+			"routes": { "1": [42161] }
+		})
+	}
+
+	fn broadcaster_with_additive_estimate() -> serde_json::Value {
+		serde_json::json!({
+			"proof_wait_time_seconds": 604_800,
+			"storage_proof_timeout_seconds": 120,
+			"default_finality_blocks": 20,
+			"oracles": {
+				"input": { "1": ["0x1111111111111111111111111111111111111111"] },
+				"output": { "42161": ["0x2222222222222222222222222222222222222222"] }
+			},
+			"routes": { "1": [42161] }
+		})
+	}
+
+	#[test]
+	fn quote_timing_clamps_default_api_quote_to_broadcaster_minimum() {
+		let config = config_with_broadcaster(broadcaster_with_explicit_min());
+		let input_oracle = input_oracle();
+
+		let timing =
+			quote_timing_for_settlement(&config, Some("broadcaster"), &input_oracle, 1, &[42161]);
+
+		assert_eq!(timing.fill_deadline_seconds, 300);
+		assert!(timing.expires_seconds >= 691_200 + 300);
+	}
+
+	#[test]
+	fn quote_timestamps_with_min_valid_until_leave_full_window() {
+		let now = 1_779_000_000;
+		let min_valid_until = now + 600;
+		let timing = QuoteTiming {
+			validity_seconds: 60,
+			fill_deadline_seconds: 300,
+			expires_seconds: 691_200 + 300,
+		};
+
+		let timestamps = timing.timestamps(now, Some(min_valid_until));
+
+		assert_eq!(timestamps.fill_deadline, min_valid_until);
+		assert_eq!(timestamps.expires, min_valid_until + 691_200);
+		assert!(timestamps.expires >= now + 691_200);
+	}
+
+	#[test]
+	fn quote_timing_clamps_to_broadcaster_additive_estimate_without_explicit_key() {
+		let config = config_with_broadcaster(broadcaster_with_additive_estimate());
+		let input_oracle = input_oracle();
+
+		let timing =
+			quote_timing_for_settlement(&config, Some("broadcaster"), &input_oracle, 1, &[42161]);
+
+		assert_eq!(timing.fill_deadline_seconds, 300);
+		assert!(timing.expires_seconds >= 604_800 + 300);
+	}
+}

--- a/crates/solver-service/src/config_merge.rs
+++ b/crates/solver-service/src/config_merge.rs
@@ -7069,6 +7069,57 @@ mod tests {
 	}
 
 	#[test]
+	fn test_operator_default_quote_config_does_not_undercut_broadcaster_expiry() {
+		let admin = OperatorAdminConfig {
+			enabled: false,
+			domain: "".to_string(),
+			chain_id: 0,
+			nonce_ttl_seconds: 0,
+			whitelist: vec![],
+			withdrawals: OperatorWithdrawalsConfig::default(),
+		};
+		let api = build_api_config_from_operator(&admin, false).unwrap();
+		let config = solver_config::ConfigBuilder::new()
+			.api(Some(api))
+			.settlement(SettlementConfig {
+				implementations: HashMap::from([(
+					"broadcaster".to_string(),
+					serde_json::json!({
+						"intent_min_expiry_seconds": 691_200,
+						"oracles": {
+							"input": {
+								"1": ["0x1111111111111111111111111111111111111111"]
+							},
+							"output": {
+								"42161": ["0x2222222222222222222222222222222222222222"]
+							}
+						},
+						"routes": {
+							"1": [42161]
+						}
+					}),
+				)]),
+				primary: "broadcaster".to_string(),
+				settlement_poll_interval_seconds: 3,
+			})
+			.build();
+		let input_oracle =
+			solver_types::utils::parse_address("0x1111111111111111111111111111111111111111")
+				.unwrap();
+
+		let timing = crate::apis::quote::timing::quote_timing_for_settlement(
+			&config,
+			Some("broadcaster"),
+			&input_oracle,
+			1,
+			&[42161],
+		);
+
+		assert_eq!(timing.fill_deadline_seconds, 300);
+		assert!(timing.expires_seconds >= 691_500);
+	}
+
+	#[test]
 	#[serial]
 	fn test_build_api_config_from_operator_uses_env_port_override() {
 		let key = "SOLVER_API_PORT";

--- a/crates/solver-settlement/src/admission.rs
+++ b/crates/solver-settlement/src/admission.rs
@@ -10,6 +10,15 @@ const DEFAULT_BROADCASTER_FINALITY_BLOCKS: u64 = 20;
 const DEFAULT_SETTLEMENT_SAFETY_BUFFER_SECONDS: u64 = 90;
 const DEFAULT_BLOCK_TIME_SECONDS: u64 = 12;
 
+/// Minimal route data needed to estimate the settlement window required before
+/// an order expires.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteExpiryInputs {
+	pub input_oracle: Address,
+	pub origin_chain_id: u64,
+	pub output_chain_ids: Vec<u64>,
+}
+
 fn parse_optional_u64(value: Option<&serde_json::Value>, default_value: u64) -> u64 {
 	value
 		.and_then(serde_json::Value::as_u64)
@@ -31,17 +40,15 @@ fn parse_chain_u64_table(value: Option<&serde_json::Value>) -> HashMap<u64, u64>
 	parsed
 }
 
-fn implementation_supports_order(
+fn implementation_supports_route(
 	implementation_cfg: &serde_json::Value,
-	order_data: &Eip7683OrderData,
-	input_oracle: &Address,
+	inputs: &RouteExpiryInputs,
 ) -> bool {
-	let origin_chain = order_data.origin_chain_id.to::<u64>();
-	let cross_chain_outputs: Vec<u64> = order_data
-		.outputs
+	let cross_chain_outputs: Vec<u64> = inputs
+		.output_chain_ids
 		.iter()
-		.map(|output| output.chain_id.to::<u64>())
-		.filter(|destination| *destination != origin_chain)
+		.copied()
+		.filter(|destination| *destination != inputs.origin_chain_id)
 		.collect();
 
 	if cross_chain_outputs.is_empty() {
@@ -52,14 +59,15 @@ fn implementation_supports_order(
 		return false;
 	};
 
-	let Some(source_input_oracles) = oracle_config.input_oracles.get(&origin_chain) else {
+	let Some(source_input_oracles) = oracle_config.input_oracles.get(&inputs.origin_chain_id)
+	else {
 		return false;
 	};
-	if !source_input_oracles.contains(input_oracle) {
+	if !source_input_oracles.contains(&inputs.input_oracle) {
 		return false;
 	}
 
-	let Some(route_destinations) = oracle_config.routes.get(&origin_chain) else {
+	let Some(route_destinations) = oracle_config.routes.get(&inputs.origin_chain_id) else {
 		return false;
 	};
 	for destination in cross_chain_outputs {
@@ -91,7 +99,7 @@ fn estimated_block_time_seconds(chain_id: u64, chain_block_times: &HashMap<u64, 
 }
 
 fn estimate_broadcaster_expiry_buffer_seconds(
-	order_data: &Eip7683OrderData,
+	inputs: &RouteExpiryInputs,
 	implementation_cfg: &serde_json::Value,
 	poll_interval_seconds: u64,
 ) -> Option<(u64, String)> {
@@ -115,21 +123,19 @@ fn estimate_broadcaster_expiry_buffer_seconds(
 		DEFAULT_SETTLEMENT_SAFETY_BUFFER_SECONDS,
 	);
 
-	let origin_chain = order_data.origin_chain_id.to::<u64>();
 	let mut max_finality_seconds = 0u64;
 	let mut has_cross_chain_output = false;
-	for output in &order_data.outputs {
-		let destination_chain = output.chain_id.to::<u64>();
-		if destination_chain == origin_chain {
+	for destination_chain in &inputs.output_chain_ids {
+		if *destination_chain == inputs.origin_chain_id {
 			continue;
 		}
 		has_cross_chain_output = true;
 		let blocks = finality_blocks
-			.get(&destination_chain)
+			.get(destination_chain)
 			.copied()
 			.unwrap_or(default_finality_blocks);
 		let chain_finality_seconds = blocks.saturating_mul(estimated_block_time_seconds(
-			destination_chain,
+			*destination_chain,
 			&chain_block_times,
 		));
 		max_finality_seconds = max_finality_seconds.max(chain_finality_seconds);
@@ -154,13 +160,12 @@ fn estimate_broadcaster_expiry_buffer_seconds(
 	))
 }
 
-pub fn estimate_required_expiry_window_seconds(
-	order_data: &Eip7683OrderData,
+pub fn estimate_required_expiry_window_for_route(
+	inputs: &RouteExpiryInputs,
 	settlement_implementations: &HashMap<String, serde_json::Value>,
 	settlement_poll_interval_seconds: u64,
 	pinned_settlement_name: Option<&str>,
 ) -> Option<(u64, String)> {
-	let input_oracle = parse_address(&order_data.input_oracle).ok()?;
 	let mut matches: Vec<(u64, String)> = Vec::new();
 
 	for (implementation_name, implementation_cfg) in settlement_implementations {
@@ -170,7 +175,7 @@ pub fn estimate_required_expiry_window_seconds(
 			}
 		}
 
-		if !implementation_supports_order(implementation_cfg, order_data, &input_oracle) {
+		if !implementation_supports_route(implementation_cfg, inputs) {
 			continue;
 		}
 
@@ -189,7 +194,7 @@ pub fn estimate_required_expiry_window_seconds(
 
 		if implementation_name == "broadcaster" {
 			if let Some((required_window, breakdown)) = estimate_broadcaster_expiry_buffer_seconds(
-				order_data,
+				inputs,
 				implementation_cfg,
 				settlement_poll_interval_seconds,
 			) {
@@ -204,6 +209,31 @@ pub fn estimate_required_expiry_window_seconds(
 	matches
 		.into_iter()
 		.max_by_key(|(required_window, _)| *required_window)
+}
+
+pub fn estimate_required_expiry_window_seconds(
+	order_data: &Eip7683OrderData,
+	settlement_implementations: &HashMap<String, serde_json::Value>,
+	settlement_poll_interval_seconds: u64,
+	pinned_settlement_name: Option<&str>,
+) -> Option<(u64, String)> {
+	let input_oracle = parse_address(&order_data.input_oracle).ok()?;
+	let inputs = RouteExpiryInputs {
+		input_oracle,
+		origin_chain_id: order_data.origin_chain_id.to::<u64>(),
+		output_chain_ids: order_data
+			.outputs
+			.iter()
+			.map(|output| output.chain_id.to::<u64>())
+			.collect(),
+	};
+
+	estimate_required_expiry_window_for_route(
+		&inputs,
+		settlement_implementations,
+		settlement_poll_interval_seconds,
+		pinned_settlement_name,
+	)
 }
 
 #[cfg(test)]
@@ -270,5 +300,36 @@ mod tests {
 		assert!(!pinned_broadcaster.1.contains("hyperlane"));
 		assert!(unpinned.0 >= 500);
 		assert!(pinned_broadcaster.0 < unpinned.0);
+	}
+
+	#[test]
+	fn test_route_based_expiry_window_matches_order_based_gate() {
+		let implementations = HashMap::from([("broadcaster".to_string(), broadcaster_config())]);
+		let order_data = Eip7683OrderDataBuilder::new().build();
+		let input_oracle = parse_address(&order_data.input_oracle).unwrap();
+		let route_inputs = RouteExpiryInputs {
+			input_oracle,
+			origin_chain_id: order_data.origin_chain_id.to::<u64>(),
+			output_chain_ids: order_data
+				.outputs
+				.iter()
+				.map(|output| output.chain_id.to::<u64>())
+				.collect(),
+		};
+
+		let order_based = estimate_required_expiry_window_seconds(
+			&order_data,
+			&implementations,
+			3,
+			Some("broadcaster"),
+		);
+		let route_based = estimate_required_expiry_window_for_route(
+			&route_inputs,
+			&implementations,
+			3,
+			Some("broadcaster"),
+		);
+
+		assert_eq!(route_based, order_based);
 	}
 }

--- a/crates/solver-settlement/src/lib.rs
+++ b/crates/solver-settlement/src/lib.rs
@@ -26,6 +26,7 @@ pub mod implementations {
 
 /// Helpers for intent admission heuristics based on settlement configuration.
 pub mod admission;
+pub use admission::{estimate_required_expiry_window_for_route, RouteExpiryInputs};
 
 /// Common utilities for settlement implementations
 pub mod utils;

--- a/docs/config-storage.md
+++ b/docs/config-storage.md
@@ -148,6 +148,10 @@ For broadcaster routes with slow proof availability, tune both:
 - `monitoring_timeout_seconds` for the post-fill claimability loop
 - settlement timing fields such as `settlement.broadcaster.proof_wait_time_seconds` and `settlement.broadcaster.intent_min_expiry_seconds`
 
+Quote expiry is settlement-aware. `api.quote.expires_seconds` controls the operator-preferred minimum order lifetime, but generated signed orders are clamped upward when the selected settlement implementation requires a longer admission window. Keep `api.quote.validity_seconds` short for quote retrieval/cache TTL; do not rely on `api.quote.expires_seconds` to shorten broadcaster orders below `settlement.broadcaster.intent_min_expiry_seconds`.
+
+For seeded deployments, the bootstrap/seed override model does not currently expose `api.quote`. Runtime config still receives the default quote settings during operator-config merge, and the admission-safe quote floor is applied from settlement timing regardless.
+
 The key `intent_min_expiry_seconds` uses the same field name across:
 
 - `settlement.hyperlane.intent_min_expiry_seconds`

--- a/docs/oracles/settlement-timing-configuration.md
+++ b/docs/oracles/settlement-timing-configuration.md
@@ -26,7 +26,22 @@ Important:
 - If `monitoring_timeout_seconds` is too small, the solver can accept and fill an intent but stop monitoring before the route becomes claimable.
 - For week-scale broadcaster proofs such as Arbitrum L2 -> L1, use a monitoring timeout that exceeds the operational claim delay, for example `864000` seconds (10 days).
 
-## 2) Common field name across oracles
+## 2) Quote expiry is settlement-aware
+
+Quote responses expose two separate time concepts:
+
+- `quote.valid_until` controls how long the quote can be retrieved and submitted through the quote flow.
+- The signed order `expires` field controls whether the solver will later admit the intent for execution.
+
+The signed order expiry is computed with the same route-aware settlement window used by the admission gate. `api.quote.expires_seconds` is therefore a floor/preference, not a hard override. The solver may raise the signed order expiry above `api.quote.expires_seconds` when the selected settlement implementation requires a longer window.
+
+For example, with `api.quote.fill_deadline_seconds = 300` and `settlement.broadcaster.intent_min_expiry_seconds = 691200`, generated orders need at least:
+
+`expires_seconds = 300 + 691200 = 691500`
+
+This lets the quote remain short-lived while still producing an order that will pass admission after submission.
+
+## 3) Common field name across oracles
 
 Yes. The same key name is used across implementations:
 
@@ -40,7 +55,7 @@ Supported JSON paths:
 
 When set, this value is used as a fixed minimum window for that implementation.
 
-## 3) Broadcaster computed window (when explicit min is not set)
+## 4) Broadcaster computed window (when explicit min is not set)
 
 If `settlement.broadcaster.intent_min_expiry_seconds` is absent, solver estimates:
 
@@ -58,17 +73,17 @@ Where:
     - OP Stack + Arbitrum IDs: `2s`
     - fallback: `12s`
 
-## 4) Timing fields and defaults
+## 5) Timing fields and defaults
 
-### 4.1 Hyperlane
+### 5.1 Hyperlane
 
 - `settlement.hyperlane.intent_min_expiry_seconds` (optional, no default)
 
-### 4.2 Direct
+### 5.2 Direct
 
 - `settlement.direct.intent_min_expiry_seconds` (optional, no default)
 
-### 4.3 Broadcaster
+### 5.3 Broadcaster
 
 - `settlement.broadcaster.intent_min_expiry_seconds` (optional, no default; fixed window when set)
 - `settlement.broadcaster.proof_wait_time_seconds` (default: `30`)
@@ -78,15 +93,15 @@ Where:
 - `settlement.broadcaster.chain_block_time_seconds` (optional per-chain map)
 - `settlement.broadcaster.intent_safety_buffer_seconds` (default: `90`)
 
-### 4.4 Poll interval (global settlement loop)
+### 5.4 Poll interval (global settlement loop)
 
 - `settlement.settlement_poll_interval_seconds` (in stored operator config; seed defaults usually `3`)
 
 Broadcaster budget includes `2 * settlement_poll_interval_seconds`.
 
-## 5) JSON examples
+## 6) JSON examples
 
-### 5.1 Hyperlane fixed minimum window
+### 6.1 Hyperlane fixed minimum window
 
 ```json
 {
@@ -99,7 +114,7 @@ Broadcaster budget includes `2 * settlement_poll_interval_seconds`.
 }
 ```
 
-### 5.2 Direct fixed minimum window
+### 6.2 Direct fixed minimum window
 
 ```json
 {
@@ -112,7 +127,7 @@ Broadcaster budget includes `2 * settlement_poll_interval_seconds`.
 }
 ```
 
-### 5.3 Broadcaster computed budget with per-chain tuning
+### 6.3 Broadcaster computed budget with per-chain tuning
 
 ```json
 {
@@ -136,7 +151,7 @@ Broadcaster budget includes `2 * settlement_poll_interval_seconds`.
 }
 ```
 
-### 5.4 Broadcaster fixed minimum window (overrides computed budget)
+### 6.4 Broadcaster fixed minimum window (overrides computed budget)
 
 ```json
 {
@@ -149,14 +164,14 @@ Broadcaster budget includes `2 * settlement_poll_interval_seconds`.
 }
 ```
 
-## 6) Practical recommendation
+## 7) Practical recommendation
 
 1. Start with explicit `intent_min_expiry_seconds` for each settlement.
 2. Measure real settlement latency by route.
 3. Keep a safety margin for reorgs/prover delays.
 4. For broadcaster, only move to computed budgeting when per-chain finality and block-time inputs are accurate.
 
-## 7) Type references
+## 8) Type references
 
 - Seed override JSON model: `crates/solver-types/src/seed_overrides.rs`
 - Stored operator config model: `crates/solver-types/src/operator_config.rs`


### PR DESCRIPTION
## Problem

Broadcaster-settled intents were discovered by the solver and then immediately skipped:

```
Skipping order ... reason=Insufficient settlement window: expires_in=588s required=691200s
```

Because the order was skipped (not stored), every status poll returned "order not found" and the UI showed N/A / zero placeholders.

## Root cause

Quote generation produced a short signed-order `expires` (default `api.quote.expires_seconds = 600s`), but the settlement admission gate (added in #301) requires the order to retain at least the settlement's `intent_min_expiry_seconds` (8 days for the mainnet broadcaster).

Quote-gen and admission computed the required window **independently**. The quote path *did* have a settlement-aware floor, but it was dead code whenever `api.quote` was `Some(..)` — which is always the case on the seeded path, since `build_api_config_from_operator` hardcodes `Some(QuoteConfig::default())` (600s). So the floor never applied and `expires` stayed at ~600s.

## Fix

Make quote generation reuse the gate's own window calculation so the two cannot drift:

- Extract a route-based core `estimate_required_expiry_window_for_route` in `solver-settlement`; the existing order-based `estimate_required_expiry_window_seconds` now delegates to it (behavior-preserving, covered by an equivalence test).
- Add a shared settlement-aware quote-timing helper (`crates/solver-service/src/apis/quote/timing.rs`) and wire it into the Permit2, EIP-3009, and Compact quote paths, pinned to the settlement selected for the quote. The signed order `expires` is clamped up to that settlement's required window.
- `api.quote.expires_seconds` becomes a floor/preference: it can raise expiry but never undercut admission.

Covers both explicit `intent_min_expiry_seconds` and the additive broadcaster estimate (proof wait + finality + proof timeout + polling + safety).

## Notes / non-goals

- `valid_until` (quote cache TTL) is unchanged.
- The admission gate is unchanged — the safety mechanism is preserved.
- Seed-path plumbing of `api.quote` is intentionally out of scope: the settlement-derived floor makes correctness independent of it (documented in `docs/config-storage.md`).

## Testing

- `cargo test -p solver-settlement` — 157 passed (incl. route/order equivalence)
- `cargo test -p solver-service` — 669 passed (+7 new: timing helper, Permit2, EIP-3009, Compact, config-merge, quote pipeline)
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated` — clean
- `cargo fmt --all -- --check` — clean
- `cargo check --all-targets` and `cargo check -p solver-e2e-tests --all-targets` — ok


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quote order expiry is now settlement-aware; signed order lifetimes are automatically clamped upward to satisfy settlement admission windows.
  * Added support for `intent_min_expiry_seconds` configuration in broadcaster settlement settings.

* **Documentation**
  * Updated settlement timing configuration guidance explaining settlement-aware quote expiry and broadcaster minimum expiry enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->