### PR TITLE
fix(C-03): just-in-time forced-withdrawal check before resource-lock fill

### DIFF
--- a/crates/solver-core/Cargo.toml
+++ b/crates/solver-core/Cargo.toml
@@ -32,7 +32,7 @@ solver-order = { path = "../solver-order" }
 solver-pricing = { path = "../solver-pricing" }
 solver-settlement = { path = "../solver-settlement" }
 solver-storage = { path = "../solver-storage" }
-solver-types = { path = "../solver-types" }
+solver-types = { path = "../solver-types", features = ["oif-interfaces"] }
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -211,6 +211,7 @@ impl SolverEngine {
 			storage.clone(),
 			state_machine.clone(),
 			event_bus.clone(),
+			dynamic_config.clone(),
 		));
 
 		let transaction_handler = Arc::new(TransactionHandler::new(

--- a/crates/solver-core/src/handlers/forced_withdrawal.rs
+++ b/crates/solver-core/src/handlers/forced_withdrawal.rs
@@ -1,0 +1,218 @@
+//! Just-in-time forced-withdrawal guard for TheCompact ResourceLock orders (C-03).
+//!
+//! Intake-time validation (`solver-service`) already pins a trusted allocator and
+//! requires each input lock's `resetPeriod` to outlast the fill-to-claim window
+//! (PR #381). That floor only defends against a forced withdrawal *initiated after*
+//! the order is signed: the reset period has to elapse before the funds can be
+//! pulled. It does NOT defend against a sponsor who calls `enableForcedWithdrawal`
+//! and lets the reset period elapse *before* submitting the order — by the time the
+//! solver fills, the lock can already be force-withdrawn on demand, stranding the
+//! solver's destination outlay.
+//!
+//! This module closes that gap by querying `TheCompact.getForcedWithdrawalStatus`
+//! for each input lock as close as possible before the destination fill is
+//! released. If any lock reports a status other than `Disabled` (i.e. `Pending` or
+//! `Enabled`), the fill is aborted: a pending/enabled forced withdrawal means the
+//! sponsor can (or soon can) pull the input out from under the claim.
+//!
+//! Residual TOCTOU: the check is an `eth_call` against the origin chain performed
+//! immediately before submitting the destination fill, so a sponsor could still
+//! `enableForcedWithdrawal` in the narrow window between this call and on-chain
+//! fill inclusion. The intake reset-period floor is what bounds that residual
+//! window — a freshly-enabled withdrawal cannot complete until its reset period
+//! elapses, which by construction exceeds the fill-to-claim window. This check
+//! eliminates the *already-elapsed* case the floor cannot see.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address as AlloyAddress, U256};
+use alloy_sol_types::SolCall;
+use solver_delivery::DeliveryService;
+use solver_types::{standards::eip7683::interfaces::ITheCompact, Address, Transaction};
+
+/// `ForcedWithdrawalStatus` enum value meaning no forced withdrawal is pending or
+/// enabled. Any other value (`Pending` = 1, `Enabled` = 2) means the sponsor can
+/// pull the locked input before the solver claims, so the fill must be aborted.
+const FORCED_WITHDRAWAL_DISABLED: u8 = 0;
+
+/// Error raised when the just-in-time forced-withdrawal guard refuses to release a
+/// fill. Treated by the caller as a fatal, non-retryable reason to skip the order.
+#[derive(Debug, thiserror::Error)]
+pub enum ForcedWithdrawalError {
+	/// A lock reports a non-`Disabled` forced-withdrawal status.
+	#[error("ResourceLock input {lock_id} has forced withdrawal active (status {status}); refusing to fill")]
+	Active { lock_id: U256, status: u8 },
+	/// The on-chain query or its decoding failed; fail closed rather than fill blind.
+	#[error("Failed to query TheCompact.getForcedWithdrawalStatus: {0}")]
+	Query(String),
+}
+
+/// Build a `view`-style transaction for an `eth_call`.
+fn view_tx(to: &Address, chain_id: u64, data: Vec<u8>) -> Transaction {
+	Transaction {
+		to: Some(to.clone()),
+		data,
+		value: U256::ZERO,
+		chain_id,
+		nonce: None,
+		gas_limit: None,
+		gas_price: None,
+		max_fee_per_gas: None,
+		max_priority_fee_per_gas: None,
+	}
+}
+
+/// Just-in-time check that no input resource lock has a pending or enabled forced
+/// withdrawal, performed immediately before the destination fill is released.
+///
+/// - `sponsor` is the account whose locks back the order inputs (the StandardOrder
+///   `user`); it is the `account` argument to `getForcedWithdrawalStatus`.
+/// - `lock_ids` are the ERC-6909 lock identifiers (`inputs[i][0]`).
+/// - `the_compact_address` / `origin_chain_id` locate TheCompact on the origin chain.
+///
+/// Returns `Err` (aborting the fill) if any lock reports a non-`Disabled` status, or
+/// if the query/decoding fails (fail closed — never fill on an un-verifiable lock).
+pub async fn ensure_no_forced_withdrawal(
+	delivery: &Arc<DeliveryService>,
+	the_compact_address: &Address,
+	origin_chain_id: u64,
+	sponsor: AlloyAddress,
+	lock_ids: &[U256],
+) -> Result<(), ForcedWithdrawalError> {
+	for &lock_id in lock_ids {
+		let call = ITheCompact::getForcedWithdrawalStatusCall {
+			account: sponsor,
+			id: lock_id,
+		};
+		let tx = view_tx(the_compact_address, origin_chain_id, call.abi_encode());
+
+		let result = delivery
+			.contract_call(origin_chain_id, tx)
+			.await
+			.map_err(|e| ForcedWithdrawalError::Query(e.to_string()))?;
+
+		let decoded =
+			ITheCompact::getForcedWithdrawalStatusCall::abi_decode_returns_validate(&result)
+				.map_err(|e| ForcedWithdrawalError::Query(e.to_string()))?;
+
+		if decoded.status != FORCED_WITHDRAWAL_DISABLED {
+			return Err(ForcedWithdrawalError::Active {
+				lock_id,
+				status: decoded.status,
+			});
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use solver_delivery::{DeliveryInterface, MockDeliveryInterface};
+	use std::collections::HashMap;
+
+	const CHAIN: u64 = 1;
+
+	fn the_compact() -> Address {
+		Address(vec![0x88u8; 20])
+	}
+
+	fn sponsor() -> AlloyAddress {
+		AlloyAddress::from([0x22u8; 20])
+	}
+
+	fn id_from(byte: u8) -> U256 {
+		let mut b = [0u8; 32];
+		b[0] = byte;
+		b[31] = byte;
+		U256::from_be_bytes(b)
+	}
+
+	/// ABI-encode the `getForcedWithdrawalStatus` return tuple
+	/// `(uint8 status, uint256 forcedWithdrawalAvailableAt)`: status is the last
+	/// byte of word 0; the second word carries the timestamp.
+	fn encode_status(status: u8, available_at: u64) -> alloy_primitives::Bytes {
+		let mut out = vec![0u8; 64];
+		out[31] = status;
+		out[56..64].copy_from_slice(&available_at.to_be_bytes());
+		alloy_primitives::Bytes::from(out)
+	}
+
+	/// Delivery mock: `getForcedWithdrawalStatus(account, id)` resolves its return
+	/// tuple via `status_for(id)`.
+	fn delivery(
+		status_for: impl Fn(U256) -> (u8, u64) + Send + Sync + 'static,
+	) -> Arc<DeliveryService> {
+		let mut mock = MockDeliveryInterface::new();
+		mock.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let resp = match selector {
+				Some(s) if s == ITheCompact::getForcedWithdrawalStatusCall::SELECTOR => {
+					// account occupies word 0 (bytes 4..36); id occupies word 1 (36..68).
+					let mut id_bytes = [0u8; 32];
+					id_bytes.copy_from_slice(&tx.data[36..68]);
+					let (status, at) = status_for(U256::from_be_bytes(id_bytes));
+					encode_status(status, at)
+				},
+				_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
+			};
+			Box::pin(async move { Ok(resp) })
+		});
+		let mut impls: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		impls.insert(CHAIN, Arc::new(mock) as Arc<dyn DeliveryInterface>);
+		Arc::new(DeliveryService::new(impls, 1, 30, 60))
+	}
+
+	#[tokio::test]
+	async fn forced_withdrawal_enabled_lock_rejected_before_fill() {
+		// A lock whose forced withdrawal is Enabled (status 2) must abort the fill.
+		let d = delivery(|_| (2u8, 0));
+		let err = ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id_from(1)])
+			.await
+			.expect_err("Enabled forced withdrawal must reject the fill");
+		assert!(matches!(
+			err,
+			ForcedWithdrawalError::Active { status: 2, .. }
+		));
+	}
+
+	#[tokio::test]
+	async fn forced_withdrawal_pending_lock_rejected_before_fill() {
+		// A lock whose forced withdrawal is Pending (status 1) must abort the fill.
+		let d = delivery(|_| (1u8, 9_999_999_999));
+		let err = ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id_from(1)])
+			.await
+			.expect_err("Pending forced withdrawal must reject the fill");
+		assert!(matches!(
+			err,
+			ForcedWithdrawalError::Active { status: 1, .. }
+		));
+	}
+
+	#[tokio::test]
+	async fn disabled_forced_withdrawal_passes() {
+		let d = delivery(|_| (0u8, 0));
+		ensure_no_forced_withdrawal(
+			&d,
+			&the_compact(),
+			CHAIN,
+			sponsor(),
+			&[id_from(1), id_from(2)],
+		)
+		.await
+		.expect("Disabled forced withdrawal on all locks should pass");
+	}
+
+	#[tokio::test]
+	async fn any_active_lock_in_batch_rejected() {
+		// First lock Disabled, second lock Enabled => reject.
+		let id1 = id_from(1);
+		let d = delivery(move |id| if id == id1 { (0u8, 0) } else { (2u8, 0) });
+		let err =
+			ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id1, id_from(2)])
+				.await
+				.expect_err("a single active lock in the batch must reject the fill");
+		assert!(matches!(err, ForcedWithdrawalError::Active { .. }));
+	}
+}

--- a/crates/solver-core/src/handlers/mod.rs
+++ b/crates/solver-core/src/handlers/mod.rs
@@ -4,6 +4,7 @@
 //! lifecycle: intent discovery, order preparation and execution, transaction
 //! monitoring, and settlement claiming.
 
+pub mod forced_withdrawal;
 pub mod intent;
 pub mod order;
 pub mod settlement;

--- a/crates/solver-core/src/handlers/order.rs
+++ b/crates/solver-core/src/handlers/order.rs
@@ -4,9 +4,11 @@
 //! and fill transactions, updating order state and publishing appropriate events.
 
 use crate::engine::event_bus::EventBus;
+use crate::handlers::forced_withdrawal::ensure_no_forced_withdrawal;
 use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
+use solver_config::Config;
 use solver_delivery::{
 	DeliveryService, RevertClassification, TransactionAttemptRecorder, TransactionMonitoringEvent,
 	TransactionTracking,
@@ -14,11 +16,13 @@ use solver_delivery::{
 use solver_order::OrderService;
 use solver_storage::StorageService;
 use solver_types::{
-	truncate_id, DeliveryEvent, ExecutionParams, Order, OrderEvent, OrderStatus, SolverEvent,
+	standards::eip7683::LockType, truncate_id, utils::conversion::hex_to_alloy_address,
+	DeliveryEvent, Eip7683OrderData, ExecutionParams, Order, OrderEvent, OrderStatus, SolverEvent,
 	StorageKey, TransactionType,
 };
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::RwLock;
 use tracing::instrument;
 
 /// Errors that can occur during order processing.
@@ -46,6 +50,9 @@ pub struct OrderHandler {
 	storage: Arc<StorageService>,
 	state_machine: Arc<OrderStateMachine>,
 	event_bus: EventBus,
+	/// Dynamic config, read just-in-time so Admin API hot-reloads
+	/// (e.g. toggling `resource_lock_enabled`) take effect on the next fill.
+	dynamic_config: Arc<RwLock<Config>>,
 }
 
 impl OrderHandler {
@@ -55,6 +62,7 @@ impl OrderHandler {
 		storage: Arc<StorageService>,
 		state_machine: Arc<OrderStateMachine>,
 		event_bus: EventBus,
+		dynamic_config: Arc<RwLock<Config>>,
 	) -> Self {
 		Self {
 			order_service,
@@ -62,6 +70,7 @@ impl OrderHandler {
 			storage,
 			state_machine,
 			event_bus,
+			dynamic_config,
 		}
 	}
 
@@ -238,6 +247,55 @@ impl OrderHandler {
 		Ok(())
 	}
 
+	/// (C-03) Reject ResourceLock fills whose input locks have a pending or enabled
+	/// forced withdrawal on TheCompact, checked just before the fill is released.
+	///
+	/// No-op for non-ResourceLock orders. When ResourceLock support is disabled this
+	/// path should not be reached (intake gates it), but we still treat a ResourceLock
+	/// order arriving here as in-scope and fail closed if its compact address is
+	/// missing or the on-chain query fails.
+	async fn check_forced_withdrawal_before_fill(&self, order: &Order) -> Result<(), OrderError> {
+		let order_data: Eip7683OrderData = match serde_json::from_value(order.data.clone()) {
+			Ok(data) => data,
+			// Non-7683 orders carry no resource lock; nothing to guard.
+			Err(_) => return Ok(()),
+		};
+
+		if !matches!(order_data.lock_type, Some(LockType::ResourceLock)) {
+			return Ok(());
+		}
+
+		let origin_chain_id = order_data.origin_chain_id.to::<u64>();
+
+		// Resolve TheCompact on the origin chain from current (hot-reloadable) config.
+		let the_compact_address = {
+			let config = self.dynamic_config.read().await;
+			config
+				.networks
+				.get(&origin_chain_id)
+				.and_then(|n| n.the_compact_address.clone())
+				.ok_or_else(|| {
+					OrderError::Service(format!(
+						"ResourceLock fill aborted: TheCompact address not configured for origin chain {origin_chain_id}"
+					))
+				})?
+		};
+
+		let sponsor = hex_to_alloy_address(&order_data.user)
+			.map_err(|e| OrderError::Service(format!("Invalid sponsor address: {e}")))?;
+		let lock_ids: Vec<_> = order_data.inputs.iter().map(|input| input[0]).collect();
+
+		ensure_no_forced_withdrawal(
+			&self.delivery,
+			&the_compact_address,
+			origin_chain_id,
+			sponsor,
+			&lock_ids,
+		)
+		.await
+		.map_err(|e| OrderError::Service(e.to_string()))
+	}
+
 	/// Handles order execution by generating and submitting a fill transaction.
 	#[instrument(skip_all, fields(order_id = %truncate_id(&order.id)))]
 	pub async fn handle_execution(
@@ -245,6 +303,12 @@ impl OrderHandler {
 		order: Order,
 		params: ExecutionParams,
 	) -> Result<(), OrderError> {
+		// (C-03) Just-in-time forced-withdrawal guard for ResourceLock orders. This is
+		// the last solver-controlled point before the destination fill is released, so
+		// it catches a sponsor who enabled (or began) a forced withdrawal before the
+		// order was submitted — a case the intake-time reset-period floor cannot see.
+		self.check_forced_withdrawal_before_fill(&order).await?;
+
 		// Generate fill transaction
 		let tx = self
 			.order_service
@@ -431,6 +495,26 @@ mod tests {
 		F2: FnOnce(&mut MockDeliveryInterface),
 		F3: FnOnce(&mut MockStorageInterface),
 	{
+		create_test_handler_with_config(
+			setup_order,
+			setup_delivery,
+			setup_storage,
+			solver_config::ConfigBuilder::new().build(),
+		)
+		.await
+	}
+
+	async fn create_test_handler_with_config<F1, F2, F3>(
+		setup_order: F1,
+		setup_delivery: F2,
+		setup_storage: F3,
+		config: solver_config::Config,
+	) -> (OrderHandler, broadcast::Receiver<SolverEvent>)
+	where
+		F1: FnOnce(&mut MockOrderInterface),
+		F2: FnOnce(&mut MockDeliveryInterface),
+		F3: FnOnce(&mut MockStorageInterface),
+	{
 		let mut mock_order = MockOrderInterface::new();
 		let mut mock_delivery = MockDeliveryInterface::new();
 		let mut mock_storage = MockStorageInterface::new();
@@ -467,7 +551,14 @@ mod tests {
 		let event_bus = EventBus::new(100);
 		let event_rx = event_bus.subscribe();
 
-		let handler = OrderHandler::new(order_service, delivery, storage, state_machine, event_bus);
+		let handler = OrderHandler::new(
+			order_service,
+			delivery,
+			storage,
+			state_machine,
+			event_bus,
+			Arc::new(RwLock::new(config)),
+		);
 
 		(handler, event_rx)
 	}
@@ -861,6 +952,99 @@ mod tests {
 		match result.unwrap_err() {
 			OrderError::Service(msg) => assert!(msg.contains("Fill error")),
 			_ => panic!("Expected Service error"),
+		}
+	}
+
+	/// (C-03) A ResourceLock order whose input lock has an *enabled* forced
+	/// withdrawal must be rejected before the destination fill is released: the
+	/// sponsor can pull the locked input out from under the solver's claim.
+	///
+	/// The guard runs before `generate_fill_transaction`, so neither fill
+	/// generation nor delivery is exercised (`.times(0)`).
+	#[tokio::test]
+	async fn forced_withdrawal_enabled_resource_lock_rejected_before_fill() {
+		use alloy_sol_types::SolCall;
+		use solver_types::networks::{NetworkConfig, NetworkType, RpcEndpoint};
+		use solver_types::standards::eip7683::interfaces::ITheCompact;
+		use solver_types::standards::eip7683::LockType;
+		use solver_types::Address;
+
+		const ORIGIN_CHAIN: u64 = 137;
+		let the_compact = Address(vec![0x88u8; 20]);
+
+		// ResourceLock order with a single input lock; sponsor is `user`.
+		let lock_id = U256::from(0xABCDu64);
+		let order_data = serde_json::json!({
+			"user": "0x2222222222222222222222222222222222222222",
+			"nonce": "1",
+			"origin_chain_id": ORIGIN_CHAIN.to_string(),
+			"expires": 1_700_000_600u32,
+			"fill_deadline": 1_700_000_000u32,
+			"input_oracle": "0x3333333333333333333333333333333333333333",
+			"inputs": [[lock_id.to_string(), "1000"]],
+			"order_id": vec![0u8; 32],
+			"gas_limit_overrides": {},
+			"outputs": [],
+			"lock_type": LockType::ResourceLock,
+		});
+		let order = OrderBuilder::new().with_data(order_data).build();
+
+		// Config: origin chain network advertises TheCompact.
+		let network = NetworkConfig {
+			name: None,
+			network_type: NetworkType::default(),
+			rpc_urls: vec![RpcEndpoint::http_only("http://localhost:8545".to_string())],
+			input_settler_address: Address(vec![0x11u8; 20]),
+			output_settler_address: Address(vec![0x22u8; 20]),
+			tokens: vec![],
+			input_settler_compact_address: Some(Address(vec![0x44u8; 20])),
+			the_compact_address: Some(the_compact),
+			allocator_address: Some(Address(vec![0xA1u8; 20])),
+		};
+		let config = solver_config::ConfigBuilder::new()
+			.networks(HashMap::from([(ORIGIN_CHAIN, network)]))
+			.build();
+
+		let params = create_test_execution_params();
+
+		let (handler, _event_rx) = create_test_handler_with_config(
+			|mock_order| {
+				// Fill generation must NOT run — the guard aborts first.
+				mock_order.expect_generate_fill_transaction().times(0);
+			},
+			|mock_delivery| {
+				// `getForcedWithdrawalStatus` reports Enabled (status 2).
+				mock_delivery.expect_eth_call().returning(|tx| {
+					let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+					let resp = match selector {
+						Some(s) if s == ITheCompact::getForcedWithdrawalStatusCall::SELECTOR => {
+							let mut out = vec![0u8; 64];
+							out[31] = 2; // ForcedWithdrawalStatus::Enabled
+							alloy_primitives::Bytes::from(out)
+						},
+						_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
+					};
+					Box::pin(async move { Ok(resp) })
+				});
+				// No fill is submitted.
+				mock_delivery.expect_submit().times(0);
+			},
+			|_mock_storage| {},
+			config,
+		)
+		.await;
+
+		let result = handler.handle_execution(order, params).await;
+
+		let err = result.expect_err("enabled forced withdrawal must abort the fill");
+		match err {
+			OrderError::Service(msg) => {
+				assert!(
+					msg.contains("forced withdrawal"),
+					"unexpected error message: {msg}"
+				);
+			},
+			other => panic!("expected Service error, got {other:?}"),
 		}
 	}
 

--- a/crates/solver-types/src/standards/eip7683.rs
+++ b/crates/solver-types/src/standards/eip7683.rs
@@ -383,6 +383,11 @@ pub mod interfaces {
 		interface ITheCompact {
 			function DOMAIN_SEPARATOR() external view returns (bytes32);
 			function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
+			/// Forced-withdrawal status of a resource lock for a given account.
+			/// `status` is the `ForcedWithdrawalStatus` enum (Disabled=0, Pending=1,
+			/// Enabled=2); `forcedWithdrawalAvailableAt` is when tokens become
+			/// withdrawable while `Pending` (or became withdrawable while `Enabled`).
+			function getForcedWithdrawalStatus(address account, uint256 id) external view returns (uint8 status, uint256 forcedWithdrawalAvailableAt);
 		}
 
 		/// IAllocator interface exposing the off-chain claim authorization predicate.


### PR DESCRIPTION
## Audit finding C-03 (Critical) — Solver can lose principal on resource-lock orders without forced-withdrawal checks

Intake-time validation (PR #381) pins a trusted allocator and requires each input lock's `resetPeriod` to outlast the fill-to-claim window. That floor only defends against a forced withdrawal **initiated after** the order is signed. It does **not** defend against a sponsor who calls `enableForcedWithdrawal` and lets the reset period elapse **before** submitting the order — by fill time the lock can be force-withdrawn on demand, stranding the solver's destination outlay. No `getForcedWithdrawalStatus` check existed anywhere in the codebase.

### Changes
- **`solver-types`** — added `getForcedWithdrawalStatus(address account, uint256 id) returns (uint8 status, uint256 forcedWithdrawalAvailableAt)` to the `ITheCompact` `sol!` binding. ABI confirmed against `../oif-contracts/lib/the-compact/src/interfaces/ITheCompact.sol` and `ForcedWithdrawalStatus.sol` (enum `Disabled=0, Pending=1, Enabled=2`).
- **`solver-core`** — new `handlers/forced_withdrawal.rs` with `ensure_no_forced_withdrawal(...)`: for each input lock id, `eth_call`s `getForcedWithdrawalStatus(sponsor, id)` on the origin chain and rejects if any status != `Disabled`. **Fails closed** on query/decode error.
- **`solver-core`** — `handle_execution` calls this guard **immediately before** `generate_fill_transaction` (the last solver-controlled point before the fill is released). No-op for non-ResourceLock orders; resolves TheCompact from hot-reloadable config; sponsor = StandardOrder `user`, lock ids = `inputs[i][0]`.

### Testing
- RED-first: `forced_withdrawal_enabled_resource_lock_rejected_before_fill` — a lock reporting forced-withdrawal Enabled is rejected with `generate_fill_transaction`/`submit` asserted `.times(0)`. Plus 4 lock-level unit tests (Enabled/Pending rejected, Disabled passes, any-active-in-batch rejected).
- `cargo test -p solver-core` and `-p solver-types` pass; `cargo check --all-targets --all-features`, `clippy -D warnings`, `fmt --check` all clean.

### Residual (documented in module header)
The check is an origin-chain `eth_call` right before submitting the destination fill, so a sponsor could still `enableForcedWithdrawal` in the narrow gap before on-chain fill inclusion. That residual is bounded by the intake reset-period floor (a freshly-enabled withdrawal cannot *complete* until its reset period elapses, which exceeds the fill-to-claim window). This PR eliminates the *already-elapsed* case the floor cannot see; making fill-and-status atomic is not possible off-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
