### PR TITLE
[codex] Keep transient settlement errors retryable

### DIFF
--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -33,7 +33,7 @@ use solver_settlement::SettlementService;
 use solver_storage::StorageService;
 use solver_types::{
 	truncate_id, Address, DeliveryEvent, Intent, Order, OrderEvent, SettlementEvent, SolverEvent,
-	StorageKey,
+	StorageKey, TransactionType,
 };
 use std::future::Future;
 use std::sync::Arc;
@@ -122,23 +122,52 @@ pub struct SolverEngine {
 /// submitting claim transactions to reduce gas costs.
 static CLAIM_BATCH: usize = 1;
 
-/// Returns true when the settlement error represents a transient post-fill
-/// failure — one that may succeed on a later attempt without any code or
-/// order changes. Marking such orders as `Failed` would lock in a real loss
-/// because the Fill has already settled on chain; only the claim half
-/// remains, and it just needs another attempt with a healthier signer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettlementFailurePolicy {
+	RetryLater,
+	FailOrder,
+}
+
+/// Classifies settlement-stage failures without relying on formatted strings.
 ///
-/// Matches on the typed `SettlementError` variant rather than substring on
-/// a formatted message — drift in any error's `Display` impl would silently
-/// flip transient-recovery behavior to permanent-failure.
-///
-/// Currently identifies:
-/// - `InsufficientNativeGas` — signer balance changes outside the solver's view.
-fn is_transient_postfill_error(error: &crate::handlers::settlement::SettlementError) -> bool {
-	matches!(
-		error,
-		crate::handlers::settlement::SettlementError::InsufficientNativeGas(_)
-	)
+/// A retryable result means the order should stay in its current non-terminal
+/// state so startup recovery can re-drive the stage. Permanent failures are
+/// the only errors that should transition already-filled orders to `Failed`.
+fn settlement_failure_policy(
+	_stage: TransactionType,
+	error: &crate::handlers::settlement::SettlementError,
+) -> SettlementFailurePolicy {
+	use crate::handlers::settlement::SettlementError;
+	use solver_delivery::DeliveryError;
+	use solver_settlement::SettlementError as SettlementServiceError;
+
+	match error {
+		SettlementError::InsufficientNativeGas(_) => SettlementFailurePolicy::RetryLater,
+		SettlementError::Delivery(delivery_error) => match delivery_error {
+			DeliveryError::Network(_) => SettlementFailurePolicy::RetryLater,
+			DeliveryError::TransactionFailed(_) => SettlementFailurePolicy::FailOrder,
+			DeliveryError::NonceTooLow(_) => SettlementFailurePolicy::RetryLater,
+			DeliveryError::InsufficientNativeGas(_) => SettlementFailurePolicy::RetryLater,
+			DeliveryError::NoImplementationAvailable => SettlementFailurePolicy::RetryLater,
+			DeliveryError::ReplacementUnderpriced { .. } => SettlementFailurePolicy::RetryLater,
+		},
+		SettlementError::SettlementService(settlement_error) => match settlement_error {
+			SettlementServiceError::ValidationFailed(_) => SettlementFailurePolicy::FailOrder,
+			SettlementServiceError::InvalidProof => SettlementFailurePolicy::FailOrder,
+			SettlementServiceError::FillMismatch => SettlementFailurePolicy::FailOrder,
+			SettlementServiceError::ProofGenerationFailed { .. } => {
+				SettlementFailurePolicy::RetryLater
+			},
+			SettlementServiceError::FinalityNotReached { .. } => {
+				SettlementFailurePolicy::RetryLater
+			},
+			SettlementServiceError::ProverUnavailable(_) => SettlementFailurePolicy::RetryLater,
+			SettlementServiceError::SlotDerivationMismatch => SettlementFailurePolicy::FailOrder,
+		},
+		SettlementError::Storage(_) | SettlementError::Service(_) | SettlementError::State(_) => {
+			SettlementFailurePolicy::FailOrder
+		},
+	}
 }
 
 impl SolverEngine {
@@ -622,18 +651,28 @@ impl SolverEngine {
 							// Note: This may trigger OrderEvent::Executing which will be serialized separately
 							self.spawn_handler(&general_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
-								if let Err(e) = engine.transaction_handler.handle_confirmed(order_id, tx_hash, tx_type, receipt).await {
-									let error_msg = format!("Failed to handle transaction confirmation: {e}");
-									// Attempt to mark order as failed with the transaction type from the event
-									if let Err(state_err) = engine.state_machine
-										.transition_order_status(&order_id_clone, solver_types::OrderStatus::Failed(tx_type, error_msg.clone()))
-										.await
-									{
-										tracing::error!("Failed to mark order as failed: {}", state_err);
+								match engine.transaction_handler.handle_confirmed(order_id, tx_hash, tx_type, receipt).await {
+									Ok(()) => Ok(()),
+									Err(crate::handlers::transaction::TransactionError::SettlementCallback { stage, source }) => {
+										engine.handle_settlement_stage_error(
+											&order_id_clone,
+											stage,
+											"TransactionConfirmed",
+											crate::handlers::settlement::SettlementError::SettlementService(source),
+										).await
+									},
+									Err(e) => {
+										let error_msg = format!("Failed to handle transaction confirmation: {e}");
+										// Attempt to mark order as failed with the transaction type from the event
+										if let Err(state_err) = engine.state_machine
+											.transition_order_status(&order_id_clone, solver_types::OrderStatus::Failed(tx_type, error_msg.clone()))
+											.await
+										{
+											tracing::error!("Failed to mark order as failed: {}", state_err);
+										}
+										Err(EngineError::Service(error_msg))
 									}
-									return Err(EngineError::Service(error_msg));
 								}
-								Ok(())
 							})
 							.await;
 						}
@@ -666,33 +705,12 @@ impl SolverEngine {
 							self.spawn_handler(&transaction_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
 								if let Err(e) = engine.settlement_handler.handle_post_fill_ready(order_id).await {
-									// Discriminate transient errors from permanent ones via
-									// the typed SettlementError variant — string-matching on
-									// a formatted message is brittle to Display drift.
-									// `InsufficientNativeGas` is the textbook transient: balance
-									// changes outside the solver's view, and marking Failed here
-									// would lock in a real loss (Fill already settled on chain;
-									// we just need to top up to claim). Leave the order in
-									// `Executed` so the next restart's recovery retries.
-									if is_transient_postfill_error(&e) {
-										let error_msg = format!("Failed to handle PostFillReady: {e}");
-										tracing::warn!(
-											order_id = %order_id_clone,
-											error = %error_msg,
-											"PostFill failed with a transient error; leaving order \
-											in Executed for the next recovery cycle to retry"
-										);
-										return Err(EngineError::Service(error_msg));
-									}
-									let error_msg = format!("Failed to handle PostFillReady: {e}");
-									// Permanent failure → mark order Failed.
-									if let Err(state_err) = engine.state_machine
-										.transition_order_status(&order_id_clone, solver_types::OrderStatus::Failed(solver_types::TransactionType::PostFill, error_msg.clone()))
-										.await
-									{
-										tracing::error!("Failed to mark order as failed: {}", state_err);
-									}
-									return Err(EngineError::Service(error_msg));
+									return engine.handle_settlement_stage_error(
+										&order_id_clone,
+										TransactionType::PostFill,
+										"PostFillReady",
+										e,
+									).await;
 								}
 								Ok(())
 							})
@@ -704,15 +722,12 @@ impl SolverEngine {
 							self.spawn_handler(&transaction_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
 								if let Err(e) = engine.settlement_handler.handle_pre_claim_ready(order_id).await {
-									let error_msg = format!("Failed to handle PreClaimReady: {e}");
-									// Attempt to mark order as failed
-									if let Err(state_err) = engine.state_machine
-										.transition_order_status(&order_id_clone, solver_types::OrderStatus::Failed(solver_types::TransactionType::PreClaim, error_msg.clone()))
-										.await
-									{
-										tracing::error!("Failed to mark order as failed: {}", state_err);
-									}
-									return Err(EngineError::Service(error_msg));
+									return engine.handle_settlement_stage_error(
+										&order_id_clone,
+										TransactionType::PreClaim,
+										"PreClaimReady",
+										e,
+									).await;
 								}
 								Ok(())
 							})
@@ -746,17 +761,12 @@ impl SolverEngine {
 								// Claim sends a transaction - use transaction semaphore
 								self.spawn_handler(&transaction_semaphore, move |engine| async move {
 									if let Err(e) = engine.settlement_handler.process_claim_batch(&mut batch).await {
-										let error_msg = format!("Failed to process claim batch: {e}");
-										// Attempt to mark all orders in batch as failed
-										for order_id in batch.iter() {
-											if let Err(state_err) = engine.state_machine
-												.transition_order_status(order_id, solver_types::OrderStatus::Failed(solver_types::TransactionType::Claim, error_msg.clone()))
-												.await
-											{
-												tracing::error!("Failed to mark order {} as failed: {}", order_id, state_err);
-											}
-										}
-										return Err(EngineError::Service(error_msg));
+										return engine.handle_settlement_stage_error(
+											&e.order_id,
+											TransactionType::Claim,
+											"ClaimReady",
+											e.error,
+										).await;
 									}
 									Ok(())
 								})
@@ -909,6 +919,39 @@ impl SolverEngine {
 		Arc::clone(&self.startup_readiness)
 	}
 
+	async fn handle_settlement_stage_error(
+		&self,
+		order_id: &str,
+		tx_type: TransactionType,
+		context: &str,
+		error: crate::handlers::settlement::SettlementError,
+	) -> Result<(), EngineError> {
+		let error_msg = format!("Failed to handle {context}: {error}");
+		match settlement_failure_policy(tx_type, &error) {
+			SettlementFailurePolicy::RetryLater => {
+				tracing::warn!(
+					order_id = %order_id,
+					tx_type = ?tx_type,
+					error = %error_msg,
+					"Settlement stage failed with a transient error; leaving order retryable"
+				);
+			},
+			SettlementFailurePolicy::FailOrder => {
+				if let Err(state_err) = self
+					.state_machine
+					.transition_order_status(
+						order_id,
+						solver_types::OrderStatus::Failed(tx_type, error_msg.clone()),
+					)
+					.await
+				{
+					tracing::error!("Failed to mark order as failed: {}", state_err);
+				}
+			},
+		}
+		Err(EngineError::Service(error_msg))
+	}
+
 	/// Helper method to spawn handler tasks with semaphore-based concurrency control.
 	///
 	/// This method:
@@ -943,12 +986,13 @@ mod tests {
 	use crate::engine::event_bus::EventBus;
 	use solver_account::AccountService;
 	use solver_config::{Config, ConfigBuilder};
-	use solver_delivery::DeliveryService;
+	use solver_delivery::{DeliveryError, DeliveryService, InsufficientNativeGasInfo};
 	use solver_discovery::DiscoveryService;
 	use solver_order::OrderService;
 	use solver_settlement::SettlementService;
 	use solver_storage::StorageService;
-	use solver_types::Address;
+	use solver_types::utils::tests::builders::OrderBuilder;
+	use solver_types::{Address, OrderStatus, TransactionType};
 	use std::sync::Arc;
 	use tokio::sync::Semaphore;
 
@@ -1242,6 +1286,249 @@ mod tests {
 			handler_error.to_string(),
 			"Handler error: test handler error"
 		);
+	}
+
+	fn insufficient_native_gas_error() -> crate::handlers::settlement::SettlementError {
+		crate::handlers::settlement::SettlementError::InsufficientNativeGas(Box::new(
+			InsufficientNativeGasInfo {
+				chain_id: 1,
+				signer: "0x0000000000000000000000000000000000000001".to_string(),
+				balance_wei: "0".to_string(),
+				required_wei: "1".to_string(),
+				shortfall_wei: "1".to_string(),
+				gas_limit: Some(21_000),
+				max_fee_per_gas: Some(1),
+				gas_price: None,
+				value_wei: "0".to_string(),
+			},
+		))
+	}
+
+	async fn create_test_engine() -> SolverEngine {
+		let (
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+		) = create_mock_services().await;
+
+		SolverEngine::new(
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+			None,
+		)
+	}
+
+	#[test]
+	fn settlement_policy_retries_transient_delivery_errors() {
+		let errors = vec![
+			crate::handlers::settlement::SettlementError::Delivery(DeliveryError::Network(
+				"rpc down".to_string(),
+			)),
+			crate::handlers::settlement::SettlementError::Delivery(DeliveryError::NonceTooLow(
+				"nonce drift".to_string(),
+			)),
+			crate::handlers::settlement::SettlementError::Delivery(
+				DeliveryError::ReplacementUnderpriced {
+					hint: "raise fee".to_string(),
+				},
+			),
+			crate::handlers::settlement::SettlementError::Delivery(
+				DeliveryError::NoImplementationAvailable,
+			),
+			insufficient_native_gas_error(),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::FinalityNotReached {
+					required_blocks: 10,
+					current_blocks: 3,
+				},
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::ProverUnavailable("down".to_string()),
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::ProofGenerationFailed {
+					source_chain: 1,
+					reason: "rpc down".to_string(),
+				},
+			),
+		];
+
+		for error in errors {
+			for stage in [
+				TransactionType::PostFill,
+				TransactionType::PreClaim,
+				TransactionType::Claim,
+			] {
+				assert_eq!(
+					settlement_failure_policy(stage, &error),
+					SettlementFailurePolicy::RetryLater,
+					"expected {error:?} at {stage:?} to be retryable"
+				);
+			}
+		}
+	}
+
+	#[test]
+	fn settlement_policy_fails_permanent_settlement_errors() {
+		let errors = vec![
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::ValidationFailed("bad config".to_string()),
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::InvalidProof,
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::FillMismatch,
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::SlotDerivationMismatch,
+			),
+			crate::handlers::settlement::SettlementError::Delivery(
+				DeliveryError::TransactionFailed("reverted".to_string()),
+			),
+			crate::handlers::settlement::SettlementError::Storage("storage down".to_string()),
+			crate::handlers::settlement::SettlementError::State("cas failed".to_string()),
+			crate::handlers::settlement::SettlementError::Service("missing proof".to_string()),
+		];
+
+		for error in errors {
+			assert_eq!(
+				settlement_failure_policy(TransactionType::PreClaim, &error),
+				SettlementFailurePolicy::FailOrder,
+				"expected {error:?} to be permanent"
+			);
+		}
+	}
+
+	#[tokio::test]
+	async fn post_fill_ready_transient_error_leaves_order_executed() {
+		let engine = create_test_engine().await;
+		let order = OrderBuilder::new()
+			.with_id("post-fill-transient-order".to_string())
+			.with_status(OrderStatus::Executed)
+			.build();
+		engine.state_machine.store_order(&order).await.unwrap();
+
+		let result = engine
+			.handle_settlement_stage_error(
+				&order.id,
+				TransactionType::PostFill,
+				"PostFillReady",
+				crate::handlers::settlement::SettlementError::Delivery(DeliveryError::Network(
+					"rpc down".to_string(),
+				)),
+			)
+			.await;
+
+		assert!(result.is_err());
+		let stored = engine.state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.status, OrderStatus::Executed);
+	}
+
+	#[tokio::test]
+	async fn pre_claim_ready_transient_error_leaves_order_settled() {
+		let engine = create_test_engine().await;
+		let order = OrderBuilder::new()
+			.with_id("pre-claim-transient-order".to_string())
+			.with_status(OrderStatus::Settled)
+			.build();
+		engine.state_machine.store_order(&order).await.unwrap();
+
+		let result = engine
+			.handle_settlement_stage_error(
+				&order.id,
+				TransactionType::PreClaim,
+				"PreClaimReady",
+				insufficient_native_gas_error(),
+			)
+			.await;
+
+		assert!(result.is_err());
+		let stored = engine.state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.status, OrderStatus::Settled);
+	}
+
+	#[tokio::test]
+	async fn claim_ready_transient_error_leaves_order_retryable() {
+		let engine = create_test_engine().await;
+		let order = OrderBuilder::new()
+			.with_id("claim-transient-order".to_string())
+			.with_status(OrderStatus::PreClaimed)
+			.build();
+		engine.state_machine.store_order(&order).await.unwrap();
+
+		let result = engine
+			.handle_settlement_stage_error(
+				&order.id,
+				TransactionType::Claim,
+				"ClaimReady",
+				crate::handlers::settlement::SettlementError::Delivery(
+					DeliveryError::NoImplementationAvailable,
+				),
+			)
+			.await;
+
+		assert!(result.is_err());
+		let stored = engine.state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.status, OrderStatus::PreClaimed);
+	}
+
+	#[tokio::test]
+	async fn claim_ready_permanent_error_fails_only_affected_order() {
+		let engine = create_test_engine().await;
+		let affected = OrderBuilder::new()
+			.with_id("claim-permanent-order".to_string())
+			.with_status(OrderStatus::PreClaimed)
+			.build();
+		let unaffected = OrderBuilder::new()
+			.with_id("claim-unaffected-order".to_string())
+			.with_status(OrderStatus::PreClaimed)
+			.build();
+		engine.state_machine.store_order(&affected).await.unwrap();
+		engine.state_machine.store_order(&unaffected).await.unwrap();
+
+		let result = engine
+			.handle_settlement_stage_error(
+				&affected.id,
+				TransactionType::Claim,
+				"ClaimReady",
+				crate::handlers::settlement::SettlementError::SettlementService(
+					solver_settlement::SettlementError::InvalidProof,
+				),
+			)
+			.await;
+
+		assert!(result.is_err());
+		let affected = engine.state_machine.get_order(&affected.id).await.unwrap();
+		assert!(matches!(
+			affected.status,
+			OrderStatus::Failed(TransactionType::Claim, _)
+		));
+		let unaffected = engine
+			.state_machine
+			.get_order(&unaffected.id)
+			.await
+			.unwrap();
+		assert_eq!(unaffected.status, OrderStatus::PreClaimed);
 	}
 
 	#[tokio::test]

--- a/crates/solver-core/src/handlers/settlement.rs
+++ b/crates/solver-core/src/handlers/settlement.rs
@@ -34,6 +34,10 @@ pub enum SettlementError {
 	Storage(String),
 	#[error("Service error: {0}")]
 	Service(String),
+	#[error("Delivery error: {0}")]
+	Delivery(#[from] solver_delivery::DeliveryError),
+	#[error("Settlement service error: {0}")]
+	SettlementService(#[from] solver_settlement::SettlementError),
 	#[error("State error: {0}")]
 	State(String),
 	/// Transient delivery failure caused by the signer being short on
@@ -44,6 +48,35 @@ pub enum SettlementError {
 	/// preserved for diagnostics.
 	#[error("Insufficient native gas: {0}")]
 	InsufficientNativeGas(Box<solver_delivery::InsufficientNativeGasInfo>),
+}
+
+fn map_delivery_error(error: solver_delivery::DeliveryError) -> SettlementError {
+	match error {
+		solver_delivery::DeliveryError::InsufficientNativeGas(info) => {
+			SettlementError::InsufficientNativeGas(info)
+		},
+		other => SettlementError::Delivery(other),
+	}
+}
+
+fn map_settlement_service_error(error: solver_settlement::SettlementError) -> SettlementError {
+	SettlementError::SettlementService(error)
+}
+
+#[derive(Debug, Error)]
+#[error("Claim batch failed for order {order_id}: {error}")]
+pub struct ClaimBatchError {
+	pub order_id: String,
+	pub error: SettlementError,
+}
+
+impl ClaimBatchError {
+	fn new(order_id: &str, error: SettlementError) -> Self {
+		Self {
+			order_id: order_id.to_string(),
+			error,
+		}
+	}
 }
 
 /// Handler for processing settlement operations.
@@ -129,7 +162,7 @@ impl SettlementHandler {
 			.settlement
 			.recover_post_fill_state(&order)
 			.await
-			.map_err(|e| SettlementError::Service(e.to_string()))?;
+			.map_err(map_settlement_service_error)?;
 		if recovered {
 			tracing::info!(
 				order_id = %truncate_id(&order_id),
@@ -156,14 +189,14 @@ impl SettlementHandler {
 			.delivery
 			.get_receipt(&fill_tx_hash, chain_id)
 			.await
-			.map_err(|e| SettlementError::Service(format!("Failed to get fill receipt: {e}")))?;
+			.map_err(map_delivery_error)?;
 
 		// Generate post-fill transaction
 		let post_fill_tx = self
 			.settlement
 			.generate_post_fill_transaction(&order, &receipt)
 			.await
-			.map_err(|e| SettlementError::Service(e.to_string()))?;
+			.map_err(map_settlement_service_error)?;
 
 		match post_fill_tx {
 			Some(post_fill_tx) => {
@@ -264,15 +297,7 @@ impl SettlementHandler {
 					.delivery
 					.deliver(post_fill_tx.clone(), Some(tracking))
 					.await
-					.map_err(|e| match e {
-						// Preserve the typed transient-failure variant so the
-						// engine's PostFillReady handler can distinguish it
-						// from a permanent failure without string matching.
-						solver_delivery::DeliveryError::InsufficientNativeGas(info) => {
-							SettlementError::InsufficientNativeGas(info)
-						},
-						other => SettlementError::Service(other.to_string()),
-					})?;
+					.map_err(map_delivery_error)?;
 
 				// Store tx hash
 				self.state_machine
@@ -353,7 +378,7 @@ impl SettlementHandler {
 			.settlement
 			.generate_pre_claim_transaction(&order, &fill_proof)
 			.await
-			.map_err(|e| SettlementError::Service(e.to_string()))?;
+			.map_err(map_settlement_service_error)?;
 
 		match pre_claim_tx {
 			Some(pre_claim_tx) => {
@@ -454,7 +479,7 @@ impl SettlementHandler {
 					.delivery
 					.deliver(pre_claim_tx.clone(), Some(tracking))
 					.await
-					.map_err(|e| SettlementError::Service(e.to_string()))?;
+					.map_err(map_delivery_error)?;
 
 				// Store tx hash
 				self.state_machine
@@ -505,27 +530,34 @@ impl SettlementHandler {
 	pub async fn process_claim_batch(
 		&self,
 		batch: &mut Vec<String>,
-	) -> Result<(), SettlementError> {
-		for order_id in batch.drain(..) {
+	) -> Result<(), ClaimBatchError> {
+		let order_ids = std::mem::take(batch);
+		for order_id in order_ids {
 			// Retrieve order
 			let order: Order = self
 				.storage
 				.retrieve(StorageKey::Orders.as_str(), &order_id)
 				.await
-				.map_err(|e| SettlementError::Storage(e.to_string()))?;
+				.map_err(|e| {
+					ClaimBatchError::new(&order_id, SettlementError::Storage(e.to_string()))
+				})?;
 
 			// Retrieve fill proof (already validated when ClaimReady was emitted)
-			let fill_proof = order
-				.fill_proof
-				.clone()
-				.ok_or_else(|| SettlementError::Service("Order missing fill proof".to_string()))?;
+			let fill_proof = order.fill_proof.clone().ok_or_else(|| {
+				ClaimBatchError::new(
+					&order_id,
+					SettlementError::Service("Order missing fill proof".to_string()),
+				)
+			})?;
 
 			// Generate claim transaction
 			let claim_tx = self
 				.order_service
 				.generate_claim_transaction(&order, &fill_proof)
 				.await
-				.map_err(|e| SettlementError::Service(e.to_string()))?;
+				.map_err(|e| {
+					ClaimBatchError::new(&order_id, SettlementError::Service(e.to_string()))
+				})?;
 
 			// Submit claim transaction through delivery service with monitoring
 			let event_bus = self.event_bus.clone();
@@ -624,7 +656,7 @@ impl SettlementHandler {
 				.delivery
 				.deliver(claim_tx.clone(), Some(tracking))
 				.await
-				.map_err(|e| SettlementError::Service(e.to_string()))?;
+				.map_err(|e| ClaimBatchError::new(&order_id, map_delivery_error(e)))?;
 
 			self.event_bus
 				.publish(SolverEvent::Delivery(DeliveryEvent::TransactionPending {
@@ -639,7 +671,9 @@ impl SettlementHandler {
 			self.state_machine
 				.set_transaction_hash(&order.id, claim_tx_hash.clone(), TransactionType::Claim)
 				.await
-				.map_err(|e| SettlementError::State(e.to_string()))?;
+				.map_err(|e| {
+					ClaimBatchError::new(&order_id, SettlementError::State(e.to_string()))
+				})?;
 
 			// Store reverse mapping: tx_hash -> order_id
 			self.storage
@@ -650,7 +684,9 @@ impl SettlementHandler {
 					None,
 				)
 				.await
-				.map_err(|e| SettlementError::Storage(e.to_string()))?;
+				.map_err(|e| {
+					ClaimBatchError::new(&order_id, SettlementError::Storage(e.to_string()))
+				})?;
 		}
 		Ok(())
 	}
@@ -660,14 +696,14 @@ impl SettlementHandler {
 mod tests {
 	use super::*;
 	use mockall::predicate::*;
-	use solver_delivery::{DeliveryService, MockDeliveryInterface};
+	use solver_delivery::{DeliveryError, DeliveryService, MockDeliveryInterface};
 	use solver_order::{MockOrderInterface, OrderService};
 	use solver_settlement::{MockSettlementInterface, SettlementService};
 	use solver_storage::{MockStorageInterface, StorageError, StorageService};
 	use solver_types::utils::tests::builders::{
 		OrderBuilder, TransactionBuilder, TransactionReceiptBuilder,
 	};
-	use solver_types::{Order, Transaction, TransactionHash, TransactionReceipt};
+	use solver_types::{FillProof, Order, Transaction, TransactionHash, TransactionReceipt};
 	use std::collections::HashMap;
 	use std::sync::Arc;
 	use tokio::sync::broadcast;
@@ -678,6 +714,16 @@ mod tests {
 
 	fn create_test_receipt() -> TransactionReceipt {
 		TransactionReceiptBuilder::new().build()
+	}
+
+	fn create_test_fill_proof() -> FillProof {
+		FillProof {
+			tx_hash: TransactionHash(vec![0x11; 32]),
+			block_number: 100,
+			attestation_data: Some(vec![0x42]),
+			filled_timestamp: 1_700_000_000,
+			oracle_address: "0x1234567890123456789012345678901234567890".to_string(),
+		}
 	}
 
 	fn create_test_transaction() -> Transaction {
@@ -825,7 +871,154 @@ mod tests {
 		let mut batch = vec!["nonexistent_order".to_string()];
 		let result = handler.process_claim_batch(&mut batch).await;
 		assert!(result.is_err());
-		assert!(matches!(result.unwrap_err(), SettlementError::Storage(_)));
+		let error = result.unwrap_err();
+		assert_eq!(error.order_id, "nonexistent_order");
+		assert!(matches!(error.error, SettlementError::Storage(_)));
+	}
+
+	#[tokio::test]
+	async fn pre_claim_ready_preserves_insufficient_native_gas_as_transient() {
+		let (handler, _) = create_test_handler_with_mocks(
+			|mock_storage| {
+				mock_storage
+					.expect_get_bytes()
+					.with(eq("orders:test_order_123"))
+					.times(1)
+					.returning(|_| {
+						let order = OrderBuilder::new()
+							.with_standard("eip7683")
+							.with_fill_proof(Some(create_test_fill_proof()))
+							.build();
+						Box::pin(async move { Ok(serde_json::to_vec(&order).unwrap()) })
+					});
+			},
+			|mock_settlement| {
+				mock_settlement
+					.expect_generate_pre_claim_transaction()
+					.times(1)
+					.returning(|_, _| Box::pin(async move { Ok(Some(create_test_transaction())) }));
+			},
+			|mock_delivery| {
+				mock_delivery.expect_submit().times(1).returning(|_, _| {
+					Box::pin(async move {
+						Err(DeliveryError::InsufficientNativeGas(Box::new(
+							solver_delivery::InsufficientNativeGasInfo {
+								chain_id: 137,
+								signer: "0x0000000000000000000000000000000000000001".to_string(),
+								balance_wei: "0".to_string(),
+								required_wei: "1".to_string(),
+								shortfall_wei: "1".to_string(),
+								gas_limit: Some(21_000),
+								max_fee_per_gas: Some(1),
+								gas_price: None,
+								value_wei: "0".to_string(),
+							},
+						)))
+					})
+				});
+			},
+			|_| {},
+		)
+		.await;
+
+		let result = handler
+			.handle_pre_claim_ready("test_order_123".to_string())
+			.await;
+
+		assert!(matches!(
+			result.unwrap_err(),
+			SettlementError::InsufficientNativeGas(_)
+		));
+	}
+
+	#[tokio::test]
+	async fn post_fill_ready_preserves_receipt_network_error_as_delivery_error() {
+		let (handler, _) = create_test_handler_with_mocks(
+			|mock_storage| {
+				mock_storage
+					.expect_get_bytes()
+					.with(eq("orders:test_order_123"))
+					.times(1)
+					.returning(|_| {
+						let order = OrderBuilder::new()
+							.with_standard("eip7683")
+							.with_fill_tx_hash(Some(TransactionHash(vec![0x11; 32])))
+							.build();
+						Box::pin(async move { Ok(serde_json::to_vec(&order).unwrap()) })
+					});
+			},
+			|mock_settlement| {
+				mock_settlement
+					.expect_recover_post_fill_state()
+					.times(1)
+					.returning(|_| Box::pin(async move { Ok(false) }));
+			},
+			|mock_delivery| {
+				mock_delivery
+					.expect_get_receipt()
+					.with(eq(TransactionHash(vec![0x11; 32])), eq(137u64))
+					.times(1)
+					.returning(|_, _| {
+						Box::pin(async move { Err(DeliveryError::Network("rpc down".into())) })
+					});
+			},
+			|_| {},
+		)
+		.await;
+
+		let result = handler
+			.handle_post_fill_ready("test_order_123".to_string())
+			.await;
+
+		assert!(matches!(
+			result.unwrap_err(),
+			SettlementError::Delivery(DeliveryError::Network(_))
+		));
+	}
+
+	#[tokio::test]
+	async fn pre_claim_ready_preserves_settlement_service_error() {
+		let (handler, _) = create_test_handler_with_mocks(
+			|mock_storage| {
+				mock_storage
+					.expect_get_bytes()
+					.with(eq("orders:test_order_123"))
+					.times(1)
+					.returning(|_| {
+						let order = OrderBuilder::new()
+							.with_standard("eip7683")
+							.with_fill_proof(Some(create_test_fill_proof()))
+							.build();
+						Box::pin(async move { Ok(serde_json::to_vec(&order).unwrap()) })
+					});
+			},
+			|mock_settlement| {
+				mock_settlement
+					.expect_generate_pre_claim_transaction()
+					.times(1)
+					.returning(|_, _| {
+						Box::pin(async move {
+							Err(solver_settlement::SettlementError::ProverUnavailable(
+								"prover down".to_string(),
+							))
+						})
+					});
+			},
+			|_| {},
+			|_| {},
+		)
+		.await;
+
+		let result = handler
+			.handle_pre_claim_ready("test_order_123".to_string())
+			.await;
+
+		assert!(matches!(
+			result.unwrap_err(),
+			SettlementError::SettlementService(
+				solver_settlement::SettlementError::ProverUnavailable(_)
+			)
+		));
 	}
 
 	#[tokio::test]
@@ -1032,7 +1225,10 @@ mod tests {
 			.await;
 
 		assert!(result.is_err());
-		assert!(matches!(result.unwrap_err(), SettlementError::Service(_)));
+		assert!(matches!(
+			result.unwrap_err(),
+			SettlementError::SettlementService(_)
+		));
 	}
 
 	#[tokio::test]

--- a/crates/solver-core/src/handlers/transaction.rs
+++ b/crates/solver-core/src/handlers/transaction.rs
@@ -27,6 +27,12 @@ pub enum TransactionError {
 	Storage(String),
 	#[error("State error: {0}")]
 	State(String),
+	#[error("Settlement callback failed for {stage:?}: {source}")]
+	SettlementCallback {
+		stage: TransactionType,
+		#[source]
+		source: solver_settlement::SettlementError,
+	},
 	#[error("Service error: {0}")]
 	Service(String),
 }
@@ -161,29 +167,17 @@ impl TransactionHandler {
 			return Ok(());
 		}
 
-		// Retrieve the order for settlement callback
+		// Retrieve the order for confirmation handling.
 		let order: Order = self
 			.storage
 			.retrieve(StorageKey::Orders.as_str(), &order_id)
 			.await
 			.map_err(|e| TransactionError::Storage(e.to_string()))?;
-
-		// For PostFill and PreClaim, call settlement callback BEFORE other processing
-		// This allows Hyperlane to extract and store message IDs from receipts
-		if matches!(
+		let settlement_callback_order = matches!(
 			tx_type,
 			TransactionType::PostFill | TransactionType::PreClaim
-		) {
-			// Call settlement-specific handler
-			if let Ok(settlement) = self.settlement.find_settlement_for_order(&order) {
-				settlement
-					.handle_transaction_confirmed(&order, tx_type, &receipt)
-					.await
-					.map_err(|e: solver_settlement::SettlementError| {
-						TransactionError::Service(format!("Settlement callback failed: {e}"))
-					})?;
-			}
-		}
+		)
+		.then(|| order.clone());
 
 		// Handle based on transaction type
 		match tx_type {
@@ -202,6 +196,21 @@ impl TransactionHandler {
 			TransactionType::Claim => {
 				self.handle_claim_confirmed(tx_hash, order).await?;
 			},
+		}
+
+		// For PostFill and PreClaim, run settlement-specific receipt post-processing
+		// after persisting the chain-confirmed stage. A transient callback failure
+		// must not erase the fact that the transaction succeeded on-chain.
+		if let Some(order) = settlement_callback_order {
+			if let Ok(settlement) = self.settlement.find_settlement_for_order(&order) {
+				settlement
+					.handle_transaction_confirmed(&order, tx_type, &receipt)
+					.await
+					.map_err(|source| TransactionError::SettlementCallback {
+						stage: tx_type,
+						source,
+					})?;
+			}
 		}
 
 		Ok(())
@@ -490,7 +499,7 @@ mod tests {
 	use crate::state::OrderStateMachine;
 	use alloy_primitives::U256;
 	use mockall::predicate::*;
-	use solver_settlement::SettlementService;
+	use solver_settlement::{MockSettlementInterface, SettlementError, SettlementService};
 	use solver_storage::{MockStorageInterface, StorageService};
 	use solver_types::utils::tests::builders::{OrderBuilder, TransactionReceiptBuilder};
 	use solver_types::{
@@ -577,6 +586,36 @@ mod tests {
 			Arc::new(SettlementService::new(HashMap::new(), String::new(), 20)),
 			event_bus,
 		);
+
+		(handler, receiver, state_machine)
+	}
+
+	async fn create_memory_handler_with_order_and_settlement(
+		order: Order,
+		mock_settlement: MockSettlementInterface,
+	) -> (
+		TransactionHandler,
+		broadcast::Receiver<SolverEvent>,
+		Arc<OrderStateMachine>,
+	) {
+		let storage_impl = solver_storage::implementations::memory::MemoryStorage::new();
+		let storage = Arc::new(StorageService::new(Box::new(storage_impl)));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let event_bus = EventBus::new(100);
+		let receiver = event_bus.subscribe();
+
+		state_machine.store_order(&order).await.unwrap();
+
+		let settlement = Arc::new(SettlementService::new(
+			HashMap::from([(
+				"eip7683".to_string(),
+				Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+			)]),
+			"eip7683".to_string(),
+			20,
+		));
+		let handler =
+			TransactionHandler::new(storage, state_machine.clone(), settlement, event_bus);
 
 		(handler, receiver, state_machine)
 	}
@@ -974,6 +1013,48 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn post_fill_confirmed_transient_callback_error_persists_confirmation_first() {
+		let mut order = create_test_order(true);
+		order.status = OrderStatus::Executed;
+		order.settlement_name = Some("eip7683".to_string());
+		let tx_hash = create_test_tx_hash();
+		let receipt = create_test_receipt(true);
+
+		let mut mock_settlement = MockSettlementInterface::new();
+		mock_settlement
+			.expect_handle_transaction_confirmed()
+			.withf(|_, tx_type, _| *tx_type == TransactionType::PostFill)
+			.times(1)
+			.returning(|_, _, _| {
+				Box::pin(
+					async move { Err(SettlementError::ProverUnavailable("rpc timeout".into())) },
+				)
+			});
+		let (handler, _receiver, state_machine) =
+			create_memory_handler_with_order_and_settlement(order.clone(), mock_settlement).await;
+
+		let result = handler
+			.handle_confirmed(
+				order.id.clone(),
+				tx_hash.clone(),
+				TransactionType::PostFill,
+				receipt,
+			)
+			.await;
+
+		assert!(matches!(
+			result,
+			Err(TransactionError::SettlementCallback {
+				stage: TransactionType::PostFill,
+				..
+			})
+		));
+		let updated_order = state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(updated_order.status, OrderStatus::PostFilled);
+		assert_eq!(updated_order.post_fill_tx_hash, Some(tx_hash));
+	}
+
+	#[tokio::test]
 	async fn test_handle_post_fill_confirmed_missing_fill_tx_hash() {
 		let mut order = create_test_order(true);
 		order.fill_tx_hash = None; // Remove fill tx hash
@@ -1033,6 +1114,48 @@ mod tests {
 
 		// Verify order status was updated to PreClaimed
 		let updated_order = state_machine.get_order(&order_for_state.id).await.unwrap();
+		assert_eq!(updated_order.status, OrderStatus::PreClaimed);
+		assert_eq!(updated_order.pre_claim_tx_hash, Some(tx_hash));
+	}
+
+	#[tokio::test]
+	async fn pre_claim_confirmed_transient_callback_error_persists_confirmation_first() {
+		let tx_hash = create_test_tx_hash();
+		let mut order = create_test_order(true);
+		order.status = OrderStatus::Settled;
+		order.settlement_name = Some("eip7683".to_string());
+		let receipt = create_test_receipt(true);
+
+		let mut mock_settlement = MockSettlementInterface::new();
+		mock_settlement
+			.expect_handle_transaction_confirmed()
+			.withf(|_, tx_type, _| *tx_type == TransactionType::PreClaim)
+			.times(1)
+			.returning(|_, _, _| {
+				Box::pin(
+					async move { Err(SettlementError::ProverUnavailable("rpc timeout".into())) },
+				)
+			});
+		let (handler, _receiver, state_machine) =
+			create_memory_handler_with_order_and_settlement(order.clone(), mock_settlement).await;
+
+		let result = handler
+			.handle_confirmed(
+				order.id.clone(),
+				tx_hash.clone(),
+				TransactionType::PreClaim,
+				receipt,
+			)
+			.await;
+
+		assert!(matches!(
+			result,
+			Err(TransactionError::SettlementCallback {
+				stage: TransactionType::PreClaim,
+				..
+			})
+		));
+		let updated_order = state_machine.get_order(&order.id).await.unwrap();
 		assert_eq!(updated_order.status, OrderStatus::PreClaimed);
 		assert_eq!(updated_order.pre_claim_tx_hash, Some(tx_hash));
 	}

--- a/crates/solver-core/src/recovery/mod.rs
+++ b/crates/solver-core/src/recovery/mod.rs
@@ -896,6 +896,55 @@ impl RecoveryService {
 		}
 	}
 
+	async fn replay_confirmed_settlement_callback_if_needed(
+		&self,
+		order: &Order,
+		tx_type: TransactionType,
+		receipt: &TransactionReceipt,
+	) {
+		match tx_type {
+			TransactionType::PostFill => match self.settlement.recover_post_fill_state(order).await
+			{
+				Ok(true) => return,
+				Ok(false) => {},
+				Err(e) => {
+					tracing::warn!(
+						order_id = %order.id,
+						error = %e,
+						"Could not check recovered post-fill settlement state; continuing recovery"
+					);
+					return;
+				},
+			},
+			TransactionType::PreClaim => {},
+			_ => return,
+		}
+
+		match self.settlement.find_settlement_for_order(order) {
+			Ok(settlement) => {
+				if let Err(e) = settlement
+					.handle_transaction_confirmed(order, tx_type, receipt)
+					.await
+				{
+					tracing::warn!(
+						order_id = %order.id,
+						tx_type = ?tx_type,
+						error = %e,
+						"Could not replay confirmed settlement callback; continuing recovery"
+					);
+				}
+			},
+			Err(e) => {
+				tracing::warn!(
+					order_id = %order.id,
+					tx_type = ?tx_type,
+					error = %e,
+					"Could not find settlement for confirmed callback replay; continuing recovery"
+				);
+			},
+		}
+	}
+
 	/// Reconciles an order with blockchain state.
 	///
 	/// This method checks the actual status of transactions on the blockchain
@@ -999,6 +1048,12 @@ impl RecoveryService {
 							&receipt,
 						)
 						.await;
+						self.replay_confirmed_settlement_callback_if_needed(
+							&order,
+							TransactionType::PreClaim,
+							&receipt,
+						)
+						.await;
 						return Ok((
 							order.clone(),
 							ReconcileResult::NeedsClaim {
@@ -1057,6 +1112,12 @@ impl RecoveryService {
 							&order.id,
 							TransactionType::PostFill,
 							&post_fill_tx,
+							&receipt,
+						)
+						.await;
+						self.replay_confirmed_settlement_callback_if_needed(
+							&order,
+							TransactionType::PostFill,
 							&receipt,
 						)
 						.await;

--- a/crates/solver-core/tests/transaction_resilience_repro.rs
+++ b/crates/solver-core/tests/transaction_resilience_repro.rs
@@ -8,14 +8,16 @@ use solver_core::{
 	EventBus,
 };
 use solver_delivery::{DeliveryService, MockDeliveryInterface};
+use solver_settlement::SettlementReadiness;
 use solver_settlement::{MockSettlementInterface, SettlementService};
 use solver_storage::{
 	implementations::file::{FileStorage, TtlConfig},
 	StorageService,
 };
 use solver_types::{
-	utils::tests::builders::OrderBuilder, Address, OrderStatus, Transaction,
-	TransactionAttemptStatus, TransactionHash, TransactionReceipt, TransactionType,
+	utils::tests::builders::OrderBuilder, Address, FillProof, OrderStatus, SettlementEvent,
+	SolverEvent, Transaction, TransactionAttemptStatus, TransactionHash, TransactionReceipt,
+	TransactionType,
 };
 
 fn file_storage() -> (Arc<StorageService>, tempfile::TempDir) {
@@ -48,6 +50,16 @@ fn receipt(hash: TransactionHash, success: bool) -> TransactionReceipt {
 		success,
 		block_timestamp: Some(456),
 		logs: vec![],
+	}
+}
+
+fn fill_proof(tx_hash: TransactionHash) -> FillProof {
+	FillProof {
+		tx_hash,
+		block_number: 12345,
+		attestation_data: Some(vec![0x01, 0x02, 0x03]),
+		filled_timestamp: 456,
+		oracle_address: "0x1234567890123456789012345678901234567890".to_string(),
 	}
 }
 
@@ -174,4 +186,159 @@ async fn transaction_resilience_reproves_atomic_fill_write_and_recovery_attempt_
 	assert_eq!(attempt.status, TransactionAttemptStatus::Confirmed);
 	assert_eq!(attempt.tx_hash, Some(recovered_hash));
 	assert!(attempt.receipt.is_some());
+}
+
+#[tokio::test]
+async fn recovery_replays_missing_confirmed_post_fill_callback() {
+	let (storage, _temp_dir) = file_storage();
+	let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+	let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
+	let fill_hash = TransactionHash(vec![0x44; 32]);
+	let post_fill_hash = TransactionHash(vec![0x55; 32]);
+	let mut order = OrderBuilder::new()
+		.with_id("post-fill-callback-replay-order".to_string())
+		.with_status(OrderStatus::PostFilled)
+		.with_fill_tx_hash(Some(fill_hash))
+		.with_settlement_name(Some("eip7683"))
+		.build();
+	order.post_fill_tx_hash = Some(post_fill_hash.clone());
+	state_machine.store_order(&order).await.unwrap();
+
+	let mut mock_delivery = MockDeliveryInterface::new();
+	mock_delivery
+		.expect_get_receipt()
+		.with(
+			mockall::predicate::eq(post_fill_hash.clone()),
+			mockall::predicate::eq(137u64),
+		)
+		.times(1)
+		.returning(move |hash, _| {
+			let hash = hash.clone();
+			Box::pin(async move { Ok(receipt(hash, true)) })
+		});
+	let delivery = Arc::new(DeliveryService::new(
+		HashMap::from([(
+			137u64,
+			Arc::new(mock_delivery) as Arc<dyn solver_delivery::DeliveryInterface>,
+		)]),
+		1,
+		20,
+		60,
+	));
+
+	let mut mock_settlement = MockSettlementInterface::new();
+	mock_settlement
+		.expect_recover_post_fill_state()
+		.with(mockall::predicate::always())
+		.times(1)
+		.returning(|_| Box::pin(async move { Ok(false) }));
+	mock_settlement
+		.expect_handle_transaction_confirmed()
+		.withf(|_, tx_type, receipt| *tx_type == TransactionType::PostFill && receipt.success)
+		.times(1)
+		.returning(|_, _, _| Box::pin(async move { Ok(()) }));
+	let settlement = Arc::new(SettlementService::new(
+		HashMap::from([(
+			"eip7683".to_string(),
+			Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+		)]),
+		"eip7683".to_string(),
+		20,
+	));
+	let recovery = RecoveryService::new(
+		storage.clone(),
+		state_machine.clone(),
+		delivery,
+		settlement,
+		EventBus::new(100),
+		attempt_store,
+		Arc::new(HashMap::new()),
+	);
+
+	let (report, _orphaned) = recovery.recover_state().await.unwrap();
+	assert_eq!(report.total_orders, 1);
+	assert_eq!(report.reconciled_orders, 1);
+}
+
+#[tokio::test]
+async fn recovery_reemits_pre_claim_ready_for_settled_order_with_confirmed_post_fill_receipt() {
+	let (storage, _temp_dir) = file_storage();
+	let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+	let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
+	let fill_hash = TransactionHash(vec![0x66; 32]);
+	let post_fill_hash = TransactionHash(vec![0x77; 32]);
+	let fill_proof = fill_proof(fill_hash.clone());
+	let mut order = OrderBuilder::new()
+		.with_id("settled-pre-claim-recovery-order".to_string())
+		.with_status(OrderStatus::Settled)
+		.with_fill_tx_hash(Some(fill_hash))
+		.with_fill_proof(Some(fill_proof))
+		.with_settlement_name(Some("eip7683"))
+		.build();
+	order.post_fill_tx_hash = Some(post_fill_hash.clone());
+	state_machine.store_order(&order).await.unwrap();
+
+	let mut mock_delivery = MockDeliveryInterface::new();
+	mock_delivery
+		.expect_get_receipt()
+		.with(
+			mockall::predicate::eq(post_fill_hash.clone()),
+			mockall::predicate::eq(137u64),
+		)
+		.times(1)
+		.returning(move |hash, _| {
+			let hash = hash.clone();
+			Box::pin(async move { Ok(receipt(hash, true)) })
+		});
+	let delivery = Arc::new(DeliveryService::new(
+		HashMap::from([(
+			137u64,
+			Arc::new(mock_delivery) as Arc<dyn solver_delivery::DeliveryInterface>,
+		)]),
+		1,
+		20,
+		60,
+	));
+
+	let mut mock_settlement = MockSettlementInterface::new();
+	mock_settlement
+		.expect_recover_post_fill_state()
+		.times(1)
+		.returning(|_| Box::pin(async move { Ok(true) }));
+	mock_settlement
+		.expect_handle_transaction_confirmed()
+		.times(0);
+	mock_settlement
+		.expect_readiness()
+		.times(1)
+		.returning(|_, _| Box::pin(async move { SettlementReadiness::Ready }));
+	let settlement = Arc::new(SettlementService::new(
+		HashMap::from([(
+			"eip7683".to_string(),
+			Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+		)]),
+		"eip7683".to_string(),
+		20,
+	));
+	let event_bus = EventBus::new(100);
+	let mut receiver = event_bus.subscribe();
+	let recovery = RecoveryService::new(
+		storage.clone(),
+		state_machine.clone(),
+		delivery,
+		settlement,
+		event_bus,
+		attempt_store,
+		Arc::new(HashMap::new()),
+	);
+
+	recovery.recover_state().await.unwrap();
+
+	let event = receiver.recv().await.unwrap();
+	match event {
+		SolverEvent::Settlement(SettlementEvent::PreClaimReady { order_id }) => {
+			assert_eq!(order_id, order.id);
+		},
+		other => panic!("expected PreClaimReady, got {other:?}"),
+	}
 }

--- a/docs/superpowers/plans/2026-06-10-transient-settlement-errors.md
+++ b/docs/superpowers/plans/2026-06-10-transient-settlement-errors.md
@@ -1,0 +1,494 @@
+# Transient Settlement Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent transient settlement/post-fill/pre-claim infrastructure failures from terminally marking already-filled orders as `Failed`, so recovery can retry and solver funds are not stranded.
+
+**Architecture:** Preserve typed error information at the settlement-handler boundary, classify retryable infrastructure failures in one shared helper, and have engine settlement arms leave orders in their current retryable status for transient errors. Confirmed on-chain transaction handlers must advance status first and run settlement callback post-processing as retryable/idempotent work; only confirmed reverts and explicit permanent settlement errors should write terminal `Failed`.
+
+**Tech Stack:** Rust 2021, `solver-core`, existing `solver-delivery` and `solver-settlement` error enums, Tokio tests, `mockall`, file-backed storage test helpers.
+
+---
+
+## Investigation Summary
+
+Current `origin/main` at `9e6668dbe311b2dcbcf2e38db24ddf250253fcab` does not fully fix Group 1.
+
+- `crates/solver-core/src/engine/mod.rs`: `is_transient_postfill_error` only treats `SettlementError::InsufficientNativeGas` as transient. `PostFillReady` still fails all other errors, `PreClaimReady` fails every error, and `ClaimReady` has the same latent terminalization pattern.
+- `crates/solver-core/src/handlers/settlement.rs`: post-fill preserves `DeliveryError::InsufficientNativeGas`, but collapses other delivery errors to `Service(String)`. Pre-claim and claim collapse all delivery errors to `Service(String)`.
+- `crates/solver-core/src/handlers/transaction.rs`: `handle_confirmed` calls settlement `handle_transaction_confirmed` for `PostFill` and `PreClaim` before advancing order status. Any callback error becomes `TransactionError::Service`, and the engine marks the order `Failed(tx_type, ...)`.
+- `crates/solver-core/src/recovery/mod.rs` and `crates/solver-core/src/bump/service.rs`: both exclude `Failed` orders from automated processing. Leaving `Executed` or `Settled` unchanged is safe because recovery already re-emits `PostFillReady` and `PreClaimReady` from those statuses.
+- `crates/solver-core/src/handlers/settlement.rs`: claim batch error handling is already broken in a separate way. `process_claim_batch` drains the batch, and `CLAIM_BATCH` is currently `1`, so the engine's later `for order_id in batch` failure loop is dead code. This plan's claim-batch work primarily restores per-order error observability and policy application.
+- Startup recovery is startup-only. `RetryLater` means the order remains eligible for startup recovery and live bump/retry components where they apply; it is not a new in-process backoff loop.
+
+Baseline verification before plan: `cargo test -p solver-core 2>&1 | tee /tmp/oif-solver-core-baseline-h02-h06-m24.log` passed with `333 passed; 0 failed; 1 ignored` for unit tests, plus all solver-core integration/doc tests passing.
+
+## File Structure
+
+- Modify `crates/solver-core/src/handlers/settlement.rs`
+  - Add typed core `SettlementError::Delivery(solver_delivery::DeliveryError)` and `SettlementError::SettlementService(solver_settlement::SettlementError)` variants.
+  - Add `map_delivery_error` for every fallible delivery call, including `get_receipt` and all `deliver` calls.
+  - Add `map_settlement_service_error` for `recover_post_fill_state`, `generate_post_fill_transaction`, and `generate_pre_claim_transaction`.
+  - Preserve `solver_settlement::SettlementError` from settlement-service calls so `FinalityNotReached`, `ProverUnavailable`, `InvalidProof`, and `FillMismatch` can be classified without string matching.
+- Modify `crates/solver-core/src/handlers/transaction.rs`
+  - Add typed `TransactionError::SettlementCallback(...)` for settlement callback failures.
+  - Reorder `PostFill` and `PreClaim` confirmation processing so the order status/hash transition happens before settlement callback post-processing.
+  - Return typed callback errors after status advance so the engine can avoid terminalizing transient callback work.
+- Modify `crates/solver-core/src/recovery/mod.rs`
+  - Re-drive missing settlement callback side effects when recovery sees an already-confirmed `PostFill` or `PreClaim` receipt.
+  - Gate `PostFill` callback replay through existing post-fill state recovery so broadcaster orders with already-tracked submissions do not reset proof state on every restart.
+- Modify `crates/solver-core/src/engine/mod.rs`
+  - Replace `is_transient_postfill_error` with one shared policy helper, for example `settlement_failure_policy(stage, &error)`.
+  - Use the policy from `PostFillReady`, `PreClaimReady`, `ClaimReady`, and `TransactionConfirmed` callback-error handling.
+- Modify tests in:
+  - `crates/solver-core/src/handlers/settlement.rs`
+  - `crates/solver-core/src/handlers/transaction.rs`
+  - `crates/solver-core/tests/transaction_resilience_repro.rs` for recovery-loop regression coverage.
+
+## Data Shape and Call Sites
+
+Order state uses `OrderStatus` plus per-stage hashes: `fill_tx_hash`, `post_fill_tx_hash`, `pre_claim_tx_hash`, and `claim_tx_hash`. Reverse lookup storage uses `StorageKey::OrderByTxHash` keyed by encoded transaction hash.
+
+Call sites that exercise this path:
+
+- Live monitor callbacks publish `DeliveryEvent::TransactionConfirmed` from settlement handler callbacks.
+- Engine `TransactionConfirmed` arm calls `TransactionHandler::handle_confirmed`.
+- Engine `PostFillReady` arm calls `SettlementHandler::handle_post_fill_ready`.
+- Engine `PreClaimReady` arm calls `SettlementHandler::handle_pre_claim_ready`.
+- Engine `ClaimReady` arm calls `SettlementHandler::process_claim_batch`.
+- Startup recovery publishes `PostFillReady`, `StartMonitoring`, `PreClaimReady`, or `ClaimReady` for non-terminal orders.
+
+## Error Classification Design
+
+Add a local policy enum in `engine/mod.rs` or a small helper module under `crates/solver-core/src/engine/`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettlementFailurePolicy {
+	RetryLater,
+	FailOrder,
+}
+```
+
+Classify as `RetryLater`:
+
+- `DeliveryError::Network`
+- `DeliveryError::NonceTooLow`
+- `DeliveryError::ReplacementUnderpriced`
+- `DeliveryError::InsufficientNativeGas`
+- `DeliveryError::NoImplementationAvailable`
+- `solver_settlement::SettlementError::FinalityNotReached`
+- `solver_settlement::SettlementError::ProverUnavailable`
+- `solver_settlement::SettlementError::ProofGenerationFailed { .. }`
+- typed transaction callback storage/state errors only when the error variant proves the on-chain stage has already been persisted and the remaining failure is post-confirmation callback/storage work
+
+Classify as `FailOrder`:
+
+- confirmed receipt `success == false`, which already flows through `TransactionFailed`
+- explicit permanent settlement errors: `ValidationFailed`, `InvalidProof`, `FillMismatch`, `SlotDerivationMismatch`
+- `DeliveryError::TransactionFailed` unless a narrower typed classification proves it is retryable
+- missing invariant data that cannot be recovered by retry alone, such as no fill hash when handling post-fill or no fill proof when handling pre-claim
+- generic `SettlementError::Storage`, `SettlementError::State`, and `SettlementError::Service` unless they are replaced by typed/contextual variants proving retry is safe
+
+Do not broaden `RevertClassification::Unknown` in this PR unless tests prove it is necessary. Current delivery callbacks intentionally publish `TransactionFailed` for `Unknown`; changing that is adjacent but riskier than fixing transient infrastructure errors.
+
+## Task 1: Preserve Typed Settlement Handler Errors
+
+**Files:**
+- Modify: `crates/solver-core/src/handlers/settlement.rs`
+
+- [ ] **Step 1: Write failing tests for pre-claim delivery classification**
+
+Add tests near `test_handle_pre_claim_ready_missing_fill_proof`:
+
+```rust
+#[tokio::test]
+async fn pre_claim_ready_preserves_insufficient_native_gas_as_transient() {
+	// Arrange a settled order with fill_proof and a generated pre-claim tx.
+	// Mock delivery.submit to return DeliveryError::InsufficientNativeGas.
+	// Assert handle_pre_claim_ready returns SettlementError::InsufficientNativeGas.
+}
+
+#[tokio::test]
+async fn post_fill_ready_preserves_receipt_network_error_as_delivery_error() {
+	// Arrange an Executed order with fill_tx_hash.
+	// Mock delivery.get_receipt to return DeliveryError::Network.
+	// Assert handle_post_fill_ready returns SettlementError::Delivery.
+}
+
+#[tokio::test]
+async fn pre_claim_ready_preserves_settlement_service_error() {
+	// Arrange a Settled order with fill_proof.
+	// Mock generate_pre_claim_transaction to return solver_settlement::SettlementError::ProverUnavailable.
+	// Assert handle_pre_claim_ready returns SettlementError::SettlementService.
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+cargo test -p solver-core ready_preserves_ 2>&1 | tee /tmp/oif-red-settlement-preserve.log
+```
+
+Expected: FAIL. The pre-claim native-gas test should fail by assertion because the error is currently `Service`; the receipt and settlement-service preservation tests may initially fail to compile because the new typed variants do not exist yet. Treat that compile failure as the expected RED for new API surface.
+
+- [ ] **Step 3: Add shared mapping helper**
+
+Implement one helper:
+
+```rust
+fn map_delivery_error(error: solver_delivery::DeliveryError) -> SettlementError {
+	match error {
+		solver_delivery::DeliveryError::InsufficientNativeGas(info) => {
+			SettlementError::InsufficientNativeGas(info)
+		},
+		other => SettlementError::Delivery(other),
+	}
+}
+```
+
+Add `SettlementError::Delivery(solver_delivery::DeliveryError)`. Also add:
+
+```rust
+fn map_settlement_service_error(error: solver_settlement::SettlementError) -> SettlementError {
+	SettlementError::SettlementService(error)
+}
+```
+
+- [ ] **Step 4: Replace delivery and settlement-service mappings**
+
+Use `map_delivery_error` for:
+
+- `delivery.get_receipt` in `handle_post_fill_ready`
+- `delivery.deliver` in `handle_post_fill_ready`
+- `delivery.deliver` in `handle_pre_claim_ready`
+- `delivery.deliver` in `process_claim_batch`
+
+Use `map_settlement_service_error` for:
+
+- `settlement.recover_post_fill_state`
+- `settlement.generate_post_fill_transaction`
+- `settlement.generate_pre_claim_transaction`
+
+- [ ] **Step 5: Run GREEN**
+
+Run:
+
+```bash
+cargo test -p solver-core ready_preserves_ 2>&1 | tee /tmp/oif-green-settlement-preserve.log
+```
+
+Expected: PASS.
+
+## Task 2: Add One Shared Settlement Failure Policy
+
+**Files:**
+- Modify: `crates/solver-core/src/engine/mod.rs`
+
+- [ ] **Step 1: Write unit tests for policy**
+
+Add tests under `engine::tests`:
+
+```rust
+#[test]
+fn settlement_policy_retries_transient_delivery_errors() {
+	// Build core SettlementError values wrapping DeliveryError::Network,
+	// NonceTooLow, ReplacementUnderpriced, and InsufficientNativeGas.
+	// Assert RetryLater for PostFill, PreClaim, and Claim.
+}
+
+#[test]
+fn settlement_policy_fails_permanent_settlement_errors() {
+	// Build core SettlementError values wrapping InvalidProof/FillMismatch.
+	// Assert FailOrder.
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+cargo test -p solver-core settlement_policy 2>&1 | tee /tmp/oif-red-policy.log
+```
+
+Expected: FAIL, likely as a compile failure because the policy function and new typed variants do not exist yet. This filter should match only policy tests.
+
+- [ ] **Step 3: Implement policy**
+
+Replace `is_transient_postfill_error` with:
+
+```rust
+fn settlement_failure_policy(
+	stage: solver_types::TransactionType,
+	error: &crate::handlers::settlement::SettlementError,
+) -> SettlementFailurePolicy {
+	// Match typed variants, not strings.
+}
+```
+
+Keep the implementation local and exhaustive over current core `SettlementError` variants.
+
+Classify every wrapped `DeliveryError` and `solver_settlement::SettlementError` variant explicitly. Do not leave a wildcard arm for these source enums; adding a new upstream variant should force a policy decision.
+
+- [ ] **Step 4: Run GREEN**
+
+Run:
+
+```bash
+cargo test -p solver-core settlement_policy 2>&1 | tee /tmp/oif-green-policy.log
+```
+
+Expected: PASS.
+
+## Task 3: Apply Policy to Event Arms
+
+**Files:**
+- Modify: `crates/solver-core/src/engine/mod.rs`
+
+- [ ] **Step 1: Extract DRY helper for settlement arm errors**
+
+Create a helper used by `PostFillReady`, `PreClaimReady`, and `ClaimReady`:
+
+```rust
+async fn handle_settlement_stage_error(
+	engine: &SolverEngine,
+	order_id: &str,
+	tx_type: TransactionType,
+	context: &str,
+	error: crate::handlers::settlement::SettlementError,
+) -> Result<(), EngineError> {
+	// RetryLater: warn and return EngineError without transitioning.
+	// FailOrder: transition to OrderStatus::Failed(tx_type, message).
+}
+```
+
+If borrowing makes an async helper noisy, keep it as a small private method on `SolverEngine`.
+
+- [ ] **Step 2: Update PostFillReady**
+
+Replace the existing `is_transient_postfill_error` branch with the shared helper.
+
+- [ ] **Step 3: Update PreClaimReady**
+
+Use the same helper so transient delivery/RPC/signer errors leave the order in `Settled`. Generic `SettlementError::Storage` and `SettlementError::State` still fail unless replaced by a typed/contextual variant proving retry is safe after on-chain success.
+
+- [ ] **Step 4: Update ClaimReady**
+
+Use the same helper for claim processing, but first fix the batch error shape. Current `process_claim_batch` drains `batch`, while the engine error branch iterates the same drained vector.
+
+Implement one concrete design: make `process_claim_batch` return `Result<(), ClaimBatchError>` where `ClaimBatchError` includes the affected `order_id` and typed `SettlementError`. Preserve the input order IDs before draining or iterate without consuming them until each order succeeds, so the engine can apply the shared policy to exactly the affected order.
+
+Then transient claim submission errors and typed/contextual retry-safe post-submission storage/state errors leave that order in `Settled`/`PreClaimed` for recovery, while permanent failures transition only the affected order to `Failed(Claim, ...)`. Generic `SettlementError::Storage` and `SettlementError::State` remain `FailOrder` unless the implementation replaces them with a variant proving the chain stage already succeeded and only retryable off-chain bookkeeping failed.
+
+- [ ] **Step 5: Add and run focused engine error-path tests**
+
+Add tests for the shared helper or engine arm wrapper:
+
+```rust
+#[tokio::test]
+async fn post_fill_ready_transient_error_leaves_order_executed() {
+	// Assert RetryLater path does not call transition_order_status to Failed.
+}
+
+#[tokio::test]
+async fn pre_claim_ready_transient_error_leaves_order_settled() {
+	// Assert RetryLater path does not call transition_order_status to Failed.
+}
+
+#[tokio::test]
+async fn claim_ready_transient_error_leaves_order_retryable() {
+	// Assert transient claim error does not terminalize order.
+}
+
+#[tokio::test]
+async fn claim_ready_permanent_error_fails_only_affected_order() {
+	// Assert permanent claim error writes Failed(Claim) for the affected order.
+}
+```
+
+Run:
+
+```bash
+cargo test -p solver-core transient_error_leaves 2>&1 | tee /tmp/oif-engine-transient-arms.log
+cargo test -p solver-core claim_ready_permanent 2>&1 | tee /tmp/oif-engine-claim-ready.log
+```
+
+Expected: PASS.
+
+## Task 4: Make Confirmed Callback Post-Processing Retryable
+
+**Files:**
+- Modify: `crates/solver-core/src/handlers/transaction.rs`
+- Modify: `crates/solver-core/src/engine/mod.rs`
+- Modify: `crates/solver-core/src/recovery/mod.rs`
+
+- [ ] **Step 1: Write failing transaction-handler test**
+
+Add a test proving a successful `PostFill` receipt advances to `PostFilled` and emits `StartMonitoring` even if settlement callback post-processing returns a transient error.
+
+```rust
+#[tokio::test]
+async fn post_fill_confirmed_advances_status_before_transient_callback_error() {
+	// Stored order starts Executed with fill_tx_hash.
+	// Mock settlement handle_transaction_confirmed returns ProverUnavailable or equivalent transient.
+	// Call handle_confirmed(PostFill, success receipt).
+	// Assert stored status is PostFilled and post_fill_tx_hash is recorded.
+	// Assert returned error preserves callback context for engine logging/classification.
+}
+```
+
+Add an equivalent `PreClaim` test for `Settled -> PreClaimed` and `ClaimReady`.
+
+The test must bind the order to the mocked settlement implementation. `TransactionHandler::handle_confirmed` skips the callback when `SettlementService::find_settlement_for_order` returns `Err`, so set `order.settlement_name` to the registered mock key or configure that key as the settlement service primary name.
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+cargo test -p solver-core transient_callback_error 2>&1 | tee /tmp/oif-red-confirmed-callback.log
+```
+
+Expected: FAIL because current code runs callback before transition. Name both tests with the shared `transient_callback_error` phrase so this single filter matches them.
+
+- [ ] **Step 3: Reorder confirmed handling**
+
+For `PostFill` and `PreClaim`:
+
+1. Retrieve order.
+2. Run the stage-specific status/hash transition.
+3. Run settlement `handle_transaction_confirmed` afterward.
+4. If callback fails, return `TransactionError::SettlementCallback { stage, source }` without rolling back status.
+
+Keep receipt `success == false` behavior unchanged.
+
+- [ ] **Step 4: Apply engine policy to callback errors**
+
+In the `TransactionConfirmed` event arm, distinguish `TransactionError::SettlementCallback`. If policy is `RetryLater`, log and leave status unchanged. If policy is `FailOrder`, transition to `Failed(tx_type, ...)`.
+
+- [ ] **Step 5: Write failing recovery replay test**
+
+Add a test in `crates/solver-core/tests/transaction_resilience_repro.rs` where an order has a successful `PostFill` receipt already on chain but settlement callback state is missing. `RecoveryService::recover_state()` should call settlement `handle_transaction_confirmed` or an equivalent recovery path before moving on to monitoring/pre-claim. This test protects the broadcaster `NoSubmissionState` case.
+
+Also include the gate case: when post-fill state already exists, recovery should not replay `PostFill` callback side effects again. This avoids repeatedly calling broadcaster `track_submission`, which resets proof state to `None`.
+
+Run:
+
+```bash
+cargo test -p solver-core --test transaction_resilience_repro recovery_replays_missing_confirmed_post_fill_callback 2>&1 | tee /tmp/oif-red-recovery-callback-replay.log
+```
+
+Expected: FAIL because confirmed receipts currently bypass settlement callback replay.
+
+- [ ] **Step 6: Add recovery callback replay**
+
+Add a recovery helper that re-runs settlement callback side effects only when recovery sees a confirmed receipt and the callback state is missing or safely idempotent:
+
+```rust
+async fn replay_confirmed_settlement_callback_if_needed(
+	&self,
+	order: &Order,
+	tx_type: TransactionType,
+	receipt: &TransactionReceipt,
+) -> Result<(), RecoveryError> {
+	// PostFill: first call recover_post_fill_state(order). If it returns false,
+	// call settlement.handle_transaction_confirmed(order, PostFill, receipt).
+	// This avoids repeatedly calling broadcaster track_submission after state
+	// already exists, because track_submission resets proof to None.
+	// PreClaim: call settlement.handle_transaction_confirmed(order, PreClaim, receipt);
+	// mark_verified-style callbacks are idempotent and do not clear proofs.
+}
+```
+
+Call this helper in `reconcile_with_blockchain` successful receipt branches for `PostFill` and `PreClaim`, after `mark_recovered_attempt_confirmed` and before returning `NeedsMonitoring`, `NeedsPreClaim`, or `NeedsClaim`. On transient callback replay errors, log the retryable error and continue with the normal evidence-based `ReconcileResult`; do not return `Unknown` and do not write `Failed`.
+
+- [ ] **Step 7: Run GREEN**
+
+Run:
+
+```bash
+cargo test -p solver-core transient_callback_error 2>&1 | tee /tmp/oif-green-confirmed-callback.log
+cargo test -p solver-core --test transaction_resilience_repro recovery_replays_missing_confirmed_post_fill_callback 2>&1 | tee /tmp/oif-green-recovery-callback-replay.log
+```
+
+Expected: PASS.
+
+## Task 5: Add Recovery Regression Coverage Inside solver-core Tests
+
+**Files:**
+- Modify: `crates/solver-core/tests/transaction_resilience_repro.rs`
+
+- [ ] **Step 1: Add recovery re-drive regression for post-fill**
+
+Add a test where an `Executed` order has a confirmed fill hash. `RecoveryService::recover_state()` should reconcile the fill receipt and publish `SettlementEvent::PostFillReady`. This proves the actual safety property for Tasks 1-3: leaving an order in `Executed` after a transient post-fill error lets startup recovery re-drive the post-fill path.
+
+- [ ] **Step 2: Add recovery re-drive regression for pre-claim**
+
+Add a test where a `Settled` order has `fill_proof`, `post_fill_tx_hash`, a mocked successful post-fill receipt from `delivery.get_receipt`, and settlement readiness is `Ready`. `RecoveryService::recover_state()` should publish `SettlementEvent::PreClaimReady`. This proves leaving an order in `Settled` after a transient pre-claim error lets startup recovery re-drive pre-claim.
+
+- [ ] **Step 3: Run RED/GREEN as tests are added**
+
+For each test:
+
+```bash
+cargo test -p solver-core --test transaction_resilience_repro <test_name> 2>&1 | tee /tmp/oif-<test-name>.log
+```
+
+Expected before implementation: the recovery re-drive tests should pass if current recovery already publishes the event. Expected after implementation: PASS.
+
+## Task 6: Full Verification
+
+**Files:**
+- No new files unless implementation adds a small helper module.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all -- --check 2>&1 | tee /tmp/oif-fmt-check.log
+```
+
+Expected: PASS. If it fails, run `cargo fmt` and then re-run the check.
+
+- [ ] **Step 2: Test solver-core**
+
+Run:
+
+```bash
+cargo test -p solver-core 2>&1 | tee /tmp/oif-solver-core-final.log
+```
+
+Expected: PASS with the new regression tests included.
+
+- [ ] **Step 3: Check broader target if shared APIs changed**
+
+If `solver-delivery`, `solver-settlement`, or `solver-types` public APIs were changed, run:
+
+```bash
+cargo check --all-targets --all-features 2>&1 | tee /tmp/oif-all-targets-check.log
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Lint**
+
+Run:
+
+```bash
+cargo clippy --all-features --all-targets -- -D warnings --allow deprecated 2>&1 | tee /tmp/oif-clippy.log
+```
+
+Expected: PASS.
+
+## Risk Notes
+
+- Do not add backwards-compatible status shims. The safer behavior is to avoid writing `Failed` for retryable post-fill/pre-claim/claim work.
+- Do not classify all `Service(String)` as transient. Preserve typed sources so permanent order/proof/config faults still fail fast.
+- Do not change on-chain idempotency assumptions. Retrying post-fill/pre-claim/claim is acceptable because OIF contracts enforce single fill/claim/settle; the off-chain risk is stranded funds.
+- Be conservative with `DeliveryError::TransactionFailed` and `RevertClassification::Unknown`. Treat them as permanent unless a narrower typed signal proves transient.
+- Generic `SettlementError::Storage` and `SettlementError::State` remain terminal in this plan unless replaced by typed contextual variants. A storage blip after successful submission can still be a residual risk; handle that only with a variant proving on-chain progress already happened.
+- `RetryLater` does not introduce an in-process retry loop. It prevents terminal `Failed` writes so startup recovery, existing monitoring, or a later explicitly-designed retry loop can re-drive the stage.


### PR DESCRIPTION
## Summary

- Preserve typed settlement and delivery errors through post-fill, pre-claim, and claim paths so retryable infrastructure failures are not collapsed into terminal order failures.
- Route settlement-stage failures through a shared transient/permanent policy, leaving retryable orders in their current non-terminal state for recovery to re-drive.
- Persist confirmed PostFill and PreClaim status/hash updates before settlement callback post-processing, and replay missing confirmed callbacks during recovery with a broadcaster-safe gate.
- Add regression coverage for transient settlement errors, confirmed callback failures, recovery callback replay, and recovery re-drive into PreClaimReady.

## Root Cause

Successful on-chain settlement progress could be followed by transient off-chain failures such as RPC, prover, delivery, or callback storage errors. Several engine arms treated those errors as fatal and wrote `OrderStatus::Failed`, which is terminal and excluded from recovery, stranding already-paid fills.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p solver-core`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`

The commit is GPG-signed with the configured local key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issue where temporary delivery or settlement service failures incorrectly marked orders as permanently failed; transient errors now trigger automatic retries.

* **Improvements**
  * Enhanced system recovery to replay settlement operations for orders with confirmed transactions, reducing order failures during restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->