### PR TITLE
fix(C-03): forced-withdrawal JIT check + resource-lock pre-fill hardening

### DIFF
--- a/crates/solver-core/Cargo.toml
+++ b/crates/solver-core/Cargo.toml
@@ -32,7 +32,7 @@ solver-order = { path = "../solver-order" }
 solver-pricing = { path = "../solver-pricing" }
 solver-settlement = { path = "../solver-settlement" }
 solver-storage = { path = "../solver-storage" }
-solver-types = { path = "../solver-types" }
+solver-types = { path = "../solver-types", features = ["oif-interfaces"] }
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -240,6 +240,7 @@ impl SolverEngine {
 			storage.clone(),
 			state_machine.clone(),
 			event_bus.clone(),
+			dynamic_config.clone(),
 		));
 
 		let transaction_handler = Arc::new(TransactionHandler::new(

--- a/crates/solver-core/src/handlers/forced_withdrawal.rs
+++ b/crates/solver-core/src/handlers/forced_withdrawal.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use alloy_primitives::{Address as AlloyAddress, U256};
 use alloy_sol_types::SolCall;
-use solver_delivery::DeliveryService;
+use solver_delivery::{fetch_compact_balance, DeliveryService};
 use solver_types::{standards::eip7683::interfaces::ITheCompact, Address, Transaction};
 
 /// `ForcedWithdrawalStatus` enum value meaning no forced withdrawal is pending or
@@ -42,8 +42,15 @@ pub enum ForcedWithdrawalError {
 	/// A lock reports a non-`Disabled` forced-withdrawal status.
 	#[error("ResourceLock input {lock_id} has forced withdrawal active (status {status}); refusing to fill")]
 	Active { lock_id: U256, status: u8 },
+	/// The lock balance is no longer sufficient to cover the order input.
+	#[error("ResourceLock input {lock_id} balance {available} is below required amount {required}; refusing to fill")]
+	InsufficientBalance {
+		lock_id: U256,
+		required: U256,
+		available: U256,
+	},
 	/// The on-chain query or its decoding failed; fail closed rather than fill blind.
-	#[error("Failed to query TheCompact.getForcedWithdrawalStatus: {0}")]
+	#[error("Failed to query TheCompact resource lock state: {0}")]
 	Query(String),
 }
 
@@ -106,6 +113,56 @@ pub async fn ensure_no_forced_withdrawal(
 	Ok(())
 }
 
+/// Just-in-time ResourceLock claimability check performed immediately before a
+/// destination fill is released.
+///
+/// This composes two origin-chain reads per non-zero input: the forced-withdrawal
+/// status must still be `Disabled`, and `balanceOf(sponsor, id)` must still cover
+/// the amount the solver expects to claim.
+pub async fn ensure_resource_locks_claimable(
+	delivery: &Arc<DeliveryService>,
+	the_compact_address: &Address,
+	origin_chain_id: u64,
+	sponsor: AlloyAddress,
+	inputs: &[[U256; 2]],
+) -> Result<(), ForcedWithdrawalError> {
+	let lock_ids: Vec<_> = inputs.iter().map(|input| input[0]).collect();
+	ensure_no_forced_withdrawal(
+		delivery,
+		the_compact_address,
+		origin_chain_id,
+		sponsor,
+		&lock_ids,
+	)
+	.await?;
+
+	for &[lock_id, required] in inputs {
+		if required.is_zero() {
+			continue;
+		}
+
+		let available = fetch_compact_balance(
+			delivery.as_ref(),
+			origin_chain_id,
+			the_compact_address.clone(),
+			sponsor,
+			lock_id,
+		)
+		.await
+		.map_err(ForcedWithdrawalError::Query)?;
+
+		if available < required {
+			return Err(ForcedWithdrawalError::InsufficientBalance {
+				lock_id,
+				required,
+				available,
+			});
+		}
+	}
+
+	Ok(())
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -139,6 +196,10 @@ mod tests {
 		alloy_primitives::Bytes::from(out)
 	}
 
+	fn encode_u256(value: U256) -> alloy_primitives::Bytes {
+		alloy_primitives::Bytes::from(value.to_be_bytes::<32>().to_vec())
+	}
+
 	/// Delivery mock: `getForcedWithdrawalStatus(account, id)` resolves its return
 	/// tuple via `status_for(id)`.
 	fn delivery(
@@ -154,6 +215,37 @@ mod tests {
 					id_bytes.copy_from_slice(&tx.data[36..68]);
 					let (status, at) = status_for(U256::from_be_bytes(id_bytes));
 					encode_status(status, at)
+				},
+				_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
+			};
+			Box::pin(async move { Ok(resp) })
+		});
+		let mut impls: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		impls.insert(CHAIN, Arc::new(mock) as Arc<dyn DeliveryInterface>);
+		Arc::new(DeliveryService::new(impls, 1, 30, 60))
+	}
+
+	/// Delivery mock for the full pre-fill ResourceLock guard:
+	/// `getForcedWithdrawalStatus(account, id)` resolves via `status_for(id)`, and
+	/// `balanceOf(account, id)` resolves via `balance_for(id)`.
+	fn delivery_with_balances(
+		status_for: impl Fn(U256) -> (u8, u64) + Send + Sync + 'static,
+		balance_for: impl Fn(U256) -> U256 + Send + Sync + 'static,
+	) -> Arc<DeliveryService> {
+		let mut mock = MockDeliveryInterface::new();
+		mock.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let resp = match selector {
+				Some(s) if s == ITheCompact::getForcedWithdrawalStatusCall::SELECTOR => {
+					let mut id_bytes = [0u8; 32];
+					id_bytes.copy_from_slice(&tx.data[36..68]);
+					let (status, at) = status_for(U256::from_be_bytes(id_bytes));
+					encode_status(status, at)
+				},
+				Some(s) if s == ITheCompact::balanceOfCall::SELECTOR => {
+					let mut id_bytes = [0u8; 32];
+					id_bytes.copy_from_slice(&tx.data[36..68]);
+					encode_u256(balance_for(U256::from_be_bytes(id_bytes)))
 				},
 				_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
 			};
@@ -214,5 +306,37 @@ mod tests {
 				.await
 				.expect_err("a single active lock in the batch must reject the fill");
 		assert!(matches!(err, ForcedWithdrawalError::Active { .. }));
+	}
+
+	#[tokio::test]
+	async fn insufficient_compact_balance_rejected_before_fill() {
+		let d = delivery_with_balances(|_| (0u8, 0), |_| U256::from(999u64));
+		let err = ensure_resource_locks_claimable(
+			&d,
+			&the_compact(),
+			CHAIN,
+			sponsor(),
+			&[[id_from(1), U256::from(1000u64)]],
+		)
+		.await
+		.expect_err("insufficient JIT balance must reject the fill");
+		assert!(matches!(
+			err,
+			ForcedWithdrawalError::InsufficientBalance { .. }
+		));
+	}
+
+	#[tokio::test]
+	async fn disabled_forced_withdrawal_and_sufficient_balance_passes() {
+		let d = delivery_with_balances(|_| (0u8, 0), |_| U256::from(1000u64));
+		ensure_resource_locks_claimable(
+			&d,
+			&the_compact(),
+			CHAIN,
+			sponsor(),
+			&[[id_from(1), U256::from(1000u64)]],
+		)
+		.await
+		.expect("disabled forced withdrawal plus sufficient balance should pass");
 	}
 }

--- a/crates/solver-core/src/handlers/forced_withdrawal.rs
+++ b/crates/solver-core/src/handlers/forced_withdrawal.rs
@@ -1,0 +1,218 @@
+//! Just-in-time forced-withdrawal guard for TheCompact ResourceLock orders (C-03).
+//!
+//! Intake-time validation (`solver-service`) already pins a trusted allocator and
+//! requires each input lock's `resetPeriod` to outlast the fill-to-claim window
+//! (PR #381). That floor only defends against a forced withdrawal *initiated after*
+//! the order is signed: the reset period has to elapse before the funds can be
+//! pulled. It does NOT defend against a sponsor who calls `enableForcedWithdrawal`
+//! and lets the reset period elapse *before* submitting the order — by the time the
+//! solver fills, the lock can already be force-withdrawn on demand, stranding the
+//! solver's destination outlay.
+//!
+//! This module closes that gap by querying `TheCompact.getForcedWithdrawalStatus`
+//! for each input lock as close as possible before the destination fill is
+//! released. If any lock reports a status other than `Disabled` (i.e. `Pending` or
+//! `Enabled`), the fill is aborted: a pending/enabled forced withdrawal means the
+//! sponsor can (or soon can) pull the input out from under the claim.
+//!
+//! Residual TOCTOU: the check is an `eth_call` against the origin chain performed
+//! immediately before submitting the destination fill, so a sponsor could still
+//! `enableForcedWithdrawal` in the narrow window between this call and on-chain
+//! fill inclusion. The intake reset-period floor is what bounds that residual
+//! window — a freshly-enabled withdrawal cannot complete until its reset period
+//! elapses, which by construction exceeds the fill-to-claim window. This check
+//! eliminates the *already-elapsed* case the floor cannot see.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address as AlloyAddress, U256};
+use alloy_sol_types::SolCall;
+use solver_delivery::DeliveryService;
+use solver_types::{standards::eip7683::interfaces::ITheCompact, Address, Transaction};
+
+/// `ForcedWithdrawalStatus` enum value meaning no forced withdrawal is pending or
+/// enabled. Any other value (`Pending` = 1, `Enabled` = 2) means the sponsor can
+/// pull the locked input before the solver claims, so the fill must be aborted.
+const FORCED_WITHDRAWAL_DISABLED: u8 = 0;
+
+/// Error raised when the just-in-time forced-withdrawal guard refuses to release a
+/// fill. Treated by the caller as a fatal, non-retryable reason to skip the order.
+#[derive(Debug, thiserror::Error)]
+pub enum ForcedWithdrawalError {
+	/// A lock reports a non-`Disabled` forced-withdrawal status.
+	#[error("ResourceLock input {lock_id} has forced withdrawal active (status {status}); refusing to fill")]
+	Active { lock_id: U256, status: u8 },
+	/// The on-chain query or its decoding failed; fail closed rather than fill blind.
+	#[error("Failed to query TheCompact.getForcedWithdrawalStatus: {0}")]
+	Query(String),
+}
+
+/// Build a `view`-style transaction for an `eth_call`.
+fn view_tx(to: &Address, chain_id: u64, data: Vec<u8>) -> Transaction {
+	Transaction {
+		to: Some(to.clone()),
+		data,
+		value: U256::ZERO,
+		chain_id,
+		nonce: None,
+		gas_limit: None,
+		gas_price: None,
+		max_fee_per_gas: None,
+		max_priority_fee_per_gas: None,
+	}
+}
+
+/// Just-in-time check that no input resource lock has a pending or enabled forced
+/// withdrawal, performed immediately before the destination fill is released.
+///
+/// - `sponsor` is the account whose locks back the order inputs (the StandardOrder
+///   `user`); it is the `account` argument to `getForcedWithdrawalStatus`.
+/// - `lock_ids` are the ERC-6909 lock identifiers (`inputs[i][0]`).
+/// - `the_compact_address` / `origin_chain_id` locate TheCompact on the origin chain.
+///
+/// Returns `Err` (aborting the fill) if any lock reports a non-`Disabled` status, or
+/// if the query/decoding fails (fail closed — never fill on an un-verifiable lock).
+pub async fn ensure_no_forced_withdrawal(
+	delivery: &Arc<DeliveryService>,
+	the_compact_address: &Address,
+	origin_chain_id: u64,
+	sponsor: AlloyAddress,
+	lock_ids: &[U256],
+) -> Result<(), ForcedWithdrawalError> {
+	for &lock_id in lock_ids {
+		let call = ITheCompact::getForcedWithdrawalStatusCall {
+			account: sponsor,
+			id: lock_id,
+		};
+		let tx = view_tx(the_compact_address, origin_chain_id, call.abi_encode());
+
+		let result = delivery
+			.contract_call(origin_chain_id, tx)
+			.await
+			.map_err(|e| ForcedWithdrawalError::Query(e.to_string()))?;
+
+		let decoded =
+			ITheCompact::getForcedWithdrawalStatusCall::abi_decode_returns_validate(&result)
+				.map_err(|e| ForcedWithdrawalError::Query(e.to_string()))?;
+
+		if decoded.status != FORCED_WITHDRAWAL_DISABLED {
+			return Err(ForcedWithdrawalError::Active {
+				lock_id,
+				status: decoded.status,
+			});
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use solver_delivery::{DeliveryInterface, MockDeliveryInterface};
+	use std::collections::HashMap;
+
+	const CHAIN: u64 = 1;
+
+	fn the_compact() -> Address {
+		Address(vec![0x88u8; 20])
+	}
+
+	fn sponsor() -> AlloyAddress {
+		AlloyAddress::from([0x22u8; 20])
+	}
+
+	fn id_from(byte: u8) -> U256 {
+		let mut b = [0u8; 32];
+		b[0] = byte;
+		b[31] = byte;
+		U256::from_be_bytes(b)
+	}
+
+	/// ABI-encode the `getForcedWithdrawalStatus` return tuple
+	/// `(uint8 status, uint256 forcedWithdrawalAvailableAt)`: status is the last
+	/// byte of word 0; the second word carries the timestamp.
+	fn encode_status(status: u8, available_at: u64) -> alloy_primitives::Bytes {
+		let mut out = vec![0u8; 64];
+		out[31] = status;
+		out[56..64].copy_from_slice(&available_at.to_be_bytes());
+		alloy_primitives::Bytes::from(out)
+	}
+
+	/// Delivery mock: `getForcedWithdrawalStatus(account, id)` resolves its return
+	/// tuple via `status_for(id)`.
+	fn delivery(
+		status_for: impl Fn(U256) -> (u8, u64) + Send + Sync + 'static,
+	) -> Arc<DeliveryService> {
+		let mut mock = MockDeliveryInterface::new();
+		mock.expect_eth_call().returning(move |tx| {
+			let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+			let resp = match selector {
+				Some(s) if s == ITheCompact::getForcedWithdrawalStatusCall::SELECTOR => {
+					// account occupies word 0 (bytes 4..36); id occupies word 1 (36..68).
+					let mut id_bytes = [0u8; 32];
+					id_bytes.copy_from_slice(&tx.data[36..68]);
+					let (status, at) = status_for(U256::from_be_bytes(id_bytes));
+					encode_status(status, at)
+				},
+				_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
+			};
+			Box::pin(async move { Ok(resp) })
+		});
+		let mut impls: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		impls.insert(CHAIN, Arc::new(mock) as Arc<dyn DeliveryInterface>);
+		Arc::new(DeliveryService::new(impls, 1, 30, 60))
+	}
+
+	#[tokio::test]
+	async fn forced_withdrawal_enabled_lock_rejected_before_fill() {
+		// A lock whose forced withdrawal is Enabled (status 2) must abort the fill.
+		let d = delivery(|_| (2u8, 0));
+		let err = ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id_from(1)])
+			.await
+			.expect_err("Enabled forced withdrawal must reject the fill");
+		assert!(matches!(
+			err,
+			ForcedWithdrawalError::Active { status: 2, .. }
+		));
+	}
+
+	#[tokio::test]
+	async fn forced_withdrawal_pending_lock_rejected_before_fill() {
+		// A lock whose forced withdrawal is Pending (status 1) must abort the fill.
+		let d = delivery(|_| (1u8, 9_999_999_999));
+		let err = ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id_from(1)])
+			.await
+			.expect_err("Pending forced withdrawal must reject the fill");
+		assert!(matches!(
+			err,
+			ForcedWithdrawalError::Active { status: 1, .. }
+		));
+	}
+
+	#[tokio::test]
+	async fn disabled_forced_withdrawal_passes() {
+		let d = delivery(|_| (0u8, 0));
+		ensure_no_forced_withdrawal(
+			&d,
+			&the_compact(),
+			CHAIN,
+			sponsor(),
+			&[id_from(1), id_from(2)],
+		)
+		.await
+		.expect("Disabled forced withdrawal on all locks should pass");
+	}
+
+	#[tokio::test]
+	async fn any_active_lock_in_batch_rejected() {
+		// First lock Disabled, second lock Enabled => reject.
+		let id1 = id_from(1);
+		let d = delivery(move |id| if id == id1 { (0u8, 0) } else { (2u8, 0) });
+		let err =
+			ensure_no_forced_withdrawal(&d, &the_compact(), CHAIN, sponsor(), &[id1, id_from(2)])
+				.await
+				.expect_err("a single active lock in the batch must reject the fill");
+		assert!(matches!(err, ForcedWithdrawalError::Active { .. }));
+	}
+}

--- a/crates/solver-core/src/handlers/mod.rs
+++ b/crates/solver-core/src/handlers/mod.rs
@@ -5,6 +5,7 @@
 //! monitoring, and settlement claiming.
 
 pub mod compact_reservation;
+pub mod forced_withdrawal;
 pub mod intent;
 pub mod order;
 pub mod settlement;

--- a/crates/solver-core/src/handlers/order.rs
+++ b/crates/solver-core/src/handlers/order.rs
@@ -4,7 +4,7 @@
 //! and fill transactions, updating order state and publishing appropriate events.
 
 use crate::engine::event_bus::EventBus;
-use crate::handlers::forced_withdrawal::ensure_no_forced_withdrawal;
+use crate::handlers::forced_withdrawal::ensure_resource_locks_claimable;
 use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
@@ -257,6 +257,11 @@ impl OrderHandler {
 	async fn check_forced_withdrawal_before_fill(&self, order: &Order) -> Result<(), OrderError> {
 		let order_data: Eip7683OrderData = match serde_json::from_value(order.data.clone()) {
 			Ok(data) => data,
+			Err(e) if order.standard == "eip7683" => {
+				return Err(OrderError::Service(format!(
+					"Failed to parse EIP-7683 order data before ResourceLock guard: {e}"
+				)));
+			},
 			// Non-7683 orders carry no resource lock; nothing to guard.
 			Err(_) => return Ok(()),
 		};
@@ -265,7 +270,8 @@ impl OrderHandler {
 			return Ok(());
 		}
 
-		let origin_chain_id = order_data.origin_chain_id.to::<u64>();
+		let origin_chain_id = u64::try_from(order_data.origin_chain_id)
+			.map_err(|_| OrderError::Service("Invalid origin chain ID".to_string()))?;
 
 		// Resolve TheCompact on the origin chain from current (hot-reloadable) config.
 		let the_compact_address = {
@@ -283,14 +289,13 @@ impl OrderHandler {
 
 		let sponsor = hex_to_alloy_address(&order_data.user)
 			.map_err(|e| OrderError::Service(format!("Invalid sponsor address: {e}")))?;
-		let lock_ids: Vec<_> = order_data.inputs.iter().map(|input| input[0]).collect();
 
-		ensure_no_forced_withdrawal(
+		ensure_resource_locks_claimable(
 			&self.delivery,
 			&the_compact_address,
 			origin_chain_id,
 			sponsor,
-			&lock_ids,
+			&order_data.inputs,
 		)
 		.await
 		.map_err(|e| OrderError::Service(e.to_string()))
@@ -953,6 +958,39 @@ mod tests {
 			OrderError::Service(msg) => assert!(msg.contains("Fill error")),
 			_ => panic!("Expected Service error"),
 		}
+	}
+
+	#[tokio::test]
+	async fn malformed_eip7683_order_data_rejected_before_fill_generation() {
+		let order = OrderBuilder::new()
+			.with_standard("eip7683")
+			.with_data(serde_json::json!({
+				"lock_type": "resource_lock",
+				"origin_chain_id": "137"
+			}))
+			.build();
+		let params = create_test_execution_params();
+
+		let (handler, _event_rx) = create_test_handler_with_mocks(
+			|mock_order| {
+				mock_order.expect_generate_fill_transaction().times(0);
+			},
+			|mock_delivery| {
+				mock_delivery.expect_submit().times(0);
+			},
+			|_mock_storage| {},
+		)
+		.await;
+
+		let err = handler
+			.handle_execution(order, params)
+			.await
+			.expect_err("malformed EIP-7683 data must fail before fill generation");
+
+		assert!(matches!(
+			err,
+			OrderError::Service(msg) if msg.contains("Failed to parse EIP-7683 order data")
+		));
 	}
 
 	/// (C-03) A ResourceLock order whose input lock has an *enabled* forced

--- a/crates/solver-core/src/handlers/order.rs
+++ b/crates/solver-core/src/handlers/order.rs
@@ -4,9 +4,11 @@
 //! and fill transactions, updating order state and publishing appropriate events.
 
 use crate::engine::event_bus::EventBus;
+use crate::handlers::forced_withdrawal::ensure_no_forced_withdrawal;
 use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
+use solver_config::Config;
 use solver_delivery::{
 	DeliveryService, RevertClassification, TransactionAttemptRecorder, TransactionMonitoringEvent,
 	TransactionTracking,
@@ -14,11 +16,13 @@ use solver_delivery::{
 use solver_order::OrderService;
 use solver_storage::StorageService;
 use solver_types::{
-	truncate_id, DeliveryEvent, ExecutionParams, Order, OrderEvent, OrderStatus, SolverEvent,
+	standards::eip7683::LockType, truncate_id, utils::conversion::hex_to_alloy_address,
+	DeliveryEvent, Eip7683OrderData, ExecutionParams, Order, OrderEvent, OrderStatus, SolverEvent,
 	StorageKey, TransactionType,
 };
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::RwLock;
 use tracing::instrument;
 
 /// Errors that can occur during order processing.
@@ -46,6 +50,9 @@ pub struct OrderHandler {
 	storage: Arc<StorageService>,
 	state_machine: Arc<OrderStateMachine>,
 	event_bus: EventBus,
+	/// Dynamic config, read just-in-time so Admin API hot-reloads
+	/// (e.g. toggling `resource_lock_enabled`) take effect on the next fill.
+	dynamic_config: Arc<RwLock<Config>>,
 }
 
 impl OrderHandler {
@@ -55,6 +62,7 @@ impl OrderHandler {
 		storage: Arc<StorageService>,
 		state_machine: Arc<OrderStateMachine>,
 		event_bus: EventBus,
+		dynamic_config: Arc<RwLock<Config>>,
 	) -> Self {
 		Self {
 			order_service,
@@ -62,6 +70,7 @@ impl OrderHandler {
 			storage,
 			state_machine,
 			event_bus,
+			dynamic_config,
 		}
 	}
 
@@ -238,6 +247,55 @@ impl OrderHandler {
 		Ok(())
 	}
 
+	/// (C-03) Reject ResourceLock fills whose input locks have a pending or enabled
+	/// forced withdrawal on TheCompact, checked just before the fill is released.
+	///
+	/// No-op for non-ResourceLock orders. When ResourceLock support is disabled this
+	/// path should not be reached (intake gates it), but we still treat a ResourceLock
+	/// order arriving here as in-scope and fail closed if its compact address is
+	/// missing or the on-chain query fails.
+	async fn check_forced_withdrawal_before_fill(&self, order: &Order) -> Result<(), OrderError> {
+		let order_data: Eip7683OrderData = match serde_json::from_value(order.data.clone()) {
+			Ok(data) => data,
+			// Non-7683 orders carry no resource lock; nothing to guard.
+			Err(_) => return Ok(()),
+		};
+
+		if !matches!(order_data.lock_type, Some(LockType::ResourceLock)) {
+			return Ok(());
+		}
+
+		let origin_chain_id = order_data.origin_chain_id.to::<u64>();
+
+		// Resolve TheCompact on the origin chain from current (hot-reloadable) config.
+		let the_compact_address = {
+			let config = self.dynamic_config.read().await;
+			config
+				.networks
+				.get(&origin_chain_id)
+				.and_then(|n| n.the_compact_address.clone())
+				.ok_or_else(|| {
+					OrderError::Service(format!(
+						"ResourceLock fill aborted: TheCompact address not configured for origin chain {origin_chain_id}"
+					))
+				})?
+		};
+
+		let sponsor = hex_to_alloy_address(&order_data.user)
+			.map_err(|e| OrderError::Service(format!("Invalid sponsor address: {e}")))?;
+		let lock_ids: Vec<_> = order_data.inputs.iter().map(|input| input[0]).collect();
+
+		ensure_no_forced_withdrawal(
+			&self.delivery,
+			&the_compact_address,
+			origin_chain_id,
+			sponsor,
+			&lock_ids,
+		)
+		.await
+		.map_err(|e| OrderError::Service(e.to_string()))
+	}
+
 	/// Handles order execution by generating and submitting a fill transaction.
 	#[instrument(skip_all, fields(order_id = %truncate_id(&order.id)))]
 	pub async fn handle_execution(
@@ -245,6 +303,12 @@ impl OrderHandler {
 		order: Order,
 		params: ExecutionParams,
 	) -> Result<(), OrderError> {
+		// (C-03) Just-in-time forced-withdrawal guard for ResourceLock orders. This is
+		// the last solver-controlled point before the destination fill is released, so
+		// it catches a sponsor who enabled (or began) a forced withdrawal before the
+		// order was submitted — a case the intake-time reset-period floor cannot see.
+		self.check_forced_withdrawal_before_fill(&order).await?;
+
 		// Generate fill transaction
 		let tx = self
 			.order_service
@@ -431,6 +495,26 @@ mod tests {
 		F2: FnOnce(&mut MockDeliveryInterface),
 		F3: FnOnce(&mut MockStorageInterface),
 	{
+		create_test_handler_with_config(
+			setup_order,
+			setup_delivery,
+			setup_storage,
+			solver_config::ConfigBuilder::new().build(),
+		)
+		.await
+	}
+
+	async fn create_test_handler_with_config<F1, F2, F3>(
+		setup_order: F1,
+		setup_delivery: F2,
+		setup_storage: F3,
+		config: solver_config::Config,
+	) -> (OrderHandler, broadcast::Receiver<SolverEvent>)
+	where
+		F1: FnOnce(&mut MockOrderInterface),
+		F2: FnOnce(&mut MockDeliveryInterface),
+		F3: FnOnce(&mut MockStorageInterface),
+	{
 		let mut mock_order = MockOrderInterface::new();
 		let mut mock_delivery = MockDeliveryInterface::new();
 		let mut mock_storage = MockStorageInterface::new();
@@ -467,7 +551,14 @@ mod tests {
 		let event_bus = EventBus::new(100);
 		let event_rx = event_bus.subscribe();
 
-		let handler = OrderHandler::new(order_service, delivery, storage, state_machine, event_bus);
+		let handler = OrderHandler::new(
+			order_service,
+			delivery,
+			storage,
+			state_machine,
+			event_bus,
+			Arc::new(RwLock::new(config)),
+		);
 
 		(handler, event_rx)
 	}
@@ -861,6 +952,99 @@ mod tests {
 		match result.unwrap_err() {
 			OrderError::Service(msg) => assert!(msg.contains("Fill error")),
 			_ => panic!("Expected Service error"),
+		}
+	}
+
+	/// (C-03) A ResourceLock order whose input lock has an *enabled* forced
+	/// withdrawal must be rejected before the destination fill is released: the
+	/// sponsor can pull the locked input out from under the solver's claim.
+	///
+	/// The guard runs before `generate_fill_transaction`, so neither fill
+	/// generation nor delivery is exercised (`.times(0)`).
+	#[tokio::test]
+	async fn forced_withdrawal_enabled_resource_lock_rejected_before_fill() {
+		use alloy_sol_types::SolCall;
+		use solver_types::networks::{NetworkConfig, NetworkType, RpcEndpoint};
+		use solver_types::standards::eip7683::interfaces::ITheCompact;
+		use solver_types::standards::eip7683::LockType;
+		use solver_types::Address;
+
+		const ORIGIN_CHAIN: u64 = 137;
+		let the_compact = Address(vec![0x88u8; 20]);
+
+		// ResourceLock order with a single input lock; sponsor is `user`.
+		let lock_id = U256::from(0xABCDu64);
+		let order_data = serde_json::json!({
+			"user": "0x2222222222222222222222222222222222222222",
+			"nonce": "1",
+			"origin_chain_id": ORIGIN_CHAIN.to_string(),
+			"expires": 1_700_000_600u32,
+			"fill_deadline": 1_700_000_000u32,
+			"input_oracle": "0x3333333333333333333333333333333333333333",
+			"inputs": [[lock_id.to_string(), "1000"]],
+			"order_id": vec![0u8; 32],
+			"gas_limit_overrides": {},
+			"outputs": [],
+			"lock_type": LockType::ResourceLock,
+		});
+		let order = OrderBuilder::new().with_data(order_data).build();
+
+		// Config: origin chain network advertises TheCompact.
+		let network = NetworkConfig {
+			name: None,
+			network_type: NetworkType::default(),
+			rpc_urls: vec![RpcEndpoint::http_only("http://localhost:8545".to_string())],
+			input_settler_address: Address(vec![0x11u8; 20]),
+			output_settler_address: Address(vec![0x22u8; 20]),
+			tokens: vec![],
+			input_settler_compact_address: Some(Address(vec![0x44u8; 20])),
+			the_compact_address: Some(the_compact),
+			allocator_address: Some(Address(vec![0xA1u8; 20])),
+		};
+		let config = solver_config::ConfigBuilder::new()
+			.networks(HashMap::from([(ORIGIN_CHAIN, network)]))
+			.build();
+
+		let params = create_test_execution_params();
+
+		let (handler, _event_rx) = create_test_handler_with_config(
+			|mock_order| {
+				// Fill generation must NOT run — the guard aborts first.
+				mock_order.expect_generate_fill_transaction().times(0);
+			},
+			|mock_delivery| {
+				// `getForcedWithdrawalStatus` reports Enabled (status 2).
+				mock_delivery.expect_eth_call().returning(|tx| {
+					let selector = tx.data.get(0..4).map(|s| [s[0], s[1], s[2], s[3]]);
+					let resp = match selector {
+						Some(s) if s == ITheCompact::getForcedWithdrawalStatusCall::SELECTOR => {
+							let mut out = vec![0u8; 64];
+							out[31] = 2; // ForcedWithdrawalStatus::Enabled
+							alloy_primitives::Bytes::from(out)
+						},
+						_ => alloy_primitives::Bytes::from(vec![0u8; 64]),
+					};
+					Box::pin(async move { Ok(resp) })
+				});
+				// No fill is submitted.
+				mock_delivery.expect_submit().times(0);
+			},
+			|_mock_storage| {},
+			config,
+		)
+		.await;
+
+		let result = handler.handle_execution(order, params).await;
+
+		let err = result.expect_err("enabled forced withdrawal must abort the fill");
+		match err {
+			OrderError::Service(msg) => {
+				assert!(
+					msg.contains("forced withdrawal"),
+					"unexpected error message: {msg}"
+				);
+			},
+			other => panic!("expected Service error, got {other:?}"),
 		}
 	}
 

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -811,7 +811,7 @@ async fn validate_intent_request(
 		let config = state.config.read().await;
 		state
 			.signature_validation
-			.validate_signature(standard, intent, &config.networks, state.solver.delivery())
+			.validate_signature(standard, intent, &config, state.solver.delivery())
 			.await?;
 	}
 

--- a/crates/solver-service/src/validators/compact_allocator.rs
+++ b/crates/solver-service/src/validators/compact_allocator.rs
@@ -163,8 +163,8 @@ pub async fn validate_allocator_authorization(
 		})?;
 		if reset_secs <= required_reset_secs {
 			return Err(validation_error(format!(
-					"ResourceLock input reset period ({reset_secs}s) does not exceed the {required_reset_label} ({required_reset_secs}s)"
-				)));
+				"ResourceLock input reset period ({reset_secs}s) does not exceed the {required_reset_label} ({required_reset_secs}s)"
+			)));
 		}
 
 		match resolved {

--- a/crates/solver-service/src/validators/compact_allocator.rs
+++ b/crates/solver-service/src/validators/compact_allocator.rs
@@ -94,6 +94,9 @@ async fn resolve_allocator(
 ///   `TheCompact.batchClaim` during finalisation).
 /// - `configured_allocator`, when present (`network.allocator_address`), pins the
 ///   allocator the solver expects; a mismatch is rejected.
+/// - `route_required_reset_secs` is the route-level minimum settlement window
+///   needed after fill. It closes the gap where a signed order sets a far-future
+///   fill deadline but a narrow `expires - fillDeadline` interval.
 #[allow(clippy::too_many_arguments)]
 pub async fn validate_allocator_authorization(
 	order: &OifStandardOrder,
@@ -104,6 +107,7 @@ pub async fn validate_allocator_authorization(
 	configured_allocator: Option<&Address>,
 	delivery: &Arc<DeliveryService>,
 	chain_id: u64,
+	route_required_reset_secs: u64,
 ) -> Result<(), APIError> {
 	if order.inputs.is_empty() {
 		return Err(validation_error(
@@ -111,17 +115,25 @@ pub async fn validate_allocator_authorization(
 		));
 	}
 
-	// (C-02) The lock's reset period must outlast the window between filling the
-	// destination output and claiming the input; otherwise the user could force-
-	// withdraw the input after the solver has filled. Use the signed order's own
-	// fill-to-claim window: `expires - fillDeadline`.
-	let required_reset_secs =
+	// (C-02/C-03) The lock's reset period must outlast the window between filling
+	// the destination output and claiming the input; otherwise the user could
+	// force-withdraw after the solver has filled. Use the stricter of the signed
+	// order's `expires - fillDeadline` window and the route-level settlement
+	// window. The latter prevents an order from using a far-future fill deadline
+	// with a narrow signed interval to understate actual fill-to-claim latency.
+	let signed_fill_to_claim_secs =
 		u64::from(order.expires).saturating_sub(u64::from(order.fillDeadline));
-	if required_reset_secs == 0 {
+	if signed_fill_to_claim_secs == 0 {
 		return Err(validation_error(
 			"ResourceLock order is malformed: expires must exceed fillDeadline",
 		));
 	}
+	let required_reset_secs = signed_fill_to_claim_secs.max(route_required_reset_secs);
+	let required_reset_label = if route_required_reset_secs > signed_fill_to_claim_secs {
+		"route settlement window"
+	} else {
+		"fill-to-claim window"
+	};
 
 	// (C-02) ResourceLock orders require a solver-trusted allocator. Allocator
 	// registration in The Compact is permissionless, so without pinning, a user
@@ -151,8 +163,8 @@ pub async fn validate_allocator_authorization(
 		})?;
 		if reset_secs <= required_reset_secs {
 			return Err(validation_error(format!(
-				"ResourceLock input reset period ({reset_secs}s) does not exceed the fill-to-claim window ({required_reset_secs}s)"
-			)));
+					"ResourceLock input reset period ({reset_secs}s) does not exceed the {required_reset_label} ({required_reset_secs}s)"
+				)));
 		}
 
 		match resolved {
@@ -334,6 +346,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect("trusted allocator + authorized + sufficient reset period should pass");
@@ -352,6 +365,7 @@ mod tests {
 			None,
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("ResourceLock order without a configured trusted allocator must be rejected");
@@ -374,6 +388,7 @@ mod tests {
 			Some(&configured),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("allocator not matching configured allocator must be rejected");
@@ -395,6 +410,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("unauthorized allocator data must be rejected");
@@ -423,6 +439,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("mixed allocators must be rejected");
@@ -444,6 +461,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("order with no inputs must be rejected");
@@ -465,6 +483,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("reset period below the fill-to-claim window must be rejected");
@@ -488,11 +507,34 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("reset period equal to the window must be rejected (does not exceed)");
 		assert!(
 			matches!(err, APIError::BadRequest { message, .. } if message.contains("reset period"))
+		);
+	}
+
+	#[tokio::test]
+	async fn reset_period_below_route_window_rejected() {
+		let order = order_with_inputs(&[id_from(1)]);
+		let d = delivery(|_| allocator(0xA1), RESET_TEN_MINUTES, true);
+		let err = validate_allocator_authorization(
+			&order,
+			&Bytes::new(),
+			claim_hash(),
+			arbiter(),
+			&the_compact(),
+			Some(&trusted()),
+			&d,
+			CHAIN,
+			3_600,
+		)
+		.await
+		.expect_err("reset period below the route settlement window must be rejected");
+		assert!(
+			matches!(err, APIError::BadRequest { message, .. } if message.contains("route settlement window"))
 		);
 	}
 
@@ -510,6 +552,7 @@ mod tests {
 			Some(&trusted()),
 			&d,
 			CHAIN,
+			0,
 		)
 		.await
 		.expect_err("order whose expires does not exceed fillDeadline must be rejected");

--- a/crates/solver-service/src/validators/signature.rs
+++ b/crates/solver-service/src/validators/signature.rs
@@ -8,14 +8,16 @@ use crate::eip712::{
 };
 use alloy_primitives::{Address as AlloyAddress, Bytes};
 use async_trait::async_trait;
+use solver_config::Config;
 use solver_delivery::DeliveryService;
+use solver_settlement::{estimate_required_expiry_window_for_route, RouteExpiryInputs};
 use solver_types::{
 	api::PostOrderRequest,
 	standards::eip7683::{
 		compact_signatures::decode_compact_signatures,
 		interfaces::StandardOrder as OifStandardOrder, LockType,
 	},
-	APIError, ApiErrorType, NetworksConfig,
+	APIError, ApiErrorType,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -30,7 +32,7 @@ pub trait OrderSignatureValidator: Send + Sync {
 	async fn validate_signature(
 		&self,
 		intent: &PostOrderRequest,
-		networks_config: &NetworksConfig,
+		config: &Config,
 		delivery_service: &Arc<DeliveryService>,
 	) -> Result<(), APIError>;
 }
@@ -48,7 +50,7 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 	async fn validate_signature(
 		&self,
 		intent: &PostOrderRequest,
-		networks_config: &NetworksConfig,
+		config: &Config,
 		delivery_service: &Arc<DeliveryService>,
 	) -> Result<(), APIError> {
 		use alloy_sol_types::SolType;
@@ -66,7 +68,8 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 
 		let origin_chain_id = standard_order.originChainId.to::<u64>();
 		let network =
-			networks_config
+			config
+				.networks
 				.get(&origin_chain_id)
 				.ok_or_else(|| APIError::BadRequest {
 					error_type: ApiErrorType::OrderValidationFailed,
@@ -133,6 +136,33 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 		// 5. Validate allocator authorization for the decoded allocatorData (pC-02).
 		//    `struct_hash` is the BatchCompact claim hash the allocator authorizes;
 		//    `contract_address` is the InputSettlerCompact (the finalise arbiter).
+		let route_inputs = RouteExpiryInputs {
+			input_oracle: solver_types::Address(standard_order.inputOracle.as_slice().to_vec()),
+			origin_chain_id,
+			output_chain_ids: standard_order
+				.outputs
+				.iter()
+				.map(|output| output.chainId.to::<u64>())
+				.collect(),
+		};
+		let route_required_reset_secs = match estimate_required_expiry_window_for_route(
+			&route_inputs,
+			&config.settlement.implementations,
+			config.settlement.settlement_poll_interval_seconds,
+			None,
+		) {
+			Some((window, _breakdown)) => window,
+			None => {
+				tracing::warn!(
+					origin_chain_id,
+					input_oracle = ?route_inputs.input_oracle,
+					output_chain_ids = ?route_inputs.output_chain_ids,
+					"No settlement expiry estimate matched ResourceLock route; route reset-period floor is disabled. Configure intent_min_expiry_seconds for this settlement route to enforce the floor"
+				);
+				0
+			},
+		};
+
 		crate::validators::compact_allocator::validate_allocator_authorization(
 			&standard_order,
 			&decoded.allocator_data,
@@ -142,6 +172,7 @@ impl OrderSignatureValidator for Eip7683SignatureValidator {
 			network.allocator_address.as_ref(),
 			delivery_service,
 			origin_chain_id,
+			route_required_reset_secs,
 		)
 		.await?;
 		tracing::debug!("Compact allocator authorization validated");
@@ -171,7 +202,7 @@ impl SignatureValidationService {
 		&self,
 		standard: &str,
 		intent: &PostOrderRequest,
-		networks_config: &NetworksConfig,
+		config: &Config,
 		delivery_service: &Arc<DeliveryService>,
 	) -> Result<(), APIError> {
 		let validator = self
@@ -184,7 +215,7 @@ impl SignatureValidationService {
 			})?;
 
 		validator
-			.validate_signature(intent, networks_config, delivery_service)
+			.validate_signature(intent, config, delivery_service)
 			.await
 	}
 
@@ -211,6 +242,7 @@ mod tests {
 	use alloy_sol_types::SolType;
 	use secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
 	use serde_json::json;
+	use solver_config::ConfigBuilder;
 	use solver_delivery::{
 		DeliveryError, DeliveryInterface, DeliveryService, MockDeliveryInterface,
 	};
@@ -226,7 +258,7 @@ mod tests {
 	#[derive(Clone)]
 	struct SignatureFixture {
 		intent: PostOrderRequest,
-		networks: NetworksConfig,
+		config: Config,
 		delivery: Arc<DeliveryService>,
 		chain_id: u64,
 	}
@@ -500,10 +532,11 @@ mod tests {
 		networks.insert(chain_id, network_config);
 
 		let delivery = compact_delivery(chain_id, domain_separator, lock_allocator(), true);
+		let config = ConfigBuilder::new().networks(networks).build();
 
 		SignatureFixture {
 			intent,
-			networks,
+			config,
 			delivery,
 			chain_id,
 		}
@@ -525,7 +558,7 @@ mod tests {
 			.validate_signature(
 				"eip7683",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&fixture.delivery,
 			)
 			.await
@@ -546,7 +579,7 @@ mod tests {
 			.validate_signature(
 				"eip7683",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&fixture.delivery,
 			)
 			.await;
@@ -577,7 +610,7 @@ mod tests {
 
 		let service = SignatureValidationService::new();
 		let result = service
-			.validate_signature("eip7683", &fixture.intent, &fixture.networks, &delivery)
+			.validate_signature("eip7683", &fixture.intent, &fixture.config, &delivery)
 			.await;
 
 		assert!(matches!(
@@ -590,6 +623,7 @@ mod tests {
 	async fn validate_signature_rejects_missing_input_settler_compact_address() {
 		let mut fixture = build_signature_fixture();
 		fixture
+			.config
 			.networks
 			.get_mut(&fixture.chain_id)
 			.expect("network")
@@ -600,7 +634,7 @@ mod tests {
 			.validate_signature(
 				"eip7683",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&fixture.delivery,
 			)
 			.await;
@@ -619,7 +653,7 @@ mod tests {
 			.validate_signature(
 				"unknown",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&fixture.delivery,
 			)
 			.await;
@@ -634,13 +668,9 @@ mod tests {
 		let fixture = build_signature_fixture();
 		let service = SignatureValidationService::new();
 		let empty_networks = NetworksConfig::new();
+		let empty_config = ConfigBuilder::new().networks(empty_networks).build();
 		let result = service
-			.validate_signature(
-				"eip7683",
-				&fixture.intent,
-				&empty_networks,
-				&fixture.delivery,
-			)
+			.validate_signature("eip7683", &fixture.intent, &empty_config, &fixture.delivery)
 			.await;
 		assert!(matches!(
 			result,
@@ -651,13 +681,13 @@ mod tests {
 	#[tokio::test]
 	async fn validate_signature_errors_when_compact_address_missing() {
 		let fixture = build_signature_fixture();
-		let mut networks = fixture.networks.clone();
-		if let Some(network) = networks.get_mut(&fixture.chain_id) {
+		let mut config = fixture.config.clone();
+		if let Some(network) = config.networks.get_mut(&fixture.chain_id) {
 			network.the_compact_address = None;
 		}
 		let service = SignatureValidationService::new();
 		let result = service
-			.validate_signature("eip7683", &fixture.intent, &networks, &fixture.delivery)
+			.validate_signature("eip7683", &fixture.intent, &config, &fixture.delivery)
 			.await;
 		assert!(matches!(
 			result,
@@ -678,7 +708,7 @@ mod tests {
 			.validate_signature(
 				"eip7683",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&failing_delivery,
 			)
 			.await;
@@ -697,7 +727,7 @@ mod tests {
 			.validate_signature(
 				"eip7683",
 				&fixture.intent,
-				&fixture.networks,
+				&fixture.config,
 				&fixture.delivery,
 			)
 			.await;

--- a/crates/solver-types/src/standards/eip7683.rs
+++ b/crates/solver-types/src/standards/eip7683.rs
@@ -380,16 +380,16 @@ pub mod interfaces {
 		/// TheCompact contract interface for domain separator fetching and lock
 		/// detail resolution (used to resolve the allocator controlling a lock).
 		#[sol(rpc)]
-			interface ITheCompact {
-				function DOMAIN_SEPARATOR() external view returns (bytes32);
-				function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
-				function balanceOf(address owner, uint256 id) external view returns (uint256);
-				/// Forced-withdrawal status of a resource lock for a given account.
-				/// `status` is the `ForcedWithdrawalStatus` enum (Disabled=0, Pending=1,
-				/// Enabled=2); `forcedWithdrawalAvailableAt` is when tokens become
-				/// withdrawable while `Pending` (or became withdrawable while `Enabled`).
-				function getForcedWithdrawalStatus(address account, uint256 id) external view returns (uint8 status, uint256 forcedWithdrawalAvailableAt);
-			}
+		interface ITheCompact {
+			function DOMAIN_SEPARATOR() external view returns (bytes32);
+			function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
+			function balanceOf(address owner, uint256 id) external view returns (uint256);
+			/// Forced-withdrawal status of a resource lock for a given account.
+			/// `status` is the `ForcedWithdrawalStatus` enum (Disabled=0, Pending=1,
+			/// Enabled=2); `forcedWithdrawalAvailableAt` is when tokens become
+			/// withdrawable while `Pending` (or became withdrawable while `Enabled`).
+			function getForcedWithdrawalStatus(address account, uint256 id) external view returns (uint8 status, uint256 forcedWithdrawalAvailableAt);
+		}
 
 		/// IAllocator interface exposing the off-chain claim authorization predicate.
 		/// `isClaimAuthorized` returns whether the allocator authorizes the given

--- a/crates/solver-types/src/standards/eip7683.rs
+++ b/crates/solver-types/src/standards/eip7683.rs
@@ -380,11 +380,16 @@ pub mod interfaces {
 		/// TheCompact contract interface for domain separator fetching and lock
 		/// detail resolution (used to resolve the allocator controlling a lock).
 		#[sol(rpc)]
-		interface ITheCompact {
-			function DOMAIN_SEPARATOR() external view returns (bytes32);
-			function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
-			function balanceOf(address owner, uint256 id) external view returns (uint256);
-		}
+			interface ITheCompact {
+				function DOMAIN_SEPARATOR() external view returns (bytes32);
+				function getLockDetails(uint256 id) external view returns (address token, address allocator, uint8 resetPeriod, uint8 scope, bytes12 lockTag);
+				function balanceOf(address owner, uint256 id) external view returns (uint256);
+				/// Forced-withdrawal status of a resource lock for a given account.
+				/// `status` is the `ForcedWithdrawalStatus` enum (Disabled=0, Pending=1,
+				/// Enabled=2); `forcedWithdrawalAvailableAt` is when tokens become
+				/// withdrawable while `Pending` (or became withdrawable while `Enabled`).
+				function getForcedWithdrawalStatus(address account, uint256 id) external view returns (uint8 status, uint256 forcedWithdrawalAvailableAt);
+			}
 
 		/// IAllocator interface exposing the off-chain claim authorization predicate.
 		/// `isClaimAuthorized` returns whether the allocator authorizes the given


### PR DESCRIPTION
## Audit finding C-03 (Critical) — Solver can lose principal on resource-lock orders without forced-withdrawal checks

Supersedes #386 — includes its commit (cherry-picked onto current `main`, original authorship preserved) plus hardening follow-ups that close the review gaps found in it. #386 itself is conflicting with `main` and can be closed in favor of this PR.

### The finding

Compact resource-lock orders settle fill-first / claim-later: the solver pays the destination output, then claims the sponsor's locked inputs via `finalise → batchClaim`. Those inputs are never escrowed — TheCompact gives every sponsor a unilateral, allocator-free escape hatch (forced withdrawal) gated only by the lock's reset period. A sponsor who calls `enableForcedWithdrawal` and lets the reset period elapse **before** submitting the order can pull the inputs after the solver fills, stranding the solver's outlay. The intake reset-period floor (PR #381) cannot see this case.

### Changes

**From #386 (cherry-picked):**
- `solver-types` — `getForcedWithdrawalStatus(address, uint256)` added to the `ITheCompact` binding (enum `Disabled=0, Pending=1, Enabled=2`).
- `solver-core` — `handlers/forced_withdrawal.rs`: just-in-time guard called in `handle_execution` immediately before `generate_fill_transaction` (the last solver-controlled point before the fill is released). Rejects any input lock whose status != `Disabled`; fails closed on query/decode error. Recovery's `NeedsFill` path re-enters via `OrderEvent::Executing`, so it is covered too.

**Hardening follow-ups (new):**
- **Route-level reset-period floor.** Intake now requires each lock's reset period to exceed the *stricter* of the signed `expires − fillDeadline` window and the route settlement window from `estimate_required_expiry_window_for_route` (#384's estimator). This closes the gap where a sponsor signs a far-future `fillDeadline` with a narrow `expires − fillDeadline` interval to understate the real fill-to-claim latency. When no estimate matches the route, a `tracing::warn!` flags that the route floor is disabled — operators should set `intent_min_expiry_seconds` on the settlement implementation for the floor to apply.
- **JIT balance re-check.** The pre-fill guard now also verifies `balanceOf(sponsor, id)` still covers each input amount (reuses `fetch_compact_balance`), closing the time-of-check/time-of-finalize gap on solvency — forced withdrawal is not the only way a lock can drain.
- **Fail-closed parse.** Malformed `eip7683` order data now aborts before fill generation instead of skipping the guard; `origin_chain_id` conversion no longer panics on overflow.

### Testing

- RED-first unit tests: forced-withdrawal `Enabled`/`Pending` rejected, `Disabled` passes, any-active-in-batch rejected, insufficient JIT balance rejected, malformed order data rejected before fill generation (with `generate_fill_transaction`/`submit` asserted `.times(0)`), reset period below route window rejected.
- `cargo test -p solver-core` / `-p solver-service` / `-p solver-types` pass; `cargo check --all-targets --all-features`, `cargo check --all-targets` (default features), `cargo check -p solver-e2e-tests --all-targets`, `clippy -D warnings`, `fmt --check` all clean.

### Residual (documented in module header)

A sponsor can still `enableForcedWithdrawal` in the narrow gap between the JIT check and on-chain fill inclusion. That residual is bounded by the reset-period floor: a freshly-enabled withdrawal cannot complete until its reset period elapses, which now must exceed both the signed window and the route settlement window. Making fill-and-status atomic is not possible off-chain; a pre-fill on-chain commitment (finding recommendation 3) would require protocol-level changes and is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forced withdrawal validation to block solver fills when active forced withdrawals are present on resource locks.
  * Introduced route-level settlement window validation for allocator authorization.

* **Tests**
  * Expanded test coverage for forced withdrawal detection and related order validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->