### PR TITLE
Bind quote costs to submitted orders

### DIFF
--- a/crates/solver-core/src/bump/service.rs
+++ b/crates/solver-core/src/bump/service.rs
@@ -1408,6 +1408,7 @@ mod tests {
 				adjusted_amounts: std::collections::HashMap::new(),
 			},
 			settlement_name: None,
+			binding: None,
 		};
 		storage
 			.store(StorageKey::Quotes.as_str(), quote_id, &stored, None)

--- a/crates/solver-core/src/engine/cost_profit.rs
+++ b/crates/solver-core/src/engine/cost_profit.rs
@@ -330,6 +330,21 @@ impl CostProfitService {
 		}
 	}
 
+	/// Retrieves the full stored quote record (cost context + economic binding) by
+	/// quote ID.
+	///
+	/// Used by the profitability gate to verify the submitted order against the
+	/// quote's economic binding (H-07) before honoring the stored cost context.
+	pub async fn get_stored_quote_by_quote_id(
+		&self,
+		quote_id: &str,
+	) -> Result<solver_types::StoredQuote, CostProfitError> {
+		self.storage_service
+			.retrieve::<solver_types::StoredQuote>(StorageKey::Quotes.as_str(), quote_id)
+			.await
+			.map_err(CostProfitError::Storage)
+	}
+
 	/// Calculate base swap amounts using pricing service exchange rates.
 	///
 	/// This method determines the required token amounts for a swap based on the swap type:
@@ -1413,28 +1428,7 @@ impl CostProfitService {
 		quote_id: Option<&str>,
 		intent_source: &str,
 	) -> Result<Decimal, APIError> {
-		// Retrieve the cost context if a quote ID is provided
-		let cost_context = if let Some(id) = quote_id {
-			match self.get_cost_context_by_quote_id(id).await {
-				Ok(ctx) => {
-					tracing::debug!(
-						"Cost context from quote generation: operational_cost=${:.2}, min_profit=${:.2}, total=${:.2}",
-						ctx.cost_breakdown.operational_cost,
-						ctx.cost_breakdown.min_profit,
-						ctx.cost_breakdown.total
-					);
-					Some(ctx)
-				},
-				Err(e) => {
-					tracing::warn!("Failed to retrieve cost context for quote {}: {}", id, e);
-					None
-				},
-			}
-		} else {
-			None
-		};
-
-		// Parse the order to get actual input/output amounts
+		// Parse the order first so a stored quote can be bound to it (H-07).
 		let order_parsed = order.parse_order_data().map_err(|e| APIError::BadRequest {
 			error_type: ApiErrorType::InvalidRequest,
 			message: format!("Failed to parse order data: {e}"),
@@ -1443,6 +1437,73 @@ impl CostProfitService {
 
 		let available_inputs = order_parsed.parse_available_inputs();
 		let requested_outputs = order_parsed.parse_requested_outputs();
+
+		// Retrieve the stored quote's cost context if a quote ID is provided, but
+		// honor it ONLY when its economic binding matches THIS order (H-07).
+		//
+		// A `quote_id` is otherwise an unaudienced bearer token: an unrelated,
+		// loss-making order presenting a cheap quote's id would be judged against
+		// that quote's (cheaper) stored operational cost and swap-type denominator,
+		// letting a loss-making fill clear the gate. The binding pins the economic
+		// identity of the order the quote priced, so a mismatch is rejected.
+		let cost_context = if let Some(id) = quote_id {
+			match self.get_stored_quote_by_quote_id(id).await {
+				Ok(stored) => match stored.binding {
+					Some(stored_binding) => {
+						let actual = solver_types::quote_order_binding(
+							order_parsed.origin_chain_id(),
+							order_parsed.parse_lock_type().as_deref(),
+							&available_inputs,
+							&requested_outputs,
+						);
+						if stored_binding == actual {
+							let ctx = stored.cost_context;
+							tracing::debug!(
+								"Cost context from quote generation: operational_cost=${:.2}, min_profit=${:.2}, total=${:.2}",
+								ctx.cost_breakdown.operational_cost,
+								ctx.cost_breakdown.min_profit,
+								ctx.cost_breakdown.total
+							);
+							Some(ctx)
+						} else {
+							// Fail closed: the order does not match the quote it
+							// references. This cannot happen on a legitimate
+							// redemption (the order is rebuilt from the stored
+							// quote), so a mismatch is anomalous and must not be
+							// priced on the stored economics.
+							tracing::warn!(
+								quote_id = %id,
+								expected_binding = %stored_binding,
+								actual_binding = %actual,
+								"Rejecting order: quote binding does not match submitted order (H-07)"
+							);
+							return Err(APIError::UnprocessableEntity {
+								error_type: ApiErrorType::QuoteOrderMismatch,
+								message: "Order does not match the quote it references".to_string(),
+								details: None,
+							});
+						}
+					},
+					None => {
+						// Legacy/unbindable quote record (e.g. stored before this
+						// change, or a generic order). Judge on the freshly
+						// recomputed breakdown, exactly like a direct submission.
+						// Scoped strictly to a missing binding — never a mismatch.
+						tracing::debug!(
+							"Quote {} has no economic binding; judging on freshly recomputed cost",
+							id
+						);
+						None
+					},
+				},
+				Err(e) => {
+					tracing::warn!("Failed to retrieve quote for {}: {}", id, e);
+					None
+				},
+			}
+		} else {
+			None
+		};
 
 		// Calculate actual USD values from the order amounts
 		let total_input_value_usd = self
@@ -3315,6 +3376,7 @@ mod tests {
 				adjusted_amounts: HashMap::new(),
 			},
 			settlement_name: None,
+			binding: None,
 		}
 	}
 
@@ -4548,6 +4610,7 @@ mod tests {
 			},
 			cost_context: create_cost_context_with_swap_type(SwapType::ExactInput),
 			settlement_name: None,
+			binding: Some(binding_for_order(&create_profitable_order())),
 		};
 
 		mock_storage
@@ -4618,6 +4681,7 @@ mod tests {
 			},
 			cost_context: create_cost_context_with_swap_type(SwapType::ExactOutput),
 			settlement_name: None,
+			binding: Some(binding_for_order(&create_profitable_order())),
 		};
 
 		mock_storage
@@ -7351,7 +7415,24 @@ mod tests {
 				adjusted_amounts: HashMap::new(),
 			},
 			settlement_name: None,
+			// Bind the stored quote to the canonical test order so the stored-cost
+			// path (binding matches) is exercised. Tests that need a mismatch or a
+			// legacy record override `binding` after calling this helper.
+			binding: Some(binding_for_order(&create_profitable_order())),
 		}
+	}
+
+	/// Recompute the H-07 economic binding for an order, exactly as the gate does.
+	fn binding_for_order(order: &Order) -> alloy_primitives::B256 {
+		let parsed = order
+			.parse_order_data()
+			.expect("parse order data for binding");
+		solver_types::quote_order_binding(
+			parsed.origin_chain_id(),
+			parsed.parse_lock_type().as_deref(),
+			&parsed.parse_available_inputs(),
+			&parsed.parse_requested_outputs(),
+		)
 	}
 
 	#[tokio::test]
@@ -7406,6 +7487,123 @@ mod tests {
 		assert!(
 			result.is_ok(),
 			"validator must use stored cost; got {result:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn validate_profitability_rejects_order_with_mismatched_quote_binding() {
+		// H-07 (RED before the binding check): a cheap quote's id stapled to a
+		// DIFFERENT order must not be priced on that quote's stored (cheaper)
+		// economics. The stored operational_cost ($0.044) would clear the 2% floor;
+		// the fresh one ($50) would not. Before the fix, the gate used the stored
+		// figure and ACCEPTED the loss-making order. After it, a binding that does
+		// not match the submitted order fails closed.
+		let quote_id = "test_quote_mismatched_binding";
+		let mut mock_storage = MockStorageInterface::new();
+		let mut stored =
+			stored_quote_with_operational_cost(quote_id, Decimal::from_str("0.044").unwrap());
+		// Pretend this quote priced a different order: a binding that cannot match
+		// the submitted `create_profitable_order()`.
+		stored.binding = Some(alloy_primitives::B256::repeat_byte(0xAB));
+		mock_storage
+			.expect_get_bytes()
+			.with(eq(format!("quotes:{quote_id}")))
+			.returning(move |_| {
+				let serialized = serde_json::to_vec(&stored).unwrap();
+				Box::pin(async move { Ok(serialized) })
+			});
+
+		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
+
+		let order = create_profitable_order();
+		let mut fresh_breakdown =
+			create_test_cost_breakdown_with_profit(Decimal::from_str("200.0").unwrap());
+		fresh_breakdown.operational_cost = Decimal::from_str("50.0").unwrap();
+		fresh_breakdown.gas_fill = Decimal::from_str("50.0").unwrap();
+
+		let result = service
+			.validate_profitability(
+				&order,
+				&fresh_breakdown,
+				Decimal::from_str("2.0").unwrap(),
+				Some(quote_id),
+				"off-chain",
+			)
+			.await;
+		assert!(
+			matches!(
+				result,
+				Err(APIError::UnprocessableEntity {
+					error_type: ApiErrorType::QuoteOrderMismatch,
+					..
+				})
+			),
+			"mismatched quote binding must fail closed; got {result:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn validate_profitability_falls_back_to_fresh_when_quote_binding_absent() {
+		// §4.2: a quote with no binding (legacy record / generic order) is judged
+		// on the freshly recomputed breakdown — like a direct submission — never on
+		// the stored cost. The fresh op cost ($50) fails the 2% floor, so the order
+		// is rejected for insufficient profitability (NOT a binding mismatch, and
+		// NOT accepted on the stored $0.044).
+		let quote_id = "test_quote_no_binding";
+		let mut mock_storage = MockStorageInterface::new();
+		let mut stored =
+			stored_quote_with_operational_cost(quote_id, Decimal::from_str("0.044").unwrap());
+		stored.binding = None;
+		mock_storage
+			.expect_get_bytes()
+			.with(eq(format!("quotes:{quote_id}")))
+			.returning(move |_| {
+				let serialized = serde_json::to_vec(&stored).unwrap();
+				Box::pin(async move { Ok(serialized) })
+			});
+
+		let (pricing, delivery, token_manager, _) = setup_profitable_mocks().await;
+		let storage = Arc::new(StorageService::new(Box::new(mock_storage)));
+		let service = CostProfitService::new(
+			pricing,
+			delivery,
+			token_manager,
+			storage,
+			no_fee_settlement_service(),
+		);
+
+		let order = create_profitable_order();
+		let mut fresh_breakdown =
+			create_test_cost_breakdown_with_profit(Decimal::from_str("200.0").unwrap());
+		fresh_breakdown.operational_cost = Decimal::from_str("50.0").unwrap();
+		fresh_breakdown.gas_fill = Decimal::from_str("50.0").unwrap();
+
+		let result = service
+			.validate_profitability(
+				&order,
+				&fresh_breakdown,
+				Decimal::from_str("2.0").unwrap(),
+				Some(quote_id),
+				"off-chain",
+			)
+			.await;
+		assert!(
+			matches!(
+				result,
+				Err(APIError::UnprocessableEntity {
+					error_type: ApiErrorType::InsufficientProfitability,
+					..
+				})
+			),
+			"absent binding must judge on fresh breakdown (fail 2% floor); got {result:?}"
 		);
 	}
 
@@ -7561,6 +7759,7 @@ mod tests {
 			},
 			cost_context: stored_cost_context.clone(),
 			settlement_name: None,
+			binding: Some(binding_for_order(&create_profitable_order())),
 		};
 
 		// 3. Build a validator-side service whose storage returns the stored quote.

--- a/crates/solver-service/src/apis/quote/mod.rs
+++ b/crates/solver-service/src/apis/quote/mod.rs
@@ -268,6 +268,30 @@ fn quote_cost_profit_service(solver: &SolverEngine) -> Arc<CostProfitService> {
 ///
 /// Each quote is stored together with its cost context as a StoredQuote record.
 /// Storage errors are logged but do not fail the request.
+/// Compute the H-07 economic binding for a generated quote, derived from the order
+/// it priced. The profitability gate recomputes this from the submitted order and
+/// honors the stored cost context only on a match.
+///
+/// Returns `None` when the quote's order cannot be projected to a canonical
+/// `StandardOrder` (e.g. generic orders); the gate then judges such an order on the
+/// freshly recomputed breakdown rather than the stored one.
+fn binding_for_quote(quote: &Quote) -> Option<alloy_primitives::B256> {
+	use solver_types::order::OrderParsable;
+	use solver_types::standards::eip7683::{interfaces::StandardOrder, Eip7683OrderData};
+
+	let standard = StandardOrder::try_from(&quote.order).ok()?;
+	let order_data = Eip7683OrderData::from(standard);
+	Some(solver_types::quote_order_binding(
+		order_data.origin_chain_id(),
+		// Flow key derived explicitly from the quote's order variant (not via the
+		// lossy `From<StandardOrder>`, which drops the lock type). `OifOrder::flow_key`
+		// and the gate's `parse_lock_type` produce identical strings by construction.
+		quote.order.flow_key().as_deref(),
+		&order_data.parse_available_inputs(),
+		&order_data.parse_requested_outputs(),
+	))
+}
+
 async fn store_quotes(
 	solver: &SolverEngine,
 	quotes: &[(Quote, Option<String>)],
@@ -290,11 +314,15 @@ async fn store_quotes(
 			Duration::from_secs(1)
 		};
 
-		// Create combined structure with quote and cost context
+		// Create combined structure with quote and cost context. The economic
+		// binding (H-07) pins this quote's stored cost to the order it priced, so
+		// the profitability gate cannot be tricked into applying it to a different,
+		// loss-making order that merely presents this quote's id.
 		let quote_with_context = StoredQuote {
 			quote: quote.clone(),
 			cost_context: cost_context.clone(),
 			settlement_name: settlement_name.clone(),
+			binding: binding_for_quote(quote),
 		};
 
 		// Store the combined structure in a single I/O operation
@@ -444,6 +472,8 @@ mod tests {
 	use solver_pricing::PricingService;
 	use solver_settlement::{MockSettlementInterface, SettlementInterface, SettlementService};
 	use solver_storage::{implementations::memory::MemoryStorage, StorageService};
+	use solver_types::order::OrderParsable;
+	use solver_types::standards::eip7683::{interfaces::StandardOrder, Eip7683OrderData, LockType};
 	use solver_types::{
 		current_timestamp, oif_versions, parse_address, Address, AuthScheme, CostBreakdown,
 		CostContext, FailureHandlingMode, GetQuoteRequest, IntentRequest, IntentType,
@@ -949,6 +979,277 @@ mod tests {
 		}
 	}
 
+	fn quote_with_order(order: OifOrder) -> Quote {
+		Quote {
+			order,
+			failure_handling: FailureHandlingMode::RefundAutomatic,
+			partial_fill: false,
+			valid_until: current_timestamp() + 300,
+			eta: Some(60),
+			quote_id: TEST_QUOTE_ID.to_string(),
+			provider: Some("test_solver".to_string()),
+			preview: QuotePreview {
+				inputs: vec![],
+				outputs: vec![],
+			},
+		}
+	}
+
+	fn valid_permit2_quote() -> Quote {
+		quote_with_order(OifOrder::OifEscrowV0 {
+			payload: OrderPayload {
+				signature_type: SignatureType::Eip712,
+				domain: serde_json::json!({
+					"name": "Permit2",
+					"chainId": 1,
+					"verifyingContract": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+				}),
+				primary_type: "PermitBatchWitnessTransferFrom".to_string(),
+				message: serde_json::json!({
+					"permitted": [{
+						"token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+						"amount": "1000"
+					}],
+					"nonce": "1",
+					"deadline": "2",
+					"witness": {
+						"user": "0x1111111111111111111111111111111111111111",
+						"expires": 3,
+						"inputOracle": "0x2222222222222222222222222222222222222222",
+						"outputs": [{
+							"oracle": "0x0000000000000000000000003333333333333333333333333333333333333333",
+							"settler": "0x0000000000000000000000004444444444444444444444444444444444444444",
+							"chainId": 137,
+							"token": "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+							"amount": "900",
+							"recipient": "0x0000000000000000000000005555555555555555555555555555555555555555",
+							"callbackData": "0x",
+							"context": "0x"
+						}]
+					}
+				}),
+				types: None,
+			},
+		})
+	}
+
+	fn valid_eip3009_quote() -> Quote {
+		let user = InteropAddress::new_ethereum(1, AlloyAddress::from([0x11; 20])).to_string();
+		let input_asset =
+			InteropAddress::new_ethereum(1, AlloyAddress::from([0xA0; 20])).to_string();
+		let output_asset =
+			InteropAddress::new_ethereum(137, AlloyAddress::from([0xB0; 20])).to_string();
+		let receiver =
+			InteropAddress::new_ethereum(137, AlloyAddress::from([0x55; 20])).to_string();
+
+		quote_with_order(OifOrder::Oif3009V0 {
+			payload: OrderPayload {
+				signature_type: SignatureType::Eip712,
+				domain: serde_json::json!({
+					"name": "USDC",
+					"version": "2",
+					"chainId": 1,
+					"verifyingContract": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+				}),
+				primary_type: "ReceiveWithAuthorization".to_string(),
+				message: serde_json::json!({
+					"from": "0x1111111111111111111111111111111111111111",
+					"to": "0x2222222222222222222222222222222222222222",
+					"value": "1000",
+					"validAfter": 0,
+					"validBefore": 2,
+					"nonce": "0x1111111111111111111111111111111111111111111111111111111111111111"
+				}),
+				types: None,
+			},
+			metadata: serde_json::json!({
+				"domain_separator": "0x1111111111111111111111111111111111111111111111111111111111111111",
+				"user": user,
+				"nonce": 1,
+				"originChainId": 1,
+				"expires": 3,
+				"fillDeadline": 2,
+				"inputOracle": "0x2222222222222222222222222222222222222222",
+				"inputs": [{
+					"chainId": 1,
+					"asset": input_asset,
+					"amount": "1000",
+					"user": user
+				}],
+				"outputs": [{
+					"chainId": 137,
+					"asset": output_asset,
+					"amount": "900",
+					"receiver": receiver,
+					"oracle": "0x3333333333333333333333333333333333333333",
+					"settler": "0x4444444444444444444444444444444444444444"
+				}]
+			}),
+		})
+	}
+
+	fn valid_resource_lock_quote() -> Quote {
+		quote_with_order(OifOrder::OifResourceLockV0 {
+			payload: OrderPayload {
+				signature_type: SignatureType::Eip712,
+				domain: serde_json::json!({
+					"name": "The Compact",
+					"version": "1",
+					"chainId": 1,
+					"verifyingContract": "0x6666666666666666666666666666666666666666"
+				}),
+				primary_type: "BatchCompact".to_string(),
+				message: serde_json::json!({
+					"sponsor": "0x1111111111111111111111111111111111111111",
+					"nonce": "1",
+					"expires": "3",
+					"commitments": [{
+						"lockTag": "0x0102030405060708090a0b0c",
+						"token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+						"amount": "1000"
+					}],
+					"mandate": {
+						"fillDeadline": "2",
+						"inputOracle": "0x2222222222222222222222222222222222222222",
+						"outputs": [{
+							"oracle": "0x0000000000000000000000003333333333333333333333333333333333333333",
+							"settler": "0x0000000000000000000000004444444444444444444444444444444444444444",
+							"chainId": 137,
+							"token": "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+							"amount": "900",
+							"recipient": "0x0000000000000000000000005555555555555555555555555555555555555555",
+							"callbackData": "0x",
+							"context": "0x"
+						}]
+					}
+				}),
+				types: None,
+			},
+		})
+	}
+
+	fn gate_binding_for_quote_order(quote: &Quote, lock_type: LockType) -> alloy_primitives::B256 {
+		let standard = StandardOrder::try_from(&quote.order).expect("valid StandardOrder");
+		let mut order_data = Eip7683OrderData::from(standard);
+		order_data.lock_type = Some(lock_type);
+		let parsed_lock_type = order_data.parse_lock_type();
+		let inputs = order_data.parse_available_inputs();
+		let outputs = order_data.parse_requested_outputs();
+
+		assert!(
+			!inputs.is_empty(),
+			"gate-side derivation must parse non-empty inputs for {lock_type:?}"
+		);
+		assert!(
+			!outputs.is_empty(),
+			"gate-side derivation must parse non-empty outputs for {lock_type:?}"
+		);
+
+		solver_types::quote_order_binding(
+			order_data.origin_chain_id(),
+			parsed_lock_type.as_deref(),
+			&inputs,
+			&outputs,
+		)
+	}
+
+	/// H-07 store↔gate agreement: the binding's flow key is derived on the **store**
+	/// side via `OifOrder::flow_key()` (`binding_for_quote`) but on the **gate** side
+	/// via `Eip7683OrderData::parse_lock_type()`, i.e. `LockType`'s `Display`
+	/// (`Display` delegates to `as_str`). These two independent derivations must
+	/// produce identical strings for every concrete order variant, or a legitimate
+	/// quote redemption false-rejects at the profitability gate (a fail-closed
+	/// outage). The gate's own tests build the stored binding with the gate-side
+	/// derivation, so they cannot catch a store↔gate divergence; this pins it.
+	#[test]
+	fn flow_key_agrees_with_gate_lock_type_for_all_variants() {
+		use solver_types::standards::eip7683::LockType;
+
+		fn empty_payload() -> OrderPayload {
+			OrderPayload {
+				signature_type: SignatureType::Eip712,
+				domain: serde_json::json!({}),
+				primary_type: "Order".to_string(),
+				message: serde_json::json!({}),
+				types: Some(serde_json::json!({})),
+			}
+		}
+
+		// (order variant, the LockType the gate derives via `parse_lock_type`)
+		let cases = [
+			(
+				OifOrder::OifEscrowV0 {
+					payload: empty_payload(),
+				},
+				LockType::Permit2Escrow,
+			),
+			(
+				OifOrder::Oif3009V0 {
+					payload: empty_payload(),
+					metadata: serde_json::json!({}),
+				},
+				LockType::Eip3009Escrow,
+			),
+			(
+				OifOrder::OifResourceLockV0 {
+					payload: empty_payload(),
+				},
+				LockType::ResourceLock,
+			),
+		];
+
+		for (order, gate_lock_type) in cases {
+			// Gate side computes `parse_lock_type()` == `lock_type.to_string()`.
+			// Store side computes `flow_key()`. They MUST match.
+			assert_eq!(
+				order.flow_key().as_deref(),
+				Some(gate_lock_type.to_string().as_str()),
+				"store-side flow_key() must equal gate-side parse_lock_type() for \
+				 {gate_lock_type:?}; a divergence false-rejects every redemption of \
+				 this variant",
+			);
+		}
+
+		// Generic orders intentionally carry no flow key and no economic binding;
+		// the gate falls back to the fresh breakdown on a `None` binding.
+		assert_eq!(
+			OifOrder::OifGenericV0 {
+				payload: serde_json::json!({})
+			}
+			.flow_key(),
+			None,
+		);
+	}
+
+	#[test]
+	fn binding_for_quote_matches_gate_derivation_for_all_concrete_flows() {
+		let cases = [
+			(valid_permit2_quote(), LockType::Permit2Escrow),
+			(valid_eip3009_quote(), LockType::Eip3009Escrow),
+			(valid_resource_lock_quote(), LockType::ResourceLock),
+		];
+
+		for (quote, lock_type) in cases {
+			let stored_binding = binding_for_quote(&quote).expect("quote binding");
+			let gate_binding = gate_binding_for_quote_order(&quote, lock_type);
+
+			assert_eq!(
+				stored_binding, gate_binding,
+				"store-side binding_for_quote() must match gate-side parse_lock_type() \
+					 derivation for {lock_type:?}",
+			);
+		}
+	}
+
+	#[test]
+	fn binding_for_quote_returns_none_for_generic_orders() {
+		let quote = quote_with_order(OifOrder::OifGenericV0 {
+			payload: serde_json::json!({}),
+		});
+
+		assert_eq!(binding_for_quote(&quote), None);
+	}
+
 	/// Creates a test cost context
 	fn create_test_cost_context() -> CostContext {
 		CostContext {
@@ -985,6 +1286,7 @@ mod tests {
 			quote: create_test_quote(),
 			cost_context: create_test_cost_context(),
 			settlement_name: None,
+			binding: None,
 		}
 	}
 

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -1016,13 +1016,16 @@ mod tests {
 		SignatureType,
 	};
 	use solver_types::networks::RpcEndpoint;
+	use solver_types::oracle::{OracleInfo, OracleRoutes};
 	use solver_types::standards::eip7683::interfaces::ITheCompact::DOMAIN_SEPARATORCall;
 	use solver_types::standards::eip7683::interfaces::{
 		IAllocator, ITheCompact, SolMandateOutput, StandardOrder as OifStandardOrder,
 	};
 	use solver_types::utils::tests::builders::{NetworkConfigBuilder, NetworksConfigBuilder};
 	use solver_types::{
-		APIError, Address, ApiErrorType, AuthConfig, AuthScope, ErrorResponse, SecretString,
+		APIError, Address, ApiErrorType, AuthConfig, AuthScope, CostBreakdown, CostContext,
+		ErrorResponse, FailureHandlingMode, InteropAddress, Quote, QuotePreview, SecretString,
+		StorageKey, StoredQuote, SwapType,
 	};
 	use std::collections::HashMap;
 	use std::convert::TryFrom;
@@ -1234,6 +1237,134 @@ mod tests {
 		);
 
 		Arc::new(engine)
+	}
+
+	async fn build_quote_redemption_test_app_state() -> AppState {
+		let origin_network = NetworkConfigBuilder::new()
+			.input_settler_address_hex("0x0000000000000000000000000000000000000011")
+			.unwrap()
+			.output_settler_address_hex("0x0000000000000000000000000000000000000022")
+			.unwrap()
+			.add_rpc_endpoint(RpcEndpoint::http_only("http://localhost:8545".to_string()))
+			.build();
+		let output_network = NetworkConfigBuilder::new()
+			.input_settler_address_hex("0x0000000000000000000000000000000000000011")
+			.unwrap()
+			.output_settler_address_hex("0x4444444444444444444444444444444444444444")
+			.unwrap()
+			.add_rpc_endpoint(RpcEndpoint::http_only("http://localhost:8547".to_string()))
+			.build();
+		let networks = NetworksConfigBuilder::new()
+			.add_network(1, origin_network)
+			.add_network(42161, output_network)
+			.build();
+		let config = ConfigBuilder::new().networks(networks).build();
+
+		let mut mock_delivery = MockDeliveryInterface::new();
+		mock_delivery
+			.expect_get_balance()
+			.returning(|_, _, _| Box::pin(async { Ok("1000000000000000000000".to_string()) }));
+		mock_delivery.expect_eth_call().returning(|_| {
+			Box::pin(async { Ok(Bytes::from(FixedBytes::from([0x99u8; 32]).to_vec())) })
+		});
+		let mut delivery_implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		delivery_implementations.insert(1, Arc::new(mock_delivery) as Arc<dyn DeliveryInterface>);
+
+		let mut supported_routes = HashMap::new();
+		supported_routes.insert(
+			OracleInfo {
+				chain_id: 1,
+				oracle: Address(vec![0x22; 20]),
+			},
+			vec![OracleInfo {
+				chain_id: 42161,
+				oracle: Address(vec![0x33; 20]),
+			}],
+		);
+		let oracle_routes = OracleRoutes { supported_routes };
+		let order_impl = solver_order::implementations::standards::_7683::Eip7683OrderImpl::new(
+			config.networks.clone(),
+			oracle_routes,
+		)
+		.expect("EIP-7683 order implementation");
+		let mut order_implementations: HashMap<String, Box<dyn solver_order::OrderInterface>> =
+			HashMap::new();
+		order_implementations.insert("eip7683".to_string(), Box::new(order_impl));
+
+		let storage = Arc::new(StorageService::new(Box::new(MemoryStorage::new())));
+		let account_config: serde_json::Value = json!({
+			"private_key": "0x1234567890123456789012345678901234567890123456789012345678901234"
+		});
+		let account_impl = solver_account::implementations::local::create_account(&account_config)
+			.await
+			.expect("failed to create account impl");
+		let account = Arc::new(AccountService::new(account_impl));
+		let solver_address = Address(vec![0x11; 20]);
+		let delivery = Arc::new(DeliveryService::new(delivery_implementations, 1, 10, 60));
+		let discovery = empty_discovery();
+		let strategy_config = serde_json::Value::Object(serde_json::Map::new());
+		let strategy =
+			solver_order::implementations::strategies::simple::create_strategy(&strategy_config)
+				.expect("failed to create order strategy");
+		let order = Arc::new(OrderService::new(order_implementations, strategy));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 10));
+		let pricing_impl = create_mock_pricing(&serde_json::Value::Object(serde_json::Map::new()))
+			.expect("failed to create mock pricing");
+		let pricing = Arc::new(PricingService::new(pricing_impl, Vec::new()));
+		let event_bus = EventBus::new(10);
+		let token_manager = Arc::new(TokenManager::new(
+			config.networks.clone(),
+			delivery.clone(),
+			account.clone(),
+		));
+
+		let dynamic_config = Arc::new(RwLock::new(config.clone()));
+		let solver = Arc::new(SolverEngine::new(
+			dynamic_config,
+			config,
+			storage,
+			account,
+			solver_address,
+			delivery,
+			discovery,
+			order,
+			settlement,
+			pricing,
+			event_bus,
+			token_manager,
+			None,
+		));
+
+		build_test_app_state_with_solver(None, solver).await
+	}
+
+	fn empty_cost_context() -> CostContext {
+		CostContext {
+			cost_breakdown: CostBreakdown {
+				gas_open: rust_decimal::Decimal::ZERO,
+				gas_fill: rust_decimal::Decimal::ZERO,
+				gas_post_fill: rust_decimal::Decimal::ZERO,
+				gas_pre_claim: rust_decimal::Decimal::ZERO,
+				gas_claim: rust_decimal::Decimal::ZERO,
+				gas_buffer: rust_decimal::Decimal::ZERO,
+				settlement_fee: rust_decimal::Decimal::ZERO,
+				settlement_fee_buffer: rust_decimal::Decimal::ZERO,
+				rate_buffer: rust_decimal::Decimal::ZERO,
+				base_price: rust_decimal::Decimal::ZERO,
+				min_profit: rust_decimal::Decimal::ZERO,
+				operational_cost: rust_decimal::Decimal::ZERO,
+				subtotal: rust_decimal::Decimal::ZERO,
+				total: rust_decimal::Decimal::ZERO,
+				currency: "USD".to_string(),
+			},
+			execution_costs_by_chain: HashMap::new(),
+			liquidity_cost_adjustment: rust_decimal::Decimal::ZERO,
+			protocol_fees: HashMap::new(),
+			swap_type: SwapType::ExactInput,
+			cost_amounts_in_tokens: HashMap::new(),
+			swap_amounts: HashMap::new(),
+			adjusted_amounts: HashMap::new(),
+		}
 	}
 
 	fn resource_lock_config_for_signature_order() -> Config {
@@ -1789,6 +1920,9 @@ mod tests {
 		witness_user: &str,
 		secret: &SecretKey,
 	) -> PostOrderRequest {
+		let now = solver_types::current_timestamp();
+		let fill_deadline = now + 1_800;
+		let expires = now + 3_600;
 		let payload = OrderPayload {
 			signature_type: SignatureType::Eip712,
 			domain: json!({
@@ -1798,22 +1932,22 @@ mod tests {
 			}),
 			primary_type: "PermitBatchWitnessTransferFrom".to_string(),
 			message: json!({
-				"permitted": [{
-					"token": "0x0000000000000000000000000000000000000033",
-					"amount": "1000"
-				}],
-				"spender": "0x0000000000000000000000000000000000000011",
-				"nonce": "1",
-				"deadline": "1700000100",
-				"witness": {
-					"user": witness_user,
-					"expires": 1700000000u64,
-					"inputOracle": "0x2222222222222222222222222222222222222222",
-					"outputs": [{
-						"oracle": "0x0000000000000000000000003333333333333333333333333333333333333333",
-						"settler": "0x0000000000000000000000004444444444444444444444444444444444444444",
-						"chainId": 42161,
-						"token": "0x0000000000000000000000000000000000000000000000000000000000000033",
+					"permitted": [{
+						"token": "0x0000000000000000000000000000000000000033",
+						"amount": "1000"
+					}],
+					"spender": "0x0000000000000000000000000000000000000011",
+					"nonce": "1",
+					"deadline": fill_deadline.to_string(),
+					"witness": {
+						"user": witness_user,
+						"expires": expires,
+						"inputOracle": "0x2222222222222222222222222222222222222222",
+						"outputs": [{
+							"oracle": "0x0000000000000000000000003333333333333333333333333333333333333333",
+							"settler": "0x0000000000000000000000004444444444444444444444444444444444444444",
+							"chainId": 42161,
+							"token": "0x0000000000000000000000000000000000000000000000000000000000000033",
 						"amount": "900",
 						"recipient": "0x0000000000000000000000005555555555555555555555555555555555555555",
 						"callbackData": "0x",
@@ -1829,6 +1963,69 @@ mod tests {
 				payload: payload.clone(),
 			},
 			signature: sign_permit2_payload(&payload, secret),
+			quote_id: None,
+			origin_submission: None,
+		}
+	}
+
+	fn sample_eip3009_request() -> PostOrderRequest {
+		let now = solver_types::current_timestamp();
+		let fill_deadline = now + 1_800;
+		let expires = now + 3_600;
+		let user = InteropAddress::new_ethereum(1, AlloyAddress::from([0x11; 20])).to_string();
+		let input_asset =
+			InteropAddress::new_ethereum(1, AlloyAddress::from([0x33; 20])).to_string();
+		let output_asset =
+			InteropAddress::new_ethereum(42161, AlloyAddress::from([0x33; 20])).to_string();
+		let receiver =
+			InteropAddress::new_ethereum(42161, AlloyAddress::from([0x55; 20])).to_string();
+
+		PostOrderRequest {
+			order: OifOrder::Oif3009V0 {
+				payload: OrderPayload {
+					signature_type: SignatureType::Eip712,
+					domain: json!({
+						"name": "USDC",
+						"version": "2",
+						"chainId": 1,
+						"verifyingContract": "0x0000000000000000000000000000000000000033"
+					}),
+					primary_type: "ReceiveWithAuthorization".to_string(),
+					message: json!({
+						"from": "0x1111111111111111111111111111111111111111",
+						"to": "0x0000000000000000000000000000000000000011",
+						"value": "1000",
+						"validAfter": 0,
+						"validBefore": fill_deadline,
+						"nonce": "0x1111111111111111111111111111111111111111111111111111111111111111"
+					}),
+					types: None,
+				},
+				metadata: json!({
+					"domain_separator": "0x1111111111111111111111111111111111111111111111111111111111111111",
+					"user": user,
+					"nonce": 1,
+					"originChainId": 1,
+					"expires": expires,
+					"fillDeadline": fill_deadline,
+					"inputOracle": "0x2222222222222222222222222222222222222222",
+					"inputs": [{
+						"chainId": 1,
+						"asset": input_asset,
+						"amount": "1000",
+						"user": user
+					}],
+					"outputs": [{
+						"chainId": 42161,
+						"asset": output_asset,
+						"amount": "900",
+						"receiver": receiver,
+						"oracle": "0x3333333333333333333333333333333333333333",
+						"settler": "0x4444444444444444444444444444444444444444"
+					}]
+				}),
+			},
+			signature: Bytes::from(vec![0xAB; 65]),
 			quote_id: None,
 			origin_submission: None,
 		}
@@ -2364,6 +2561,77 @@ mod tests {
 				..
 			}
 		));
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn quote_acceptance_validation_populates_lock_type_for_gate_binding() {
+		let state = build_quote_redemption_test_app_state().await;
+		let secret = SecretKey::from_byte_array([0x31u8; 32]).expect("valid secret");
+		let cases = [
+			(
+				"permit2",
+				sample_permit2_request_with_witness_user(
+					"0x1111111111111111111111111111111111111111",
+					&secret,
+				),
+				"permit2_escrow",
+			),
+			("eip3009", sample_eip3009_request(), "eip3009_escrow"),
+		];
+
+		for (case_name, quoted_request, expected_flow) in cases {
+			let quote_id = format!("quote-lock-type-population-{case_name}");
+			let quote = Quote {
+				order: quoted_request.order.clone(),
+				failure_handling: FailureHandlingMode::RefundAutomatic,
+				partial_fill: false,
+				valid_until: 4_102_444_800,
+				eta: Some(60),
+				quote_id: quote_id.clone(),
+				provider: Some("test_solver".to_string()),
+				preview: QuotePreview {
+					inputs: vec![],
+					outputs: vec![],
+				},
+			};
+			let stored_quote = StoredQuote {
+				quote,
+				cost_context: empty_cost_context(),
+				settlement_name: None,
+				binding: None,
+			};
+			state
+				.solver
+				.storage()
+				.store(StorageKey::Quotes.as_str(), &quote_id, &stored_quote, None)
+				.await
+				.expect("store quote");
+
+			let payload = json!({
+				"quoteId": quote_id,
+				"signature": format!("0x{}", hex::encode(quoted_request.signature.as_ref())),
+			});
+			let redeemed = super::extract_intent_request(payload, &state, "eip7683")
+				.await
+				.expect("quote acceptance should reconstruct request");
+
+			assert_eq!(redeemed.quote_id.as_deref(), Some(quote_id.as_str()));
+			assert_eq!(redeemed.order.flow_key().as_deref(), Some(expected_flow));
+
+			let validated_order = super::validate_intent_request(&redeemed, &state, "eip7683")
+				.await
+				.expect("redeemed quote should validate");
+			let parsed = validated_order
+				.parse_order_data()
+				.expect("validated order data should parse");
+
+			assert_eq!(
+				parsed.parse_lock_type().as_deref(),
+				Some(expected_flow),
+				"quote redemption must populate Order.data.lock_type for {case_name} so \
+				 the profitability gate recomputes the same binding flow that storage used",
+			);
+		}
 	}
 
 	#[tokio::test(flavor = "multi_thread")]

--- a/crates/solver-types/src/api.rs
+++ b/crates/solver-types/src/api.rs
@@ -673,6 +673,8 @@ pub enum ApiErrorType {
 	QuoteNotFound,
 	QuoteProcessingFailed,
 	QuoteConversionFailed,
+	/// The submitted order does not match the order the quote priced (H-07).
+	QuoteOrderMismatch,
 	MissingSignature,
 	InvalidRequest,
 	UnsupportedAsset,

--- a/crates/solver-types/src/lib.rs
+++ b/crates/solver-types/src/lib.rs
@@ -51,6 +51,8 @@ pub mod versioned;
 pub mod costs;
 /// Pricing oracle types for currency conversion.
 pub mod pricing;
+/// Canonical economic binding between a stored quote and the order it priced (H-07).
+pub mod quote_binding;
 
 // Re-export all types for convenient access
 pub use account::*;
@@ -80,6 +82,7 @@ pub use provider::{
 	create_http_provider, create_http_providers, create_ws_provider, create_ws_providers,
 	ensure_rustls_crypto_provider, ProviderError,
 };
+pub use quote_binding::{quote_order_binding, QUOTE_BINDING_VERSION};
 pub use registry::ImplementationRegistry;
 pub use secret_string::SecretString;
 pub use seed_overrides::{AccountOverride, NetworkOverride, SeedOverrides, Token};

--- a/crates/solver-types/src/quote_binding.rs
+++ b/crates/solver-types/src/quote_binding.rs
@@ -1,0 +1,246 @@
+//! Canonical economic binding between a stored quote and the order it priced.
+//!
+//! Audit finding H-07: a `quote_id` must only unlock a stored cost context for the
+//! *same* order the quote was generated for. Without this, an order presenting an
+//! unrelated `quote_id` is judged against that quote's (cheaper) stored economics,
+//! letting a loss-making fill clear the profitability gate.
+//!
+//! [`quote_order_binding`] derives a deterministic hash over the economically
+//! relevant, **order-derived** fields, including the execution **flow key** that
+//! selects gas units from `config.gas.flows`. The two callers compute it for the
+//! same logical order so the hashes match byte-for-byte:
+//! - at quote time (`solver-service` `store_quotes`): inputs/outputs from the same
+//!   [`crate::Eip7683OrderData`] parse methods, and the flow key from
+//!   [`crate::OifOrder::flow_key`].
+//! - at the profitability gate (`solver-core` `validate_profitability`):
+//!   inputs/outputs from the submitted order, and the flow key from
+//!   [`crate::order::OrderParsable::parse_lock_type`].
+//!
+//! The flow key is included because cost context is flow-specific: two orders with
+//! identical economic amounts but different lock/auth flow (`permit2_escrow`,
+//! `eip3009_escrow`, `resource_lock`) select different gas units, so they must not
+//! share a binding. It is derived **explicitly on each side** (not via
+//! `From<StandardOrder>`, which drops `lock_type`); `OifOrder::flow_key()` and
+//! `LockType::Display` produce the identical strings by construction.
+//!
+//! Deliberately **excluded**:
+//! - `swap_type` and `settlement_name` — these are quote *metadata*, not properties
+//!   of the order, so they cannot be recomputed from the submitted order. The binding
+//!   answers "is this the order I quoted?"; once it matches, the stored metadata
+//!   legitimately applies. (`settlement_name` is also re-derived from the stored
+//!   quote's settlement binding before execution, so it is not load-bearing here.)
+//! - `nonce` / `signature` / `fillDeadline` / `expires` / `inputOracle` — not economic
+//!   and may legitimately differ between the quote and the signed submission.
+
+use crate::api::{OrderInput, OrderOutput};
+use alloy_primitives::{keccak256, B256};
+
+/// Version tag mixed into the binding so a future encoding change can't silently
+/// collide with v1 hashes.
+pub const QUOTE_BINDING_VERSION: u8 = 1;
+
+const DOMAIN: &[u8] = b"oif.quote-order-binding.v1";
+
+/// Deterministic economic binding for an order.
+///
+/// Encoding is explicit and length-prefixed (no `serde`/map iteration, whose
+/// ordering is not a stable security primitive). Inputs and outputs are hashed in
+/// their on-chain order — order is economically meaningful and is not sorted.
+pub fn quote_order_binding(
+	origin_chain_id: u64,
+	flow_key: Option<&str>,
+	inputs: &[OrderInput],
+	outputs: &[OrderOutput],
+) -> B256 {
+	let mut buf: Vec<u8> = Vec::new();
+	buf.extend_from_slice(DOMAIN);
+	buf.push(QUOTE_BINDING_VERSION);
+	buf.extend_from_slice(&origin_chain_id.to_be_bytes());
+
+	// Execution flow key (lock/auth path) — selects gas units, so it is part of the
+	// order's economic identity. Presence byte distinguishes `None` from `Some("")`.
+	match flow_key {
+		Some(flow) => {
+			buf.push(1);
+			push_field(&mut buf, flow.as_bytes());
+		},
+		None => buf.push(0),
+	}
+
+	buf.extend_from_slice(&(inputs.len() as u64).to_be_bytes());
+	for input in inputs {
+		// `to_bytes` is the canonical EIP-7930 encoding; it embeds the chain id,
+		// so per-field chain ids do not need to be hashed separately.
+		push_field(&mut buf, &input.user.to_bytes());
+		push_field(&mut buf, &input.asset.to_bytes());
+		buf.extend_from_slice(&input.amount.to_be_bytes::<32>());
+	}
+
+	buf.extend_from_slice(&(outputs.len() as u64).to_be_bytes());
+	for output in outputs {
+		push_field(&mut buf, &output.receiver.to_bytes());
+		push_field(&mut buf, &output.asset.to_bytes());
+		buf.extend_from_slice(&output.amount.to_be_bytes::<32>());
+		push_field(
+			&mut buf,
+			normalize_calldata(output.calldata.as_deref()).as_bytes(),
+		);
+	}
+
+	keccak256(&buf)
+}
+
+/// Length-prefix a variable-length field so concatenation is unambiguous
+/// (prevents `["ab","c"]` colliding with `["a","bc"]`).
+fn push_field(buf: &mut Vec<u8>, bytes: &[u8]) {
+	buf.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+	buf.extend_from_slice(bytes);
+}
+
+/// Canonicalize the hex calldata string so equivalent encodings hash equally.
+/// `None` and an empty/`0x` payload are all treated as "no calldata".
+fn normalize_calldata(calldata: Option<&str>) -> String {
+	let raw = calldata.unwrap_or("");
+	let stripped = raw
+		.strip_prefix("0x")
+		.or_else(|| raw.strip_prefix("0X"))
+		.unwrap_or(raw);
+	stripped.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::standards::eip7930::InteropAddress;
+	use crate::Address;
+	use alloy_primitives::U256;
+
+	fn addr(chain: u64, byte: u8) -> InteropAddress {
+		InteropAddress::from((chain, Address(vec![byte; 20])))
+	}
+
+	fn input(chain: u64, asset: u8, amount: u64) -> OrderInput {
+		OrderInput {
+			user: addr(chain, 0xAA),
+			asset: addr(chain, asset),
+			amount: U256::from(amount),
+			lock: None,
+		}
+	}
+
+	fn output(chain: u64, asset: u8, amount: u64, calldata: Option<&str>) -> OrderOutput {
+		OrderOutput {
+			receiver: addr(chain, 0xBB),
+			asset: addr(chain, asset),
+			amount: U256::from(amount),
+			calldata: calldata.map(|s| s.to_string()),
+		}
+	}
+
+	// Canonical flow key held fixed in field-isolation tests.
+	const FLOW: Option<&str> = Some("permit2_escrow");
+
+	#[test]
+	fn binding_is_deterministic() {
+		let i = vec![input(1, 0x01, 100)];
+		let o = vec![output(10, 0x02, 90, Some("0xdeadbeef"))];
+		assert_eq!(
+			quote_order_binding(1, FLOW, &i, &o),
+			quote_order_binding(1, FLOW, &i, &o)
+		);
+	}
+
+	#[test]
+	fn binding_changes_with_input_amount() {
+		let o = vec![output(10, 0x02, 90, None)];
+		let a = quote_order_binding(1, FLOW, &[input(1, 0x01, 100)], &o);
+		let b = quote_order_binding(1, FLOW, &[input(1, 0x01, 101)], &o);
+		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn binding_changes_with_output_amount() {
+		let i = vec![input(1, 0x01, 100)];
+		let a = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, None)]);
+		let b = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 91, None)]);
+		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn binding_changes_with_asset() {
+		let i = vec![input(1, 0x01, 100)];
+		let a = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, None)]);
+		let b = quote_order_binding(1, FLOW, &i, &[output(10, 0x03, 90, None)]);
+		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn binding_changes_with_destination_chain() {
+		let i = vec![input(1, 0x01, 100)];
+		let a = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, None)]);
+		let b = quote_order_binding(1, FLOW, &i, &[output(11, 0x02, 90, None)]);
+		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn binding_changes_with_origin_chain() {
+		let i = vec![input(1, 0x01, 100)];
+		let o = vec![output(10, 0x02, 90, None)];
+		assert_ne!(
+			quote_order_binding(1, FLOW, &i, &o),
+			quote_order_binding(2, FLOW, &i, &o)
+		);
+	}
+
+	#[test]
+	fn binding_changes_with_flow_key() {
+		// Same economic amounts, different lock/auth flow → different gas units →
+		// must not share a binding (the P1 finding).
+		let i = vec![input(1, 0x01, 100)];
+		let o = vec![output(10, 0x02, 90, None)];
+		let permit2 = quote_order_binding(1, Some("permit2_escrow"), &i, &o);
+		let eip3009 = quote_order_binding(1, Some("eip3009_escrow"), &i, &o);
+		let lock = quote_order_binding(1, Some("resource_lock"), &i, &o);
+		let none = quote_order_binding(1, None, &i, &o);
+		assert_ne!(permit2, eip3009);
+		assert_ne!(permit2, lock);
+		assert_ne!(eip3009, lock);
+		assert_ne!(permit2, none);
+	}
+
+	#[test]
+	fn binding_changes_with_calldata() {
+		let i = vec![input(1, 0x01, 100)];
+		let a = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, Some("0xdeadbeef"))]);
+		let b = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, Some("0xdeadbe"))]);
+		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn binding_changes_with_output_count_or_order() {
+		let i = vec![input(1, 0x01, 100)];
+		let one = vec![output(10, 0x02, 90, None)];
+		let two = vec![output(10, 0x02, 90, None), output(10, 0x03, 90, None)];
+		assert_ne!(
+			quote_order_binding(1, FLOW, &i, &one),
+			quote_order_binding(1, FLOW, &i, &two)
+		);
+
+		let ab = vec![output(10, 0x02, 90, None), output(10, 0x03, 90, None)];
+		let ba = vec![output(10, 0x03, 90, None), output(10, 0x02, 90, None)];
+		assert_ne!(
+			quote_order_binding(1, FLOW, &i, &ab),
+			quote_order_binding(1, FLOW, &i, &ba)
+		);
+	}
+
+	#[test]
+	fn calldata_none_matches_empty_and_0x() {
+		let i = vec![input(1, 0x01, 100)];
+		let none = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, None)]);
+		let empty = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, Some(""))]);
+		let zerox = quote_order_binding(1, FLOW, &i, &[output(10, 0x02, 90, Some("0x"))]);
+		assert_eq!(none, empty);
+		assert_eq!(none, zerox);
+	}
+}

--- a/crates/solver-types/src/storage.rs
+++ b/crates/solver-types/src/storage.rs
@@ -17,6 +17,14 @@ pub struct StoredQuote {
 	/// Settlement implementation name selected at quote time.
 	#[serde(skip_serializing_if = "Option::is_none", default)]
 	pub settlement_name: Option<String>,
+	/// Canonical economic binding to the order this quote priced (audit finding
+	/// H-07). The profitability gate honors `cost_context` only when this matches
+	/// the binding recomputed from the submitted order, so a `quote_id` cannot
+	/// unlock cheaper stored economics for an unrelated order. `None` for legacy
+	/// records or orders that cannot be projected (e.g. generic orders); see
+	/// [`crate::quote_binding::quote_order_binding`].
+	#[serde(skip_serializing_if = "Option::is_none", default)]
+	pub binding: Option<alloy_primitives::B256>,
 }
 
 /// Storage keys for different data collections.


### PR DESCRIPTION
## Summary

- add a canonical quote/order economic binding and persist it with stored quotes
- verify the binding in `validate_profitability` before honoring quote-time cost context
- fail closed on binding mismatch, while legacy/unbindable `None` records fall back to fresh profitability costs
- add store-to-gate binding agreement tests and quote-redemption population coverage for Permit2 and EIP-3009

## Root Cause

The profitability gate could combine spread from the submitted order with operational cost and swap denominator from an unrelated referenced quote. A `quote_id` alone did not prove that the order under validation was the order originally priced by the quote.

## Validation

- `cargo test -p solver-types`
- `cargo test -p solver-core`
- `cargo test -p solver-service`
- `cargo test -p solver-service binding_for_quote -- --nocapture`
- `cargo test -p solver-service quote_acceptance_validation_populates_lock_type_for_gate_binding -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`

## Notes

The quote-redemption population proof is covered in `solver-service` unit/integration tests rather than the Anvil e2e suite, which currently has no quote-redemption happy path fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quotes are now economically bound to specific orders to ensure submitted orders match the original quote terms
  
* **Improvements**
  * Invalid orders that don't match their quotes are rejected with a clear validation error

<!-- end of auto-generated comment: release notes by coderabbit.ai -->