### PR TITLE
fix: require origin-chain prepare before filling off-chain escrow on recovery

### DIFF
--- a/crates/solver-core/src/handlers/order.rs
+++ b/crates/solver-core/src/handlers/order.rs
@@ -5,6 +5,7 @@
 
 use crate::engine::event_bus::EventBus;
 use crate::handlers::forced_withdrawal::ensure_resource_locks_claimable;
+use crate::order_preparation::order_requires_preparation;
 use crate::state::transaction_attempt::TransactionAttemptStore;
 use crate::state::OrderStateMachine;
 use alloy_primitives::hex;
@@ -308,6 +309,13 @@ impl OrderHandler {
 		order: Order,
 		params: ExecutionParams,
 	) -> Result<(), OrderError> {
+		if order_requires_preparation(&order) && order.prepare_tx_hash.is_none() {
+			return Err(OrderError::Service(format!(
+				"Order {} requires preparation before fill, but prepare_tx_hash is missing",
+				order.id
+			)));
+		}
+
 		// (C-03) Just-in-time forced-withdrawal guard for ResourceLock orders. This is
 		// the last solver-controlled point before the destination fill is released, so
 		// it catches a sponsor who enabled (or began) a forced withdrawal before the
@@ -459,7 +467,9 @@ mod tests {
 	use solver_delivery::{DeliveryService, MockDeliveryInterface};
 	use solver_order::{MockOrderInterface, OrderService};
 	use solver_storage::{MockStorageInterface, StorageService};
-	use solver_types::utils::tests::builders::{OrderBuilder, TransactionBuilder};
+	use solver_types::utils::tests::builders::{
+		Eip7683OrderDataBuilder, OrderBuilder, TransactionBuilder,
+	};
 	use solver_types::{
 		ExecutionParams, Order, SolverEvent, Transaction, TransactionHash, TransactionType,
 	};
@@ -488,6 +498,104 @@ mod tests {
 
 	fn create_test_tx_hash() -> TransactionHash {
 		TransactionHash(vec![0xab; 32])
+	}
+
+	fn eip7683_order_with_lock(
+		lock_type: LockType,
+		offchain_fields: bool,
+		prepare_tx_hash: Option<TransactionHash>,
+	) -> Order {
+		let mut order_data = Eip7683OrderDataBuilder::new()
+			.lock_type(lock_type)
+			.raw_order_data("0x1234");
+
+		if offchain_fields {
+			order_data = order_data
+				.sponsor("0x1111111111111111111111111111111111111111")
+				.signature("0xabcdef");
+		}
+
+		OrderBuilder::new()
+			.with_data(serde_json::to_value(order_data.build()).unwrap())
+			.with_prepare_tx_hash(prepare_tx_hash)
+			.build()
+	}
+
+	async fn assert_handle_execution_succeeds(order: Order) {
+		let params = create_test_execution_params();
+		let fill_tx = create_test_transaction();
+		let fill_tx_hash = create_test_tx_hash();
+		let order_clone = order.clone();
+		let fill_tx_clone = fill_tx.clone();
+		let fill_tx_hash_clone = fill_tx_hash.clone();
+
+		let (handler, mut event_rx) = create_test_handler_with_mocks(
+			|mock_order| {
+				let fill_tx_clone = fill_tx_clone.clone();
+				mock_order
+					.expect_generate_fill_transaction()
+					.times(1)
+					.returning(move |_, _| {
+						let tx = fill_tx_clone.clone();
+						Box::pin(async move { Ok(tx) })
+					});
+			},
+			|mock_delivery| {
+				let fill_tx_hash_clone = fill_tx_hash_clone.clone();
+				mock_delivery
+					.expect_submit()
+					.times(1)
+					.returning(move |_tx, _tracking| {
+						let hash = fill_tx_hash_clone.clone();
+						Box::pin(async move { Ok(hash) })
+					});
+			},
+			|mock_storage| {
+				let order_clone = order_clone.clone();
+				mock_storage
+					.expect_set_bytes()
+					.times(1)
+					.returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+
+				mock_storage
+					.expect_exists()
+					.returning(|_| Box::pin(async { Ok(true) }));
+
+				mock_storage.expect_get_bytes().returning(move |_| {
+					let order = order_clone.clone();
+					Box::pin(async move { Ok(serde_json::to_vec(&order).unwrap()) })
+				});
+
+				mock_storage
+					.expect_compare_and_swap_with_indexes()
+					.times(1)
+					.returning(|_, _, _, _, _| Box::pin(async { Ok(true) }));
+			},
+		)
+		.await;
+
+		let result = handler.handle_execution(order.clone(), params).await;
+		assert!(result.is_ok());
+
+		let event = tokio::time::timeout(std::time::Duration::from_millis(100), event_rx.recv())
+			.await
+			.expect("Should receive event")
+			.expect("Event should be valid");
+
+		match event {
+			SolverEvent::Delivery(DeliveryEvent::TransactionPending {
+				order_id,
+				tx_hash,
+				tx_type,
+				tx_chain_id,
+			}) => {
+				assert_eq!(order_id, order.id);
+				assert_eq!(tx_hash, fill_tx_hash);
+				assert_eq!(tx_type, TransactionType::Fill);
+				assert_eq!(tx_chain_id, fill_tx.chain_id);
+			},
+			_ => panic!("Expected TransactionPending event"),
+		}
 	}
 
 	async fn create_test_handler_with_mocks<F1, F2, F3>(
@@ -957,6 +1065,164 @@ mod tests {
 		match result.unwrap_err() {
 			OrderError::Service(msg) => assert!(msg.contains("Fill error")),
 			_ => panic!("Expected Service error"),
+		}
+	}
+
+	#[tokio::test]
+	async fn handle_execution_rejects_offchain_escrow_without_prepare_hash() {
+		let order = eip7683_order_with_lock(LockType::Permit2Escrow, true, None);
+		let params = create_test_execution_params();
+
+		let (handler, _event_rx) = create_test_handler_with_mocks(
+			|mock_order| {
+				mock_order.expect_generate_fill_transaction().times(0);
+			},
+			|mock_delivery| {
+				mock_delivery.expect_submit().times(0);
+			},
+			|_mock_storage| {},
+		)
+		.await;
+
+		let err = handler
+			.handle_execution(order, params)
+			.await
+			.expect_err("off-chain escrow order without prepare hash must not fill");
+
+		assert!(matches!(
+			err,
+			OrderError::Service(msg)
+				if msg.contains("requires preparation") && msg.contains("prepare_tx_hash")
+		));
+	}
+
+	#[tokio::test]
+	async fn handle_execution_allows_offchain_escrow_with_prepare_hash() {
+		let order = eip7683_order_with_lock(
+			LockType::Permit2Escrow,
+			true,
+			Some(TransactionHash(vec![0xcd; 32])),
+		);
+
+		assert_handle_execution_succeeds(order).await;
+	}
+
+	#[tokio::test]
+	async fn handle_execution_allows_onchain_escrow_without_prepare_hash() {
+		let order = eip7683_order_with_lock(LockType::Permit2Escrow, false, None);
+
+		assert_handle_execution_succeeds(order).await;
+	}
+
+	#[tokio::test]
+	async fn handle_execution_allows_resource_lock_without_prepare_hash() {
+		use solver_types::networks::{NetworkConfig, NetworkType, RpcEndpoint};
+		use solver_types::Address;
+
+		let order_data = Eip7683OrderDataBuilder::new()
+			.origin_chain_id(U256::from(137))
+			.inputs(vec![[U256::from(1000), U256::ZERO]])
+			.lock_type(LockType::ResourceLock)
+			.raw_order_data("0x1234")
+			.sponsor("0x1111111111111111111111111111111111111111")
+			.signature("0xabcdef")
+			.build();
+		let order = OrderBuilder::new()
+			.with_data(serde_json::to_value(order_data).unwrap())
+			.with_prepare_tx_hash(None)
+			.build();
+		let params = create_test_execution_params();
+		let fill_tx = create_test_transaction();
+		let fill_tx_hash = create_test_tx_hash();
+		let order_clone = order.clone();
+		let fill_tx_clone = fill_tx.clone();
+		let fill_tx_hash_clone = fill_tx_hash.clone();
+
+		let network = NetworkConfig {
+			name: None,
+			network_type: NetworkType::default(),
+			rpc_urls: vec![RpcEndpoint::http_only("http://localhost:8545".to_string())],
+			input_settler_address: Address(vec![0x11u8; 20]),
+			output_settler_address: Address(vec![0x22u8; 20]),
+			tokens: vec![],
+			input_settler_compact_address: Some(Address(vec![0x44u8; 20])),
+			the_compact_address: Some(Address(vec![0x88u8; 20])),
+			allocator_address: Some(Address(vec![0xA1u8; 20])),
+		};
+		let config = solver_config::ConfigBuilder::new()
+			.networks(HashMap::from([(137, network)]))
+			.build();
+
+		let (handler, mut event_rx) = create_test_handler_with_config(
+			|mock_order| {
+				let fill_tx_clone = fill_tx_clone.clone();
+				mock_order
+					.expect_generate_fill_transaction()
+					.times(1)
+					.returning(move |_, _| {
+						let tx = fill_tx_clone.clone();
+						Box::pin(async move { Ok(tx) })
+					});
+			},
+			|mock_delivery| {
+				let fill_tx_hash_clone = fill_tx_hash_clone.clone();
+				mock_delivery.expect_eth_call().times(1).returning(|_| {
+					Box::pin(async { Ok(alloy_primitives::Bytes::from(vec![0u8; 64])) })
+				});
+				mock_delivery
+					.expect_submit()
+					.times(1)
+					.returning(move |_tx, _tracking| {
+						let hash = fill_tx_hash_clone.clone();
+						Box::pin(async move { Ok(hash) })
+					});
+			},
+			|mock_storage| {
+				let order_clone = order_clone.clone();
+				mock_storage
+					.expect_set_bytes()
+					.times(1)
+					.returning(|_, _, _, _| Box::pin(async { Ok(()) }));
+
+				mock_storage
+					.expect_exists()
+					.returning(|_| Box::pin(async { Ok(true) }));
+
+				mock_storage.expect_get_bytes().returning(move |_| {
+					let order = order_clone.clone();
+					Box::pin(async move { Ok(serde_json::to_vec(&order).unwrap()) })
+				});
+
+				mock_storage
+					.expect_compare_and_swap_with_indexes()
+					.times(1)
+					.returning(|_, _, _, _, _| Box::pin(async { Ok(true) }));
+			},
+			config,
+		)
+		.await;
+
+		let result = handler.handle_execution(order.clone(), params).await;
+		assert!(result.is_ok());
+
+		let event = tokio::time::timeout(std::time::Duration::from_millis(100), event_rx.recv())
+			.await
+			.expect("Should receive event")
+			.expect("Event should be valid");
+
+		match event {
+			SolverEvent::Delivery(DeliveryEvent::TransactionPending {
+				order_id,
+				tx_hash,
+				tx_type,
+				tx_chain_id,
+			}) => {
+				assert_eq!(order_id, order.id);
+				assert_eq!(tx_hash, fill_tx_hash);
+				assert_eq!(tx_type, TransactionType::Fill);
+				assert_eq!(tx_chain_id, fill_tx.chain_id);
+			},
+			_ => panic!("Expected TransactionPending event"),
 		}
 	}
 

--- a/crates/solver-core/src/lib.rs
+++ b/crates/solver-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bump;
 pub mod engine;
 pub mod handlers;
 pub mod monitoring;
+pub(crate) mod order_preparation;
 pub mod recovery;
 pub mod state;
 

--- a/crates/solver-core/src/order_preparation.rs
+++ b/crates/solver-core/src/order_preparation.rs
@@ -1,0 +1,101 @@
+use solver_types::{
+	standards::eip7683::{Eip7683OrderData, LockType},
+	Order,
+};
+
+pub(crate) fn order_requires_preparation(order: &Order) -> bool {
+	if order.standard != "eip7683" {
+		return false;
+	}
+
+	let Ok(order_data) = serde_json::from_value::<Eip7683OrderData>(order.data.clone()) else {
+		return false;
+	};
+
+	let escrow_lock = matches!(
+		order_data.lock_type,
+		Some(LockType::Permit2Escrow | LockType::Eip3009Escrow)
+	);
+
+	escrow_lock
+		&& order_data.raw_order_data.is_some()
+		&& order_data.sponsor.is_some()
+		&& order_data.signature.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::order_requires_preparation;
+	use solver_types::{
+		standards::eip7683::LockType,
+		utils::tests::builders::{Eip7683OrderDataBuilder, OrderBuilder},
+	};
+
+	fn order_with_data(data: serde_json::Value) -> solver_types::Order {
+		OrderBuilder::new().with_data(data).build()
+	}
+
+	fn eip7683_data(
+		lock_type: LockType,
+		raw: bool,
+		sponsor: bool,
+		signature: bool,
+	) -> serde_json::Value {
+		let mut builder = Eip7683OrderDataBuilder::new().lock_type(lock_type);
+		if raw {
+			builder = builder.raw_order_data("0x1234");
+		}
+		if sponsor {
+			builder = builder.sponsor("0x1111111111111111111111111111111111111111");
+		}
+		if signature {
+			builder = builder.signature("0xabcdef");
+		}
+		serde_json::to_value(builder.build()).expect("serialize order data")
+	}
+
+	#[test]
+	fn offchain_escrow_shape_requires_prepare() {
+		let order = order_with_data(eip7683_data(LockType::Permit2Escrow, true, true, true));
+
+		assert!(order_requires_preparation(&order));
+	}
+
+	#[test]
+	fn offchain_eip3009_shape_requires_prepare() {
+		let order = order_with_data(eip7683_data(LockType::Eip3009Escrow, true, true, true));
+
+		assert!(order_requires_preparation(&order));
+	}
+
+	#[test]
+	fn resource_lock_shape_does_not_require_prepare() {
+		let order = order_with_data(eip7683_data(LockType::ResourceLock, true, true, true));
+
+		assert!(!order_requires_preparation(&order));
+	}
+
+	#[test]
+	fn onchain_escrow_shape_without_sponsor_or_signature_does_not_require_prepare() {
+		let order = order_with_data(eip7683_data(LockType::Permit2Escrow, true, false, false));
+
+		assert!(!order_requires_preparation(&order));
+	}
+
+	#[test]
+	fn non_eip7683_order_does_not_require_prepare() {
+		let order = OrderBuilder::new()
+			.with_standard("other-standard")
+			.with_data(serde_json::json!({ "not": "eip7683" }))
+			.build();
+
+		assert!(!order_requires_preparation(&order));
+	}
+
+	#[test]
+	fn unparseable_eip7683_data_does_not_require_prepare() {
+		let order = order_with_data(serde_json::json!({ "not": "eip7683" }));
+
+		assert!(!order_requires_preparation(&order));
+	}
+}

--- a/crates/solver-core/src/recovery/mod.rs
+++ b/crates/solver-core/src/recovery/mod.rs
@@ -8,6 +8,7 @@ mod chain_evidence;
 
 use crate::bump::lineage::{lineage_components, lineage_tip};
 use crate::engine::event_bus::EventBus;
+use crate::order_preparation::order_requires_preparation;
 use crate::state::order::{
 	FAILED_STATUS_KIND_INDEX_VALUE, FINALIZED_STATUS_KIND_INDEX_VALUE, STATUS_KIND_INDEX_FIELD,
 };
@@ -18,9 +19,9 @@ use solver_delivery::DeliveryService;
 use solver_settlement::{SettlementReadiness, SettlementService};
 use solver_storage::{QueryFilter, StorageService};
 use solver_types::{
-	with_0x_prefix, DeliveryEvent, Intent, Order, OrderEvent, OrderStatus, SettlementEvent,
-	SolverEvent, StorageKey, TransactionAttempt, TransactionAttemptStatus, TransactionHash,
-	TransactionReceipt, TransactionType,
+	standards::eip7683::Eip7683OrderData, with_0x_prefix, DeliveryEvent, Intent, IntentMetadata,
+	Order, OrderEvent, OrderStatus, SettlementEvent, SolverEvent, StorageKey, TransactionAttempt,
+	TransactionAttemptStatus, TransactionHash, TransactionReceipt, TransactionType,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -45,6 +46,8 @@ pub enum RecoveryError {
 /// comparing its stored state with the actual blockchain state during recovery.
 #[derive(Debug)]
 enum ReconcileResult {
+	/// Off-chain escrow order needs origin-chain prepare/openFor before fill.
+	NeedsPrepare,
 	/// Order needs initial execution (no transactions yet)
 	NeedsExecution,
 	/// Prepare confirmed, needs fill transaction
@@ -1315,8 +1318,13 @@ impl RecoveryService {
 			StageResolution::NotFound => { /* fall through to NeedsExecution */ },
 		}
 
-		// No transactions yet, needs execution
-		Ok((order, ReconcileResult::NeedsExecution))
+		// No transactions yet. Off-chain escrow orders must be opened on the
+		// origin chain before any destination fill can be submitted.
+		if order_requires_preparation(&order) && order.prepare_tx_hash.is_none() {
+			Ok((order, ReconcileResult::NeedsPrepare))
+		} else {
+			Ok((order, ReconcileResult::NeedsExecution))
+		}
 	}
 
 	/// Ensures the order is in the correct state based on reconciliation result.
@@ -1334,14 +1342,16 @@ impl RecoveryService {
 	/// The updated order with the correct status, or the original if update fails
 	async fn ensure_correct_state(&self, order: Order, result: &ReconcileResult) -> Order {
 		let target_status = match result {
+			ReconcileResult::NeedsPrepare => {
+				// Preserve the persisted state. In particular, do not force Pending
+				// back to Created; Pending -> Created is not a valid state-machine edge.
+				order.status.clone()
+			},
 			ReconcileResult::NeedsExecution => {
-				// No transactions yet, should be in Created or Executing (for on-chain)
-				if order.prepare_tx_hash.is_none() && order.execution_params.is_some() {
-					// On-chain intent with execution params, should be Executing
+				if !order_requires_preparation(&order) && order.execution_params.is_some() {
 					OrderStatus::Executing
 				} else {
-					// Off-chain intent, should stay in Created
-					OrderStatus::Created
+					order.status.clone()
 				}
 			},
 			ReconcileResult::NeedsFill => {
@@ -1423,6 +1433,32 @@ impl RecoveryService {
 		}
 	}
 
+	fn recovery_intent_for_prepare(order: &Order) -> Option<Intent> {
+		let order_data: Eip7683OrderData = serde_json::from_value(order.data.clone()).ok()?;
+		let raw_order_data = order_data.raw_order_data.as_ref()?;
+		let lock_type = order_data.lock_type?;
+		let order_bytes = alloy_primitives::Bytes::from(
+			hex::decode(solver_types::without_0x_prefix(raw_order_data)).ok()?,
+		);
+
+		// `handle_preparation` consumes only `source`; remaining fields keep the
+		// transient recovery intent complete for event consumers.
+		Some(Intent {
+			id: order.id.clone(),
+			source: "off-chain".to_string(),
+			standard: order.standard.clone(),
+			metadata: IntentMetadata {
+				requires_auction: false,
+				exclusive_until: None,
+				discovered_at: solver_types::current_timestamp(),
+			},
+			data: order.data.clone(),
+			order_bytes,
+			quote_id: order.quote_id.clone(),
+			lock_type: lock_type.to_string(),
+		})
+	}
+
 	/// Publishes appropriate event based on reconciliation result.
 	///
 	/// This method converts the reconciliation result into the appropriate
@@ -1437,6 +1473,29 @@ impl RecoveryService {
 		// First ensure the order is in the correct state
 		let order = self.ensure_correct_state(order, &result).await;
 		match result {
+			ReconcileResult::NeedsPrepare => {
+				let Some(params) = order.execution_params.clone() else {
+					tracing::error!(
+						"Order {} missing execution params, cannot resume preparation",
+						order.id
+					);
+					return;
+				};
+				let Some(intent) = Self::recovery_intent_for_prepare(&order) else {
+					tracing::error!(
+						"Order {} missing recovery intent data, cannot resume preparation",
+						order.id
+					);
+					return;
+				};
+				self.event_bus
+					.publish(SolverEvent::Order(OrderEvent::Preparing {
+						intent,
+						order,
+						params,
+					}))
+					.ok();
+			},
 			ReconcileResult::NeedsExecution => {
 				// Order needs initial execution
 				if let Some(params) = order.execution_params.clone() {
@@ -1757,7 +1816,8 @@ mod tests {
 		MockStorageInterface,
 	};
 	use solver_types::{
-		utils::tests::builders::{IntentBuilder, OrderBuilder},
+		standards::eip7683::LockType,
+		utils::tests::builders::{Eip7683OrderDataBuilder, IntentBuilder, OrderBuilder},
 		Address, ExecutionParams, FillProof, Transaction, TransactionAttempt,
 		TransactionAttemptStatus, TransactionHash,
 	};
@@ -1843,6 +1903,52 @@ mod tests {
 				gas_price: alloy_primitives::U256::from(1000000000u64),
 				priority_fee: Some(alloy_primitives::U256::from(1000000u64)),
 			}))
+			.build()
+	}
+
+	fn offchain_escrow_order_with_status(status: OrderStatus) -> Order {
+		let order_data = Eip7683OrderDataBuilder::new()
+			.lock_type(LockType::Permit2Escrow)
+			.raw_order_data("0x1234")
+			.sponsor("0x1111111111111111111111111111111111111111")
+			.signature("0xabcdef")
+			.build();
+
+		OrderBuilder::new()
+			.with_status(status)
+			.with_data(serde_json::to_value(order_data).unwrap())
+			.with_execution_params(Some(ExecutionParams {
+				gas_price: alloy_primitives::U256::from(1000000000u64),
+				priority_fee: Some(alloy_primitives::U256::from(1000000u64)),
+			}))
+			.with_prepare_tx_hash(None)
+			.with_fill_tx_hash(None)
+			.with_post_fill_tx_hash(None)
+			.with_pre_claim_tx_hash(None)
+			.with_claim_tx_hash(None)
+			.build()
+	}
+
+	fn resource_lock_order_with_status(status: OrderStatus) -> Order {
+		let order_data = Eip7683OrderDataBuilder::new()
+			.lock_type(LockType::ResourceLock)
+			.raw_order_data("0x1234")
+			.sponsor("0x1111111111111111111111111111111111111111")
+			.signature("0xabcdef")
+			.build();
+
+		OrderBuilder::new()
+			.with_status(status)
+			.with_data(serde_json::to_value(order_data).unwrap())
+			.with_execution_params(Some(ExecutionParams {
+				gas_price: alloy_primitives::U256::from(1000000000u64),
+				priority_fee: Some(alloy_primitives::U256::from(1000000u64)),
+			}))
+			.with_prepare_tx_hash(None)
+			.with_fill_tx_hash(None)
+			.with_post_fill_tx_hash(None)
+			.with_pre_claim_tx_hash(None)
+			.with_claim_tx_hash(None)
 			.build()
 	}
 
@@ -3571,6 +3677,96 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn publish_recovery_event_needs_prepare_emits_preparing() {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let order = offchain_escrow_order_with_status(OrderStatus::Pending);
+		let expected_params = order.execution_params.clone().unwrap();
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		state_machine.store_order(&order).await.unwrap();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let mut receiver = event_bus.subscribe();
+		let (attempt_store, _attempts_tmp) = empty_attempt_store();
+
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+			empty_networks_config(),
+		);
+
+		recovery_service
+			.publish_recovery_event(order.clone(), ReconcileResult::NeedsPrepare)
+			.await;
+
+		let event = receiver.try_recv().unwrap();
+		match event {
+			SolverEvent::Order(OrderEvent::Preparing {
+				intent,
+				order: event_order,
+				params,
+			}) => {
+				assert_eq!(intent.source, "off-chain");
+				assert_eq!(event_order.id, order.id);
+				assert_eq!(event_order.status, OrderStatus::Pending);
+				assert_eq!(params.gas_price, expected_params.gas_price);
+				assert_eq!(params.priority_fee, expected_params.priority_fee);
+			},
+			_ => panic!("Expected Order::Preparing event"),
+		}
+	}
+
+	#[tokio::test]
+	async fn publish_recovery_event_needs_execution_for_no_prepare_order() {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let order = resource_lock_order_with_status(OrderStatus::Created);
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		state_machine.store_order(&order).await.unwrap();
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let mut receiver = event_bus.subscribe();
+		let (attempt_store, _attempts_tmp) = empty_attempt_store();
+
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+			empty_networks_config(),
+		);
+
+		recovery_service
+			.publish_recovery_event(order.clone(), ReconcileResult::NeedsExecution)
+			.await;
+
+		let event = receiver.try_recv().unwrap();
+		match event {
+			SolverEvent::Order(OrderEvent::Executing {
+				order: event_order,
+				params: _,
+			}) => {
+				assert_eq!(event_order.id, order.id);
+			},
+			_ => panic!("Expected Order::Executing event"),
+		}
+	}
+
+	#[tokio::test]
 	async fn test_publish_recovery_event_needs_pre_claim_waiting_starts_monitoring() {
 		let mut mock_settlement = MockSettlementInterface::new();
 		let mut order = create_test_order_with_status(OrderStatus::Executed);
@@ -4598,6 +4794,87 @@ mod tests {
 			.unwrap();
 		// All chain probes returned empty, fall through all stages → NeedsExecution.
 		assert!(matches!(result, ReconcileResult::NeedsExecution));
+	}
+
+	#[tokio::test]
+	async fn reconcile_offchain_escrow_without_prepare_needs_prepare() {
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let attempt_store = Arc::new(TransactionAttemptStore::new(storage.clone()));
+
+		let order = offchain_escrow_order_with_status(OrderStatus::Pending);
+		state_machine.store_order(&order).await.unwrap();
+
+		let mut networks_map = solver_types::NetworksConfig::new();
+		networks_map.insert(
+			1,
+			test_network_config(Address(vec![0xcc; 20]), Address(vec![0xaa; 20])),
+		);
+		networks_map.insert(
+			137,
+			test_network_config(Address(vec![0xcc; 20]), Address(vec![0xaa; 20])),
+		);
+		let networks = Arc::new(networks_map);
+
+		let mut mock_delivery_1 = MockDeliveryInterface::new();
+		mock_delivery_1
+			.expect_get_block_number()
+			.with(eq(1u64))
+			.times(2)
+			.returning(|_| Box::pin(async move { Ok(20_000_000u64) }));
+		mock_delivery_1
+			.expect_get_logs()
+			.times(4)
+			.returning(|_, _| Box::pin(async move { Ok(vec![]) }));
+
+		let mut mock_delivery_137 = MockDeliveryInterface::new();
+		mock_delivery_137
+			.expect_get_block_number()
+			.with(eq(137u64))
+			.times(1)
+			.returning(|_| Box::pin(async move { Ok(1_000_000u64) }));
+		mock_delivery_137
+			.expect_get_logs()
+			.times(1)
+			.returning(|_, _| Box::pin(async move { Ok(vec![]) }));
+
+		let delivery = Arc::new(DeliveryService::new(
+			HashMap::from([
+				(
+					1u64,
+					Arc::new(mock_delivery_1) as Arc<dyn solver_delivery::DeliveryInterface>,
+				),
+				(
+					137u64,
+					Arc::new(mock_delivery_137) as Arc<dyn solver_delivery::DeliveryInterface>,
+				),
+			]),
+			1,
+			20,
+			60,
+		));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine,
+			delivery,
+			settlement,
+			EventBus::new(100),
+			attempt_store,
+			networks,
+		);
+
+		let (_repaired, result) = recovery_service
+			.reconcile_with_blockchain(&order)
+			.await
+			.unwrap();
+
+		assert!(matches!(result, ReconcileResult::NeedsPrepare));
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

Restart recovery could fill off-chain EIP-7683 **escrow** intents whose origin-chain inputs were never escrowed, stranding solver funds.

Recovery inferred "on-chain / no-prepare" from `prepare_tx_hash.is_none() && execution_params.is_some()`. But the intent handler persists `execution_params` **before** publishing `OrderEvent::Preparing`, so an off-chain escrow order that crashes in that window matches the same condition. On restart it was marked `Executing` and filled on the destination chain even though `openFor` never ran on origin — leaving the fill unreimbursable.

## Fix

- **Shared classifier** (`order_preparation.rs`): EIP-7683-scoped `order_requires_preparation` — escrow lock (`Permit2Escrow`/`Eip3009Escrow`) with `raw_order_data` + `sponsor` + `signature` present. The `sponsor`+`signature` pair distinguishes off-chain escrow from on-chain orders (on-chain leaves both `None`), so on-chain and ResourceLock orders are correctly classified as no-prepare.
- **Recovery routing**: new `ReconcileResult::NeedsPrepare`. Prepare-required orders without a prepare hash now republish `OrderEvent::Preparing` (resuming `openFor`) instead of being advanced to `Executing`. Replaces the fragile `prepare_tx_hash`/`execution_params` heuristic in `ensure_correct_state`.
- **Fail-closed fill guard**: `handle_execution` rejects any prepare-required order that reaches fill submission without `prepare_tx_hash`.

Recovery routing and the fill guard are a single safety unit — the guard alone would convert the data-loss window into a stuck order, so both ship together. No `Order` storage-schema change.

## Testing

- `order_preparation`: escrow / EIP-3009 / ResourceLock / on-chain-shape / non-EIP-7683 / unparseable
- recovery: `reconcile_offchain_escrow_without_prepare_needs_prepare`, `publish_recovery_event_needs_prepare_emits_preparing`, `publish_recovery_event_needs_execution_for_no_prepare_order`
- `handle_execution`: rejects off-chain escrow without prepare hash (asserts no fill is generated); allows off-chain-escrow-with-hash, on-chain escrow, and ResourceLock

`cargo test -p solver-core`/`-order`/`-types`, `cargo check --all-targets --all-features`, `cargo check -p solver-e2e-tests`, `cargo fmt --all -- --check`, and `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Orders requiring off-chain preparation now validate the presence of a preparation transaction hash before proceeding with execution.

* **New Features**
  * The system can now distinguish between orders requiring an initial preparation step and those ready for direct execution.
  * Improved handling and recovery flow for escrow orders, including proper state reconciliation based on preparation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->