### PR TITLE
fix: admin auth hardening (M-18, M-25)

### DIFF
--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -915,30 +915,34 @@ async fn ensure_new_token_approvals(
 	Ok(approvals_set)
 }
 
-/// Collects the set of configured settler addresses across all networks the
-/// `TokenManager` currently knows about.
+/// Builds a per-network map of configured settler addresses.
 ///
-/// This is the exact set the safe auto-approval path (`ensure_new_token_approvals`)
-/// is willing to grant allowances to: the non-zero input and output settler
-/// addresses on each network. The admin `approve` endpoint validates its
-/// admin-supplied `spender` against this set so a compromised admin key cannot
-/// grant an arbitrary attacker unlimited allowance — the same blast-radius
-/// reduction the withdrawal recipient allowlist provides for `handle_withdrawal`.
-async fn configured_settler_set(
+/// The value for each chain is the set of non-zero input/output settler
+/// addresses the safe auto-approval path (`ensure_new_token_approvals`) is
+/// willing to grant allowances to ON THAT chain. Keeping the mapping
+/// per-network — rather than a global union — is what lets the admin `approve`
+/// endpoint reject cross-chain address confusion: a settler configured on
+/// chain B must not authorize an approval scoped to chain A, where it has no
+/// settler role.
+async fn configured_settlers_by_chain(
 	token_manager: &TokenManager,
-) -> std::collections::HashSet<solver_types::Address> {
+) -> std::collections::HashMap<u64, std::collections::HashSet<solver_types::Address>> {
 	let zero_address = solver_types::Address(vec![0u8; 20]);
 	let networks = token_manager.get_networks().await;
-	let mut settlers = std::collections::HashSet::new();
-	for network in networks.values() {
+	let mut by_chain: std::collections::HashMap<
+		u64,
+		std::collections::HashSet<solver_types::Address>,
+	> = std::collections::HashMap::new();
+	for (chain_id, network) in networks.iter() {
+		let entry = by_chain.entry(*chain_id).or_default();
 		if network.input_settler_address != zero_address {
-			settlers.insert(network.input_settler_address.clone());
+			entry.insert(network.input_settler_address.clone());
 		}
 		if network.output_settler_address != zero_address {
-			settlers.insert(network.output_settler_address.clone());
+			entry.insert(network.output_settler_address.clone());
 		}
 	}
-	settlers
+	by_chain
 }
 
 /// PUT /api/v1/admin/fees
@@ -1283,23 +1287,49 @@ pub async fn handle_approve_tokens(
 	let approve = contents.to_eip712()?;
 	let spender = solver_types::Address::from(approve.spender);
 
-	// Spender allowlist: the spender MUST be one of the operator-configured
-	// input/output settlers — exactly the set the safe auto-approval path
-	// (`ensure_new_token_approvals`) is willing to grant allowances to. Without
-	// this guard a compromised admin key could `approve(attacker, U256::MAX)`
-	// for all tokens on all chains, bypassing the equivalent control the
-	// sibling `handle_withdrawal` enforces via its recipient allowlist. This
-	// also rejects the fully-wildcarded chainId=0 + token=0x0 + U256::MAX
-	// combination unless the spender is a configured settler.
-	let settlers = configured_settler_set(&state.token_manager).await;
-	if !settlers.contains(&spender) {
+	// Per-network spender allowlist: the spender MUST be a configured
+	// input/output settler ON EVERY CHAIN this approval would touch — exactly the
+	// set the safe auto-approval path (`ensure_new_token_approvals`) is willing to
+	// grant allowances to on that chain. Validating per-network (rather than
+	// against a global union of all settlers) closes the cross-chain address
+	// confusion hole: a settler configured only on chain B must not authorize an
+	// approval scoped to chain A, where it has no settler role. Without this guard
+	// a compromised admin key could `approve(attacker, U256::MAX)`, bypassing the
+	// equivalent control the sibling `handle_withdrawal` enforces via its
+	// recipient allowlist. This also rejects the fully-wildcarded chainId=0 +
+	// token=0x0 + U256::MAX combination unless the spender is a configured settler
+	// on every affected chain.
+	let settlers_by_chain = configured_settlers_by_chain(&state.token_manager).await;
+
+	// The chains this approval would actually touch: a specific chain when one is
+	// requested, or every chain the token manager knows about for the all-chains
+	// scope (mirrors `ensure_approvals_for_spender_scope`'s chain iteration).
+	let affected_chains: Vec<u64> = if contents.is_all_chains() {
+		settlers_by_chain.keys().copied().collect()
+	} else {
+		vec![contents.chain_id]
+	};
+
+	// Reject if there is no chain to authorize against (e.g. an all-chains scope
+	// on a solver with no configured networks), or if the spender is not a
+	// configured settler on any one of the affected chains.
+	let authorized = !affected_chains.is_empty()
+		&& affected_chains.iter().all(|chain_id| {
+			settlers_by_chain
+				.get(chain_id)
+				.is_some_and(|settlers| settlers.contains(&spender))
+		});
+
+	if !authorized {
 		tracing::warn!(
 			admin = %hex::encode(&admin.0),
 			spender = %with_0x_prefix(&hex::encode(&spender.0)),
-			"Rejected token approval: spender is not a configured settler"
+			chains = ?affected_chains,
+			"Rejected token approval: spender is not a configured settler on every affected chain"
 		);
 		return Err(AdminAuthError::NotAuthorized(
-			"Approval spender is not a configured input/output settler".to_string(),
+			"Approval spender is not a configured input/output settler on every affected chain"
+				.to_string(),
 		));
 	}
 
@@ -3407,6 +3437,207 @@ mod tests {
 			.0;
 		assert!(response.success);
 		assert_eq!(response.approved_count, 1);
+	}
+
+	/// Build an admin state whose `TokenManager` knows two chains with DISTINCT
+	/// settler pairs:
+	///   - chain 1: input `0x1111`, output `0x2222`, token `0x5555`
+	///   - chain 2: input `0x3333`, output `0x4444`, token `0x6666`
+	///
+	/// This is the setup the per-network spender validation (M-18) needs: a
+	/// global union of settlers would accept `0x4444` for an approval scoped to
+	/// chain 1, even though `0x4444` is only chain 2's settler.
+	async fn create_admin_state_with_two_settler_networks(expect_submit: bool) -> AdminApiState {
+		use solver_types::networks::RpcEndpoint;
+		use solver_types::{NetworkConfig as RuntimeNetworkConfig, TokenConfig};
+
+		let admin_alloy = alloy_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+		let withdrawals = OperatorWithdrawalsConfig {
+			enabled: true,
+			recipient_allowlist: vec![],
+		};
+
+		let make_mock = || {
+			let mut mock_delivery = MockDeliveryInterface::new();
+			mock_delivery
+				.expect_get_allowance()
+				.returning(|_, _, _, _| Box::pin(async { Ok("0".to_string()) }));
+			if expect_submit {
+				mock_delivery.expect_submit().returning(|_, _| {
+					Box::pin(async { Ok(solver_types::TransactionHash(vec![0x11; 32])) })
+				});
+			} else {
+				// The on-chain approve MUST NOT be attempted for a rejected request.
+				mock_delivery.expect_submit().times(0);
+			}
+			mock_delivery.expect_config_schema().returning(|| {
+				Box::new(solver_delivery::implementations::evm::alloy::AlloyDeliverySchema)
+			});
+			mock_delivery
+		};
+
+		let mut implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		implementations.insert(1, Arc::new(make_mock()));
+		implementations.insert(2, Arc::new(make_mock()));
+		let delivery = Arc::new(DeliveryService::new(implementations, 1, 30, 60));
+
+		let operator_config = build_operator_config(admin_alloy, withdrawals);
+		let state = create_admin_state_with_operator_config(operator_config, delivery).await;
+
+		let mut networks = NetworksConfig::default();
+		networks.insert(
+			1,
+			RuntimeNetworkConfig {
+				name: Some("chain-1".to_string()),
+				network_type: solver_types::NetworkType::Parent,
+				rpc_urls: vec![RpcEndpoint {
+					http: Some("http://localhost:8545".to_string()),
+					ws: None,
+				}],
+				input_settler_address: solver_address("0x1111111111111111111111111111111111111111"),
+				output_settler_address: solver_address(
+					"0x2222222222222222222222222222222222222222",
+				),
+				tokens: vec![TokenConfig {
+					address: solver_address("0x5555555555555555555555555555555555555555"),
+					symbol: "USDC".to_string(),
+					name: Some("USD Coin".to_string()),
+					decimals: 6,
+				}],
+				input_settler_compact_address: None,
+				the_compact_address: None,
+				allocator_address: None,
+			},
+		);
+		networks.insert(
+			2,
+			RuntimeNetworkConfig {
+				name: Some("chain-2".to_string()),
+				network_type: solver_types::NetworkType::New,
+				rpc_urls: vec![RpcEndpoint {
+					http: Some("http://localhost:8546".to_string()),
+					ws: None,
+				}],
+				input_settler_address: solver_address("0x3333333333333333333333333333333333333333"),
+				output_settler_address: solver_address(
+					"0x4444444444444444444444444444444444444444",
+				),
+				tokens: vec![TokenConfig {
+					address: solver_address("0x6666666666666666666666666666666666666666"),
+					symbol: "USDT".to_string(),
+					name: Some("Tether".to_string()),
+					decimals: 6,
+				}],
+				input_settler_compact_address: None,
+				the_compact_address: None,
+				allocator_address: None,
+			},
+		);
+		state.token_manager.update_networks(networks).await;
+
+		state
+	}
+
+	#[tokio::test]
+	async fn test_approve_settler_from_other_chain_is_rejected() {
+		// M-18: cross-chain address confusion. `0x4444` is chain 2's output
+		// settler but is NOT a settler on chain 1. An approval scoped to chain 1
+		// naming `0x4444` as spender must be REJECTED — a global settler union
+		// would wrongly accept it and grant an allowance on chain 1 to an
+		// address that has no settler role there.
+		let state = create_admin_state_with_two_settler_networks(false).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 1,
+			token_address: alloy_address("0x5555555555555555555555555555555555555555"),
+			spender: alloy_address("0x4444444444444444444444444444444444444444"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let result = handle_approve_tokens(State(state), verified).await;
+		match result {
+			Err(AdminAuthError::NotAuthorized(msg)) => {
+				assert!(
+					msg.contains("settler"),
+					"expected settler message, got {msg}"
+				);
+			},
+			Err(other) => panic!("expected NotAuthorized(settler), got {other:?}"),
+			Ok(_) => {
+				panic!("settler from another chain must be rejected for a chain-scoped approval")
+			},
+		}
+	}
+
+	#[tokio::test]
+	async fn test_approve_settler_on_requested_chain_is_allowed() {
+		// The legitimate counterpart: `0x2222` IS chain 1's output settler, so an
+		// approval scoped to chain 1 naming `0x2222` must still succeed.
+		let state = create_admin_state_with_two_settler_networks(true).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 1,
+			token_address: alloy_address("0x5555555555555555555555555555555555555555"),
+			spender: alloy_address("0x2222222222222222222222222222222222222222"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let response = handle_approve_tokens(State(state), verified)
+			.await
+			.unwrap()
+			.0;
+		assert!(response.success);
+		assert_eq!(response.approved_count, 1);
+	}
+
+	#[tokio::test]
+	async fn test_approve_all_chains_partial_settler_is_rejected() {
+		// M-18 all-chains scope: `0x2222` is chain 1's settler but NOT a settler
+		// on chain 2. An all-chains approval would touch chain 2 too, where
+		// `0x2222` has no settler role — so the request must be rejected.
+		let state = create_admin_state_with_two_settler_networks(false).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 0,                         // all chains
+			token_address: zero_alloy_address(), // all tokens
+			spender: alloy_address("0x2222222222222222222222222222222222222222"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let result = handle_approve_tokens(State(state), verified).await;
+		match result {
+			Err(AdminAuthError::NotAuthorized(msg)) => {
+				assert!(
+					msg.contains("settler"),
+					"expected settler message, got {msg}"
+				);
+			},
+			Err(other) => panic!("expected NotAuthorized(settler), got {other:?}"),
+			Ok(_) => {
+				panic!("all-chains approval must be rejected when spender is not a settler on every chain")
+			},
+		}
 	}
 
 	#[test]

--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -915,6 +915,32 @@ async fn ensure_new_token_approvals(
 	Ok(approvals_set)
 }
 
+/// Collects the set of configured settler addresses across all networks the
+/// `TokenManager` currently knows about.
+///
+/// This is the exact set the safe auto-approval path (`ensure_new_token_approvals`)
+/// is willing to grant allowances to: the non-zero input and output settler
+/// addresses on each network. The admin `approve` endpoint validates its
+/// admin-supplied `spender` against this set so a compromised admin key cannot
+/// grant an arbitrary attacker unlimited allowance — the same blast-radius
+/// reduction the withdrawal recipient allowlist provides for `handle_withdrawal`.
+async fn configured_settler_set(
+	token_manager: &TokenManager,
+) -> std::collections::HashSet<solver_types::Address> {
+	let zero_address = solver_types::Address(vec![0u8; 20]);
+	let networks = token_manager.get_networks().await;
+	let mut settlers = std::collections::HashSet::new();
+	for network in networks.values() {
+		if network.input_settler_address != zero_address {
+			settlers.insert(network.input_settler_address.clone());
+		}
+		if network.output_settler_address != zero_address {
+			settlers.insert(network.output_settler_address.clone());
+		}
+	}
+	settlers
+}
+
 /// PUT /api/v1/admin/fees
 ///
 /// Update fee configuration (gas buffer, minimum profitability, commission, rate buffer).
@@ -1256,6 +1282,26 @@ pub async fn handle_approve_tokens(
 	// 1. Parse amount and determine the scope
 	let approve = contents.to_eip712()?;
 	let spender = solver_types::Address::from(approve.spender);
+
+	// Spender allowlist: the spender MUST be one of the operator-configured
+	// input/output settlers — exactly the set the safe auto-approval path
+	// (`ensure_new_token_approvals`) is willing to grant allowances to. Without
+	// this guard a compromised admin key could `approve(attacker, U256::MAX)`
+	// for all tokens on all chains, bypassing the equivalent control the
+	// sibling `handle_withdrawal` enforces via its recipient allowlist. This
+	// also rejects the fully-wildcarded chainId=0 + token=0x0 + U256::MAX
+	// combination unless the spender is a configured settler.
+	let settlers = configured_settler_set(&state.token_manager).await;
+	if !settlers.contains(&spender) {
+		tracing::warn!(
+			admin = %hex::encode(&admin.0),
+			spender = %with_0x_prefix(&hex::encode(&spender.0)),
+			"Rejected token approval: spender is not a configured settler"
+		);
+		return Err(AdminAuthError::NotAuthorized(
+			"Approval spender is not a configured input/output settler".to_string(),
+		));
+	}
 
 	let token_filter = if contents.is_all_tokens() {
 		None
@@ -3189,6 +3235,178 @@ mod tests {
 		assert!(json.contains("\"success\":true"));
 		assert!(json.contains("\"approvedCount\":5"));
 		assert!(json.contains("\"chainsProcessed\":[1,10,137]"));
+	}
+
+	/// Build an admin state whose `TokenManager` knows a single chain (id 1)
+	/// with a configured input/output settler pair and one supported token.
+	/// `expect_submit` gates whether the mock delivery is allowed to submit an
+	/// on-chain approve transaction — set it to `false` to assert that a
+	/// rejected request never reaches the chain.
+	async fn create_admin_state_with_settler_network(expect_submit: bool) -> AdminApiState {
+		use solver_types::networks::RpcEndpoint;
+		use solver_types::{NetworkConfig as RuntimeNetworkConfig, TokenConfig};
+
+		let admin_alloy = alloy_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+		let withdrawals = OperatorWithdrawalsConfig {
+			enabled: true,
+			recipient_allowlist: vec![],
+		};
+
+		let mut mock_delivery = MockDeliveryInterface::new();
+		// Allowance is queried before any approve to decide whether a tx is
+		// needed; report a non-matching allowance so a permitted spender would
+		// trigger exactly one submit.
+		mock_delivery
+			.expect_get_allowance()
+			.returning(|_, _, _, _| Box::pin(async { Ok("0".to_string()) }));
+		if expect_submit {
+			mock_delivery.expect_submit().returning(|_, _| {
+				Box::pin(async { Ok(solver_types::TransactionHash(vec![0x11; 32])) })
+			});
+		} else {
+			// The on-chain approve MUST NOT be attempted for a rejected request.
+			mock_delivery.expect_submit().times(0);
+		}
+		mock_delivery.expect_config_schema().returning(|| {
+			Box::new(solver_delivery::implementations::evm::alloy::AlloyDeliverySchema)
+		});
+
+		let mut implementations: HashMap<u64, Arc<dyn DeliveryInterface>> = HashMap::new();
+		implementations.insert(1, Arc::new(mock_delivery));
+		let delivery = Arc::new(DeliveryService::new(implementations, 1, 30, 60));
+
+		let operator_config = build_operator_config(admin_alloy, withdrawals);
+		let state = create_admin_state_with_operator_config(operator_config, delivery).await;
+
+		// Populate the TokenManager with a network carrying real settler
+		// addresses and a token, so the allowlist check has a settler set to
+		// validate against.
+		let mut networks = NetworksConfig::default();
+		networks.insert(
+			1,
+			RuntimeNetworkConfig {
+				name: Some("chain-1".to_string()),
+				network_type: solver_types::NetworkType::Parent,
+				rpc_urls: vec![RpcEndpoint {
+					http: Some("http://localhost:8545".to_string()),
+					ws: None,
+				}],
+				input_settler_address: solver_address("0x1111111111111111111111111111111111111111"),
+				output_settler_address: solver_address(
+					"0x2222222222222222222222222222222222222222",
+				),
+				tokens: vec![TokenConfig {
+					address: solver_address("0x5555555555555555555555555555555555555555"),
+					symbol: "USDC".to_string(),
+					name: Some("USD Coin".to_string()),
+					decimals: 6,
+				}],
+				input_settler_compact_address: None,
+				the_compact_address: None,
+				allocator_address: None,
+			},
+		);
+		state.token_manager.update_networks(networks).await;
+
+		state
+	}
+
+	#[tokio::test]
+	async fn test_approve_non_settler_spender_is_rejected() {
+		// A compromised admin key signs an approve targeting an arbitrary
+		// (non-settler) spender. The withdrawal allowlist has a sibling control
+		// (recipient allowlist) — approvals must enforce an equivalent guard so
+		// the spender cannot be an attacker-chosen address. The request must be
+		// rejected BEFORE any on-chain approve is submitted.
+		let state = create_admin_state_with_settler_network(false).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 1,
+			token_address: alloy_address("0x5555555555555555555555555555555555555555"),
+			spender: alloy_address("0xdEAdBeEFdEadBEefDEAdbEEFdeadBEEFDEadBeeF"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let result = handle_approve_tokens(State(state), verified).await;
+		match result {
+			Err(AdminAuthError::NotAuthorized(msg)) => {
+				assert!(
+					msg.contains("settler"),
+					"expected settler message, got {msg}"
+				);
+			},
+			Err(other) => panic!("expected NotAuthorized(settler), got {other:?}"),
+			Ok(_) => panic!("non-settler spender approve must be rejected"),
+		}
+	}
+
+	#[tokio::test]
+	async fn test_approve_wildcard_non_settler_spender_is_rejected() {
+		// The fully-wildcarded scope (all chains + all tokens + max amount) to a
+		// non-settler spender is the worst case: a single signature granting an
+		// attacker unlimited allowance on every token/chain. It must be rejected.
+		let state = create_admin_state_with_settler_network(false).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 0,                         // all chains
+			token_address: zero_alloy_address(), // all tokens
+			spender: alloy_address("0xdEAdBeEFdEadBEefDEAdbEEFdeadBEEFDEadBeeF"),
+			amount: alloy_primitives::U256::MAX.to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let result = handle_approve_tokens(State(state), verified).await;
+		match result {
+			Err(AdminAuthError::NotAuthorized(msg)) => {
+				assert!(
+					msg.contains("settler"),
+					"expected settler message, got {msg}"
+				);
+			},
+			Err(other) => panic!("expected NotAuthorized(settler), got {other:?}"),
+			Ok(_) => panic!("wildcard non-settler spender approve must be rejected"),
+		}
+	}
+
+	#[tokio::test]
+	async fn test_approve_configured_settler_spender_is_allowed() {
+		// The legitimate path: approving a configured settler (here the output
+		// settler) must still succeed and reach the chain.
+		let state = create_admin_state_with_settler_network(true).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 1,
+			token_address: alloy_address("0x5555555555555555555555555555555555555555"),
+			spender: alloy_address("0x2222222222222222222222222222222222222222"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let response = handle_approve_tokens(State(state), verified)
+			.await
+			.unwrap()
+			.0;
+		assert!(response.success);
+		assert_eq!(response.approved_count, 1);
 	}
 
 	#[test]

--- a/crates/solver-service/src/apis/admin.rs
+++ b/crates/solver-service/src/apis/admin.rs
@@ -3412,6 +3412,44 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn test_approve_all_chains_fails_closed_when_no_networks_configured() {
+		// With no configured networks there is no chain-local settler allowlist
+		// against which to authorize an all-chains approval. The request must
+		// fail closed before any allowance query or approve submission.
+		let withdrawals = OperatorWithdrawalsConfig {
+			enabled: true,
+			recipient_allowlist: vec![],
+		};
+		let state = create_admin_state(None, withdrawals, false).await;
+
+		let contents = ApproveTokensContents {
+			chain_id: 0,
+			token_address: zero_alloy_address(),
+			spender: alloy_address("0x2222222222222222222222222222222222222222"),
+			amount: "1000000".to_string(),
+			nonce: 1,
+			deadline: chrono::Utc::now().timestamp() as u64 + 3600,
+		};
+
+		let verified = VerifiedAdmin {
+			admin: solver_address("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+			contents,
+		};
+
+		let result = handle_approve_tokens(State(state), verified).await;
+		match result {
+			Err(AdminAuthError::NotAuthorized(msg)) => {
+				assert!(
+					msg.contains("settler"),
+					"expected settler message, got {msg}"
+				);
+			},
+			Err(other) => panic!("expected NotAuthorized(settler), got {other:?}"),
+			Ok(_) => panic!("all-chains approval must fail closed with no configured networks"),
+		}
+	}
+
+	#[tokio::test]
 	async fn test_approve_configured_settler_spender_is_allowed() {
 		// The legitimate path: approving a configured settler (here the output
 		// settler) must still succeed and reach the chain.

--- a/crates/solver-service/src/apis/auth.rs
+++ b/crates/solver-service/src/apis/auth.rs
@@ -254,13 +254,19 @@ pub async fn register_client(
 /// Handles POST /api/v1/auth/refresh requests.
 ///
 /// This endpoint exchanges a valid refresh token for new access and refresh tokens.
+///
+/// For admin-scoped refresh tokens, the embedded scope is NOT trusted: the
+/// subject is re-checked against the LIVE admin whitelist and its scope is
+/// re-derived from the current role. A removed admin is rejected; a demoted
+/// admin receives the reduced scope. Non-admin (client) tokens keep their
+/// embedded scope unchanged.
 pub async fn refresh_token(
-	State(jwt_service): State<Option<Arc<JwtService>>>,
+	State(state): State<SiweAuthState>,
 	Json(request): Json<RefreshRequest>,
 ) -> impl IntoResponse {
 	// Check if JWT service is configured
-	let jwt_service = match jwt_service {
-		Some(service) => service,
+	let jwt_service = match &state.jwt_service {
+		Some(service) => service.clone(),
 		None => {
 			return (
 				StatusCode::SERVICE_UNAVAILABLE,
@@ -293,12 +299,80 @@ pub async fn refresh_token(
 			.into_response();
 	}
 
-	// Exchange refresh token for new tokens. `refresh_access_token` is the
-	// authoritative refresh-flow gate: it rejects anything that isn't a
-	// refresh-typed JWT, and it hands back the access-token claims it just
-	// constructed so the response can be built without a second decode.
+	// Peek at the refresh token's claims so we can decide whether it is
+	// admin-scoped. `decode_refresh_claims` rejects anything that isn't a
+	// refresh-typed JWT, so it also serves as the type gate.
+	let claims = match jwt_service.decode_refresh_claims(&request.refresh_token) {
+		Ok(claims) => claims,
+		Err(e) => {
+			tracing::warn!("Failed to refresh token: {}", e);
+			return (
+				StatusCode::UNAUTHORIZED,
+				Json(json!({
+					"error": "Invalid or expired refresh token"
+				})),
+			)
+				.into_response();
+		},
+	};
+
+	// Admin-scoped tokens must be re-validated against the LIVE whitelist on
+	// every refresh. Copying the embedded scope would let a removed or demoted
+	// admin self-renew access for the lifetime of the refresh token.
+	let is_admin_scoped = claims
+		.scope
+		.iter()
+		.any(|s| matches!(s, AuthScope::AdminAll | AuthScope::AdminRead));
+
+	let scope_override = if is_admin_scoped {
+		let runtime = match resolve_siwe_runtime_config(&state.config).await {
+			Ok(runtime) => runtime,
+			Err(response) => return response,
+		};
+
+		let address = match parse_eth_address(&claims.sub) {
+			Ok(address) => address,
+			Err(_) => {
+				tracing::warn!(
+					subject = %claims.sub,
+					"Rejected admin token refresh: subject is not a valid address"
+				);
+				return (
+					StatusCode::UNAUTHORIZED,
+					Json(json!({
+						"error": "Admin token subject is not authorized"
+					})),
+				)
+					.into_response();
+			},
+		};
+
+		match resolve_siwe_scopes(&runtime, &address) {
+			Some(scopes) => Some(scopes),
+			None => {
+				tracing::warn!(
+					subject = %claims.sub,
+					"Rejected admin token refresh: subject is no longer an authorized admin"
+				);
+				return (
+					StatusCode::UNAUTHORIZED,
+					Json(json!({
+						"error": "Admin token subject is no longer an authorized admin"
+					})),
+				)
+					.into_response();
+			},
+		}
+	} else {
+		None
+	};
+
+	// Exchange refresh token for new tokens. For admin tokens we pass the
+	// freshly-resolved scope; for client tokens we pass `None` to preserve the
+	// embedded scope. The returned access-token claims are reused for the
+	// response body without a second decode.
 	let (new_access_token, new_refresh_token, access_claims) = match jwt_service
-		.refresh_access_token(&request.refresh_token)
+		.refresh_access_token_with_scopes(&request.refresh_token, scope_override)
 		.await
 	{
 		Ok(tokens) => tokens,
@@ -870,6 +944,17 @@ mod tests {
 		}
 	}
 
+	/// Build a `SiweAuthState` for exercising the `refresh_token` handler.
+	/// `whitelist` is the LIVE admin whitelist the refresh path re-validates
+	/// admin-scoped tokens against; it is irrelevant for non-admin client
+	/// tokens.
+	fn create_refresh_state(
+		jwt_service: Option<Arc<JwtService>>,
+		whitelist: Vec<AdminWhitelistEntry>,
+	) -> SiweAuthState {
+		create_test_siwe_state_with_whitelist(jwt_service, true, whitelist, None)
+	}
+
 	async fn create_signed_siwe_verify_request(
 		nonce_store: &Arc<NonceStore>,
 		signer: &PrivateKeySigner,
@@ -1241,7 +1326,8 @@ mod tests {
 			refresh_token: refresh_token_str,
 		};
 
-		let response = refresh_token(axum::extract::State(Some(jwt_service)), Json(request)).await;
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(axum::extract::State(state), Json(request)).await;
 
 		let response_obj = response.into_response();
 		let (parts, body) = response_obj.into_parts();
@@ -1262,7 +1348,8 @@ mod tests {
 			refresh_token: "some-token".to_string(),
 		};
 
-		let response = refresh_token(axum::extract::State(None), Json(request)).await;
+		let state = create_refresh_state(None, vec![]);
+		let response = refresh_token(axum::extract::State(state), Json(request)).await;
 
 		let response_obj = response.into_response();
 		let (parts, body) = response_obj.into_parts();
@@ -1282,7 +1369,8 @@ mod tests {
 			refresh_token: "".to_string(),
 		};
 
-		let response = refresh_token(axum::extract::State(Some(jwt_service)), Json(request)).await;
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(axum::extract::State(state), Json(request)).await;
 
 		let response_obj = response.into_response();
 		let (parts, body) = response_obj.into_parts();
@@ -1299,7 +1387,8 @@ mod tests {
 			refresh_token: "some-token".to_string(),
 		};
 
-		let response = refresh_token(axum::extract::State(Some(jwt_service)), Json(request)).await;
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(axum::extract::State(state), Json(request)).await;
 
 		let response_obj = response.into_response();
 		let (parts, body) = response_obj.into_parts();
@@ -1318,7 +1407,8 @@ mod tests {
 			refresh_token: "invalid-token".to_string(),
 		};
 
-		let response = refresh_token(axum::extract::State(Some(jwt_service)), Json(request)).await;
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(axum::extract::State(state), Json(request)).await;
 
 		let response_obj = response.into_response();
 		let (parts, body) = response_obj.into_parts();
@@ -1452,8 +1542,17 @@ mod tests {
 		let original_refresh_token = siwe_tokens.refresh_token.clone();
 		assert_eq!(siwe_tokens.scopes, vec!["admin-all"]);
 
+		// Live whitelist still lists the signer as Admin — the refresh must
+		// succeed and preserve the full admin scope.
+		let refresh_state = create_refresh_state(
+			Some(jwt_service.clone()),
+			vec![AdminWhitelistEntry {
+				address: signer_address,
+				role: AdminRole::Admin,
+			}],
+		);
 		let refresh_response = refresh_token(
-			State(Some(jwt_service.clone())),
+			State(refresh_state),
 			Json(RefreshRequest {
 				refresh_token: original_refresh_token.clone(),
 			}),
@@ -1481,6 +1580,93 @@ mod tests {
 			.validate_token(&refreshed_tokens.refresh_token)
 			.expect_err("rotated refresh token must not validate as access");
 		assert!(matches!(err, AuthError::InvalidAccessToken(_)));
+	}
+
+	/// M-25 (a): An admin-scoped refresh token whose subject has been removed
+	/// from the LIVE admin whitelist must be rejected. Copying the embedded
+	/// scope would let a removed admin self-renew access for the full lifetime
+	/// of the refresh token (up to 30 days).
+	#[tokio::test]
+	async fn test_refresh_removed_admin_is_rejected() {
+		let jwt_service = create_test_jwt_service_with(true, false);
+		let signer = create_test_siwe_signer();
+		let signer_address = signer.address();
+
+		// Admin minted a refresh token while whitelisted.
+		let refresh_token_str = jwt_service
+			.generate_refresh_token(&signer_address.to_string(), vec![AuthScope::AdminAll])
+			.await
+			.unwrap();
+
+		// They have since been removed: the live whitelist no longer lists them.
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(
+			axum::extract::State(state),
+			Json(RefreshRequest {
+				refresh_token: refresh_token_str,
+			}),
+		)
+		.await;
+
+		let response_obj = response.into_response();
+		let (parts, _body) = response_obj.into_parts();
+		assert_eq!(
+			parts.status,
+			StatusCode::UNAUTHORIZED,
+			"a removed admin must not be able to refresh an admin-scoped token"
+		);
+	}
+
+	/// M-25 (b): A demoted admin's refreshed token must carry the CURRENT
+	/// reduced scope (admin-read), not the elevated scope embedded in the old
+	/// refresh token (admin-all).
+	#[tokio::test]
+	async fn test_refresh_demoted_admin_gets_reduced_scope() {
+		let jwt_service = create_test_jwt_service_with(true, false);
+		let signer = create_test_siwe_signer();
+		let signer_address = signer.address();
+
+		// Admin minted a full-admin refresh token while elevated.
+		let refresh_token_str = jwt_service
+			.generate_refresh_token(&signer_address.to_string(), vec![AuthScope::AdminAll])
+			.await
+			.unwrap();
+
+		// They have since been demoted to read-only in the live whitelist.
+		let state = create_refresh_state(
+			Some(jwt_service.clone()),
+			vec![AdminWhitelistEntry {
+				address: signer_address,
+				role: AdminRole::ReadOnly,
+			}],
+		);
+		let response = refresh_token(
+			axum::extract::State(state),
+			Json(RefreshRequest {
+				refresh_token: refresh_token_str,
+			}),
+		)
+		.await;
+
+		let response_obj = response.into_response();
+		let (parts, body) = response_obj.into_parts();
+		assert_eq!(parts.status, StatusCode::OK);
+
+		let json_body = extract_json_from_body(body).await;
+		let refreshed: RegisterResponse = serde_json::from_value(json_body).unwrap();
+		assert_eq!(
+			refreshed.scopes,
+			vec!["admin-read"],
+			"refreshed token must carry the demoted (read-only) scope, not the embedded admin-all"
+		);
+
+		// The encoded access token must also carry only the reduced scope.
+		let access_claims = jwt_service.validate_token(&refreshed.access_token).unwrap();
+		assert_eq!(access_claims.scope, vec![AuthScope::AdminRead]);
+		assert!(!JwtService::check_scope(
+			&access_claims,
+			&AuthScope::AdminAll
+		));
 	}
 
 	/// Locks in the API-separation hot-fix on the verify path: SIWE verify must

--- a/crates/solver-service/src/apis/auth.rs
+++ b/crates/solver-service/src/apis/auth.rs
@@ -646,18 +646,22 @@ fn resolve_siwe_scopes(
 	}
 }
 
-/// Returns `true` iff `subject` still resolves to an admin role in the LIVE
-/// admin whitelist.
+/// Returns `true` iff `subject` still resolves to a live admin role whose
+/// current scopes grant `required_scope`.
 ///
 /// This is the same live-config / whitelist source the refresh path consults
 /// (`resolve_siwe_runtime_config` + `SiweRuntimeConfig::role_for`, ultimately
 /// `AdminConfig::normalized_whitelist`). The auth middleware reuses it so an
 /// already-issued admin access token stops working the moment the admin is
-/// removed or admin auth is disabled — instead of remaining valid until the
-/// token's own expiry. A `false` result covers both "no longer whitelisted"
-/// and "admin auth is not configured / disabled" (in which case
+/// removed or demoted below the route's required scope — instead of remaining
+/// valid until the token's own expiry. A `false` result covers both "no longer
+/// whitelisted" and "admin auth is not configured / disabled" (in which case
 /// `resolve_siwe_runtime_config` errors).
-pub async fn is_live_admin_subject(config: &Arc<RwLock<Config>>, subject: &str) -> bool {
+pub async fn is_live_admin_subject_authorized(
+	config: &Arc<RwLock<Config>>,
+	subject: &str,
+	required_scope: &AuthScope,
+) -> bool {
 	let runtime = match resolve_siwe_runtime_config(config).await {
 		Ok(runtime) => runtime,
 		Err(_) => return false,
@@ -666,7 +670,9 @@ pub async fn is_live_admin_subject(config: &Arc<RwLock<Config>>, subject: &str) 
 		Ok(address) => address,
 		Err(_) => return false,
 	};
-	runtime.role_for(&address).is_some()
+	resolve_siwe_scopes(&runtime, &address)
+		.map(|scopes| scopes.iter().any(|scope| scope.grants(required_scope)))
+		.unwrap_or(false)
 }
 
 async fn siwe_dependencies(

--- a/crates/solver-service/src/apis/auth.rs
+++ b/crates/solver-service/src/apis/auth.rs
@@ -278,16 +278,6 @@ pub async fn refresh_token(
 		},
 	};
 
-	if !jwt_service.config().orders_auth_enabled {
-		return (
-			StatusCode::SERVICE_UNAVAILABLE,
-			Json(json!({
-				"error": "Public-client JWT authentication is disabled (orders_auth_enabled = false)"
-			})),
-		)
-			.into_response();
-	}
-
 	// Validate refresh token is not empty
 	if request.refresh_token.is_empty() {
 		return (
@@ -323,6 +313,22 @@ pub async fn refresh_token(
 		.scope
 		.iter()
 		.any(|s| matches!(s, AuthScope::AdminAll | AuthScope::AdminRead));
+
+	// The orders gate is a PUBLIC-CLIENT control. It must run only after we know
+	// the token's scope, and must NOT block admin-scoped (SIWE) tokens: an
+	// admin-only deployment keeps `orders_auth_enabled = false` yet must still let
+	// admins refresh. Admin refresh is instead gated by the live whitelist check
+	// below (admin auth must be configured for `resolve_siwe_runtime_config` to
+	// succeed).
+	if !is_admin_scoped && !jwt_service.config().orders_auth_enabled {
+		return (
+			StatusCode::SERVICE_UNAVAILABLE,
+			Json(json!({
+				"error": "Public-client JWT authentication is disabled (orders_auth_enabled = false)"
+			})),
+		)
+			.into_response();
+	}
 
 	let scope_override = if is_admin_scoped {
 		let runtime = match resolve_siwe_runtime_config(&state.config).await {
@@ -638,6 +644,29 @@ fn resolve_siwe_scopes(
 		Some(AdminRole::ReadOnly) => Some(vec![AuthScope::AdminRead]),
 		None => None,
 	}
+}
+
+/// Returns `true` iff `subject` still resolves to an admin role in the LIVE
+/// admin whitelist.
+///
+/// This is the same live-config / whitelist source the refresh path consults
+/// (`resolve_siwe_runtime_config` + `SiweRuntimeConfig::role_for`, ultimately
+/// `AdminConfig::normalized_whitelist`). The auth middleware reuses it so an
+/// already-issued admin access token stops working the moment the admin is
+/// removed or admin auth is disabled — instead of remaining valid until the
+/// token's own expiry. A `false` result covers both "no longer whitelisted"
+/// and "admin auth is not configured / disabled" (in which case
+/// `resolve_siwe_runtime_config` errors).
+pub async fn is_live_admin_subject(config: &Arc<RwLock<Config>>, subject: &str) -> bool {
+	let runtime = match resolve_siwe_runtime_config(config).await {
+		Ok(runtime) => runtime,
+		Err(_) => return false,
+	};
+	let address = match parse_eth_address(subject) {
+		Ok(address) => address,
+		Err(_) => return false,
+	};
+	runtime.role_for(&address).is_some()
 }
 
 async fn siwe_dependencies(
@@ -1383,8 +1412,15 @@ mod tests {
 	#[tokio::test]
 	async fn test_refresh_token_auth_disabled() {
 		let jwt_service = create_test_jwt_service_with(false, true);
+		// A VALID public-client refresh token: the orders gate now fires after the
+		// token is decoded (so admin tokens can bypass it), so the token must
+		// decode for the gate to be the failure point rather than a decode error.
+		let refresh_token_str = jwt_service
+			.generate_refresh_token("test-client", vec![AuthScope::ReadOrders])
+			.await
+			.unwrap();
 		let request = RefreshRequest {
-			refresh_token: "some-token".to_string(),
+			refresh_token: refresh_token_str,
 		};
 
 		let state = create_refresh_state(Some(jwt_service), vec![]);
@@ -1667,6 +1703,83 @@ mod tests {
 			&access_claims,
 			&AuthScope::AdminAll
 		));
+	}
+
+	/// M-25 (a): An admin-scoped refresh must succeed even when
+	/// `orders_auth_enabled = false`. The orders gate is a public-client control;
+	/// it must not block an admin (SIWE) token from refreshing in an admin-only
+	/// deployment. Pre-fix the gate fired before the token was decoded, returning
+	/// 503 for everyone — including admins.
+	#[tokio::test]
+	async fn test_refresh_admin_succeeds_when_orders_auth_disabled() {
+		// orders_auth_enabled = false (admin-only config), admin auth configured.
+		let jwt_service = create_test_jwt_service_with(false, false);
+		let signer = create_test_siwe_signer();
+		let signer_address = signer.address();
+
+		let refresh_token_str = jwt_service
+			.generate_refresh_token(&signer_address.to_string(), vec![AuthScope::AdminAll])
+			.await
+			.unwrap();
+
+		// The admin is on the LIVE whitelist.
+		let state = create_refresh_state(
+			Some(jwt_service),
+			vec![AdminWhitelistEntry {
+				address: signer_address,
+				role: AdminRole::Admin,
+			}],
+		);
+		let response = refresh_token(
+			axum::extract::State(state),
+			Json(RefreshRequest {
+				refresh_token: refresh_token_str,
+			}),
+		)
+		.await;
+
+		let response_obj = response.into_response();
+		let (parts, body) = response_obj.into_parts();
+		assert_eq!(
+			parts.status,
+			StatusCode::OK,
+			"admin-scoped refresh must succeed when orders_auth_enabled=false"
+		);
+
+		let json_body = extract_json_from_body(body).await;
+		let refreshed: RegisterResponse = serde_json::from_value(json_body).unwrap();
+		assert_eq!(refreshed.scopes, vec!["admin-all"]);
+	}
+
+	/// M-25 (a): The orders gate must STILL block a public-client refresh when
+	/// `orders_auth_enabled = false`. The gate moved after token decode, but its
+	/// effect for non-admin tokens is unchanged.
+	#[tokio::test]
+	async fn test_refresh_public_client_blocked_when_orders_auth_disabled() {
+		let jwt_service = create_test_jwt_service_with(false, false);
+
+		let refresh_token_str = jwt_service
+			.generate_refresh_token("test-client", vec![AuthScope::ReadOrders])
+			.await
+			.unwrap();
+
+		let state = create_refresh_state(Some(jwt_service), vec![]);
+		let response = refresh_token(
+			axum::extract::State(state),
+			Json(RefreshRequest {
+				refresh_token: refresh_token_str,
+			}),
+		)
+		.await;
+
+		let response_obj = response.into_response();
+		let (parts, body) = response_obj.into_parts();
+		assert_eq!(parts.status, StatusCode::SERVICE_UNAVAILABLE);
+		let json_body = extract_json_from_body(body).await;
+		assert_eq!(
+			json_body["error"],
+			"Public-client JWT authentication is disabled (orders_auth_enabled = false)"
+		);
 	}
 
 	/// Locks in the API-separation hot-fix on the verify path: SIWE verify must

--- a/crates/solver-service/src/auth/middleware.rs
+++ b/crates/solver-service/src/auth/middleware.rs
@@ -12,8 +12,10 @@ use axum::{
 	Json,
 };
 use serde_json::json;
+use solver_config::Config;
 use solver_types::AuthScope;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Authentication state for middleware containing JWT service and required scope.
 #[derive(Clone)]
@@ -22,6 +24,11 @@ pub struct AuthState {
 	pub jwt_service: Arc<JwtService>,
 	/// Required scope for accessing the protected endpoint
 	pub required_scope: AuthScope,
+	/// Live runtime config used to re-validate ADMIN tokens against the current
+	/// admin whitelist on every request. `None` for public-client routes, where
+	/// no whitelist gating applies; `Some` for admin routes so a removed admin's
+	/// still-unexpired access token is rejected immediately rather than at expiry.
+	pub admin_whitelist_config: Option<Arc<RwLock<Config>>>,
 }
 
 /// Middleware function that validates JWT tokens and enforces authorization.
@@ -93,6 +100,32 @@ pub async fn auth_middleware(
 			.into_response();
 	}
 
+	// Live admin-whitelist recheck. Signature/expiry/scope validation above only
+	// proves the token was legitimately issued and is unexpired — it cannot
+	// detect that the admin was removed (or admin auth disabled) AFTER issuance.
+	// For ADMIN-scoped tokens we therefore re-validate the subject against the
+	// live whitelist on every request so revocation takes effect immediately
+	// rather than lingering until the token's own expiry. Public-client tokens
+	// carry no admin scope and skip this (`admin_whitelist_config` is also `None`
+	// on their routes).
+	let is_admin_scoped = claims
+		.scope
+		.iter()
+		.any(|s| matches!(s, AuthScope::AdminAll | AuthScope::AdminRead));
+	if is_admin_scoped {
+		if let Some(config) = &state.admin_whitelist_config {
+			if !crate::apis::auth::is_live_admin_subject(config, &claims.sub).await {
+				return (
+					StatusCode::UNAUTHORIZED,
+					Json(json!({
+						"error": "Admin token subject is no longer an authorized admin"
+					})),
+				)
+					.into_response();
+			}
+		}
+	}
+
 	// Add claims to request extensions for use in handlers
 	request.extensions_mut().insert(claims);
 
@@ -141,9 +174,20 @@ mod tests {
 		jwt_service: Arc<JwtService>,
 		required_scope: AuthScope,
 	) -> Router {
+		// No live-whitelist config: existing tests assert pure
+		// signature/expiry/scope behavior with admin whitelist gating disabled.
+		create_test_app_with_scope_and_config(jwt_service, required_scope, None)
+	}
+
+	fn create_test_app_with_scope_and_config(
+		jwt_service: Arc<JwtService>,
+		required_scope: AuthScope,
+		admin_whitelist_config: Option<Arc<RwLock<Config>>>,
+	) -> Router {
 		let auth_state = AuthState {
 			jwt_service,
 			required_scope,
+			admin_whitelist_config,
 		};
 
 		Router::new()
@@ -344,5 +388,145 @@ mod tests {
 			.unwrap();
 
 		assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+	}
+
+	/// Build a live runtime `Config` whose admin whitelist contains exactly the
+	/// provided entries (admin auth enabled). This is the live source the
+	/// middleware re-checks admin tokens against.
+	fn config_with_admin_whitelist(
+		whitelist: Vec<solver_types::AdminWhitelistEntry>,
+	) -> Arc<RwLock<Config>> {
+		use solver_config::{ApiConfig, ApiImplementations, ConfigBuilder};
+		use solver_types::AdminConfig;
+
+		let auth_config = AuthConfig {
+			orders_auth_enabled: true,
+			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
+			access_token_expiry_hours: 1,
+			refresh_token_expiry_hours: 720,
+			issuer: "test".to_string(),
+			public_register_enabled: false,
+			admin: Some(AdminConfig {
+				enabled: true,
+				domain: "localhost".to_string(),
+				chain_id: Some(1),
+				nonce_ttl_seconds: 300,
+				whitelist,
+			}),
+		};
+
+		let mut config = ConfigBuilder::new().build();
+		config.api = Some(ApiConfig {
+			enabled: true,
+			host: "127.0.0.1".to_string(),
+			port: 3000,
+			timeout_seconds: 30,
+			max_request_size: 1024 * 1024,
+			implementations: ApiImplementations::default(),
+			rate_limiting: None,
+			cors: None,
+			auth: Some(auth_config),
+			quote: None,
+		});
+
+		Arc::new(RwLock::new(config))
+	}
+
+	/// M-25 (b): An ADMIN access token that was validly issued must stop working
+	/// the moment its subject is removed from the live whitelist — without
+	/// waiting for the token to expire. The middleware must re-check the live
+	/// whitelist for admin-scoped tokens.
+	#[tokio::test]
+	async fn test_removed_admin_access_token_rejected_by_middleware() {
+		use alloy_primitives::Address;
+
+		let config = AuthConfig {
+			orders_auth_enabled: true,
+			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
+			access_token_expiry_hours: 1,
+			refresh_token_expiry_hours: 720,
+			issuer: "test".to_string(),
+			public_register_enabled: false,
+			admin: None,
+		};
+		let jwt_service = Arc::new(JwtService::new(config).unwrap());
+
+		// A still-unexpired admin access token, issued while the admin was valid.
+		let admin_address = Address::from([0x11u8; 20]);
+		let token = jwt_service
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
+			.unwrap();
+
+		// The live whitelist no longer lists this admin.
+		let live_config = config_with_admin_whitelist(vec![]);
+
+		let app = create_test_app_with_scope_and_config(
+			jwt_service,
+			AuthScope::AdminAll,
+			Some(live_config),
+		);
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header("Authorization", format!("Bearer {token}"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(
+			response.status(),
+			StatusCode::UNAUTHORIZED,
+			"a removed admin's still-unexpired access token must be rejected by the middleware"
+		);
+	}
+
+	/// The legitimate counterpart: an admin still on the live whitelist must
+	/// continue to pass the middleware.
+	#[tokio::test]
+	async fn test_whitelisted_admin_access_token_allowed_by_middleware() {
+		use alloy_primitives::Address;
+		use solver_types::{AdminRole, AdminWhitelistEntry};
+
+		let config = AuthConfig {
+			orders_auth_enabled: true,
+			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
+			access_token_expiry_hours: 1,
+			refresh_token_expiry_hours: 720,
+			issuer: "test".to_string(),
+			public_register_enabled: false,
+			admin: None,
+		};
+		let jwt_service = Arc::new(JwtService::new(config).unwrap());
+
+		let admin_address = Address::from([0x11u8; 20]);
+		let token = jwt_service
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
+			.unwrap();
+
+		let live_config = config_with_admin_whitelist(vec![AdminWhitelistEntry {
+			address: admin_address,
+			role: AdminRole::Admin,
+		}]);
+
+		let app = create_test_app_with_scope_and_config(
+			jwt_service,
+			AuthScope::AdminAll,
+			Some(live_config),
+		);
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header("Authorization", format!("Bearer {token}"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
 	}
 }

--- a/crates/solver-service/src/auth/middleware.rs
+++ b/crates/solver-service/src/auth/middleware.rs
@@ -25,9 +25,9 @@ pub struct AuthState {
 	/// Required scope for accessing the protected endpoint
 	pub required_scope: AuthScope,
 	/// Live runtime config used to re-validate ADMIN tokens against the current
-	/// admin whitelist on every request. `None` for public-client routes, where
-	/// no whitelist gating applies; `Some` for admin routes so a removed admin's
-	/// still-unexpired access token is rejected immediately rather than at expiry.
+	/// admin whitelist on every request. Public-client routes may omit this only
+	/// for public-client tokens; admin-scoped tokens fail closed when this is
+	/// absent so removed admins cannot reuse `AdminAll` on public scopes.
 	pub admin_whitelist_config: Option<Arc<RwLock<Config>>>,
 }
 
@@ -106,23 +106,36 @@ pub async fn auth_middleware(
 	// For ADMIN-scoped tokens we therefore re-validate the subject against the
 	// live whitelist on every request so revocation takes effect immediately
 	// rather than lingering until the token's own expiry. Public-client tokens
-	// carry no admin scope and skip this (`admin_whitelist_config` is also `None`
-	// on their routes).
+	// carry no admin scope and skip this.
 	let is_admin_scoped = claims
 		.scope
 		.iter()
 		.any(|s| matches!(s, AuthScope::AdminAll | AuthScope::AdminRead));
 	if is_admin_scoped {
-		if let Some(config) = &state.admin_whitelist_config {
-			if !crate::apis::auth::is_live_admin_subject(config, &claims.sub).await {
-				return (
-					StatusCode::UNAUTHORIZED,
-					Json(json!({
-						"error": "Admin token subject is no longer an authorized admin"
-					})),
-				)
-					.into_response();
-			}
+		let Some(config) = &state.admin_whitelist_config else {
+			return (
+				StatusCode::UNAUTHORIZED,
+				Json(json!({
+					"error": "Admin token requires live admin whitelist validation"
+				})),
+			)
+				.into_response();
+		};
+
+		if !crate::apis::auth::is_live_admin_subject_authorized(
+			config,
+			&claims.sub,
+			&state.required_scope,
+		)
+		.await
+		{
+			return (
+				StatusCode::UNAUTHORIZED,
+				Json(json!({
+					"error": "Admin token subject is no longer an authorized admin"
+				})),
+			)
+				.into_response();
 		}
 	}
 
@@ -291,6 +304,9 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_admin_all_grants_admin_read_route() {
+		use alloy_primitives::Address;
+		use solver_types::{AdminRole, AdminWhitelistEntry};
+
 		let config = AuthConfig {
 			orders_auth_enabled: true,
 			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
@@ -302,11 +318,21 @@ mod tests {
 		};
 
 		let jwt_service = Arc::new(JwtService::new(config).unwrap());
+		let admin_address = Address::from([0x11u8; 20]);
 		let token = jwt_service
-			.generate_access_token("admin", vec![AuthScope::AdminAll])
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
 			.unwrap();
 
-		let app = create_test_app_with_scope(jwt_service, AuthScope::AdminRead);
+		let live_config = config_with_admin_whitelist(vec![AdminWhitelistEntry {
+			address: admin_address,
+			role: AdminRole::Admin,
+		}]);
+
+		let app = create_test_app_with_scope_and_config(
+			jwt_service,
+			AuthScope::AdminRead,
+			Some(live_config),
+		);
 		let response = app
 			.oneshot(
 				Request::builder()
@@ -319,6 +345,49 @@ mod tests {
 			.unwrap();
 
 		assert_eq!(response.status(), StatusCode::OK);
+	}
+
+	/// M-25: `AdminAll` grants public-client scopes too. If an admin-scoped token
+	/// reaches a public route where no live admin whitelist config is attached, the
+	/// middleware must fail closed instead of allowing a removed admin through for
+	/// the access-token lifetime.
+	#[tokio::test]
+	async fn test_admin_all_public_route_without_whitelist_config_fails_closed() {
+		use alloy_primitives::Address;
+
+		let config = AuthConfig {
+			orders_auth_enabled: true,
+			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
+			access_token_expiry_hours: 1,
+			refresh_token_expiry_hours: 720,
+			issuer: "test".to_string(),
+			public_register_enabled: false,
+			admin: None,
+		};
+
+		let jwt_service = Arc::new(JwtService::new(config).unwrap());
+		let admin_address = Address::from([0x11u8; 20]);
+		let token = jwt_service
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
+			.unwrap();
+
+		let app = create_test_app_with_scope_and_config(jwt_service, AuthScope::CreateQuotes, None);
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header("Authorization", format!("Bearer {token}"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(
+			response.status(),
+			StatusCode::UNAUTHORIZED,
+			"admin-scoped tokens must not bypass live whitelist rechecks on public routes"
+		);
 	}
 
 	#[tokio::test]
@@ -480,6 +549,55 @@ mod tests {
 			response.status(),
 			StatusCode::UNAUTHORIZED,
 			"a removed admin's still-unexpired access token must be rejected by the middleware"
+		);
+	}
+
+	#[tokio::test]
+	async fn test_demoted_admin_all_access_token_rejected_by_middleware() {
+		use alloy_primitives::Address;
+		use solver_types::{AdminRole, AdminWhitelistEntry};
+
+		let config = AuthConfig {
+			orders_auth_enabled: true,
+			jwt_secret: SecretString::from("test-secret-key-at-least-32-chars"),
+			access_token_expiry_hours: 1,
+			refresh_token_expiry_hours: 720,
+			issuer: "test".to_string(),
+			public_register_enabled: false,
+			admin: None,
+		};
+		let jwt_service = Arc::new(JwtService::new(config).unwrap());
+
+		let admin_address = Address::from([0x11u8; 20]);
+		let token = jwt_service
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
+			.unwrap();
+
+		let live_config = config_with_admin_whitelist(vec![AdminWhitelistEntry {
+			address: admin_address,
+			role: AdminRole::ReadOnly,
+		}]);
+
+		let app = create_test_app_with_scope_and_config(
+			jwt_service,
+			AuthScope::AdminAll,
+			Some(live_config),
+		);
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header("Authorization", format!("Bearer {token}"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(
+			response.status(),
+			StatusCode::UNAUTHORIZED,
+			"a demoted admin's still-unexpired AdminAll access token must be rejected"
 		);
 	}
 

--- a/crates/solver-service/src/auth/mod.rs
+++ b/crates/solver-service/src/auth/mod.rs
@@ -225,6 +225,18 @@ impl JwtService {
 		&self,
 		refresh_token: &str,
 	) -> Result<(String, String, JwtClaims), AuthError> {
+		self.refresh_access_token_with_scopes(refresh_token, None)
+			.await
+	}
+
+	/// Decodes a refresh token and verifies it is refresh-typed, returning its
+	/// claims without minting new tokens.
+	///
+	/// Used by the refresh endpoint to inspect the embedded scope/subject so it
+	/// can re-validate admin-scoped tokens against the LIVE admin whitelist
+	/// before issuing a replacement — closing the gap where a removed or
+	/// demoted admin could keep self-renewing access by copying stale claims.
+	pub fn decode_refresh_claims(&self, refresh_token: &str) -> Result<JwtClaims, AuthError> {
 		let claims = self.decode_claims(refresh_token, |msg| {
 			AuthError::InvalidRefreshToken(msg.to_string())
 		})?;
@@ -235,6 +247,28 @@ impl JwtService {
 			));
 		}
 
+		Ok(claims)
+	}
+
+	/// Like [`refresh_access_token`], but allows the caller to override the
+	/// scopes minted into the new tokens.
+	///
+	/// When `scope_override` is `Some`, the provided scopes are used instead of
+	/// the scopes embedded in the refresh token. The refresh endpoint passes a
+	/// freshly-resolved scope for admin tokens (re-derived from the live
+	/// whitelist) so a demoted admin's refreshed token carries the reduced
+	/// scope rather than the stale embedded one. `None` preserves the legacy
+	/// behavior of copying the embedded scopes (used for non-admin client
+	/// tokens).
+	pub async fn refresh_access_token_with_scopes(
+		&self,
+		refresh_token: &str,
+		scope_override: Option<Vec<AuthScope>>,
+	) -> Result<(String, String, JwtClaims), AuthError> {
+		let claims = self.decode_refresh_claims(refresh_token)?;
+
+		let scopes = scope_override.unwrap_or(claims.scope);
+
 		// Build access-token claims once and use them for both the encoded
 		// token and the response body — see `build_access_claims` for why.
 		let access_ttl = self
@@ -242,13 +276,11 @@ impl JwtService {
 			.access_token_expiry_hours
 			.saturating_mul(3600)
 			.max(1);
-		let access_claims = self.build_access_claims(&claims.sub, claims.scope.clone(), access_ttl);
+		let access_claims = self.build_access_claims(&claims.sub, scopes.clone(), access_ttl);
 		let access_token = self.encode_claims(&access_claims)?;
 
 		// Generate new refresh token (token rotation for security)
-		let new_refresh_token = self
-			.generate_refresh_token(&claims.sub, claims.scope)
-			.await?;
+		let new_refresh_token = self.generate_refresh_token(&claims.sub, scopes).await?;
 
 		Ok((access_token, new_refresh_token, access_claims))
 	}

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -319,7 +319,11 @@ pub async fn start_server(
 	};
 
 	// Build the router with /api/v1 base path and public API hardening.
-	let mut api_routes = build_public_api_routes(&api_config, jwt_service.as_ref());
+	let mut api_routes = build_public_api_routes(
+		&api_config,
+		jwt_service.as_ref(),
+		Some(app_state.config.clone()),
+	);
 
 	// Add admin routes if enabled
 	if let Some(admin_state) = admin_state {
@@ -441,6 +445,7 @@ pub async fn start_server(
 fn build_public_api_routes(
 	api_config: &ApiConfig,
 	jwt_service: Option<&Arc<JwtService>>,
+	admin_whitelist_config: Option<Arc<RwLock<Config>>>,
 ) -> Router<AppState> {
 	let mut quote_routes = Router::new().route("/quotes", post(handle_quote));
 	quote_routes = crate::api_hardening::apply_quote_concurrency(quote_routes, api_config);
@@ -456,8 +461,7 @@ fn build_public_api_routes(
 				AuthState {
 					jwt_service: jwt.clone(),
 					required_scope: solver_types::AuthScope::CreateQuotes,
-					// Public-client routes carry no admin scope: no whitelist gating.
-					admin_whitelist_config: None,
+					admin_whitelist_config: admin_whitelist_config.clone(),
 				},
 				auth_middleware,
 			));
@@ -481,7 +485,7 @@ fn build_public_api_routes(
 					AuthState {
 						jwt_service: jwt.clone(),
 						required_scope: solver_types::AuthScope::CreateOrders,
-						admin_whitelist_config: None,
+						admin_whitelist_config: admin_whitelist_config.clone(),
 					},
 					auth_middleware,
 				),
@@ -493,7 +497,7 @@ fn build_public_api_routes(
 					AuthState {
 						jwt_service: jwt.clone(),
 						required_scope: solver_types::AuthScope::ReadOrders,
-						admin_whitelist_config: None,
+						admin_whitelist_config: admin_whitelist_config.clone(),
 					},
 					auth_middleware,
 				));
@@ -1680,7 +1684,12 @@ mod tests {
 
 	async fn test_quote_app(api_config: ApiConfig, jwt_service: Option<Arc<JwtService>>) -> Router {
 		let state = build_test_app_state(None).await;
-		build_public_api_routes(&api_config, jwt_service.as_ref()).with_state(state)
+		build_public_api_routes(
+			&api_config,
+			jwt_service.as_ref(),
+			Some(state.config.clone()),
+		)
+		.with_state(state)
 	}
 
 	async fn build_intake_disabled_test_app_state(discovery_impl: Option<String>) -> AppState {
@@ -2237,6 +2246,75 @@ mod tests {
 			.await
 			.unwrap();
 		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn quotes_route_live_rechecks_admin_all_tokens_when_order_auth_enabled() {
+		use alloy_primitives::Address;
+		use solver_types::{AdminConfig, AdminRole, AdminWhitelistEntry};
+
+		let api_config = ApiConfig {
+			enabled: true,
+			host: "127.0.0.1".to_string(),
+			port: 0,
+			timeout_seconds: 30,
+			max_request_size: 1024 * 1024,
+			implementations: Default::default(),
+			rate_limiting: None,
+			cors: None,
+			auth: Some(test_auth_config()),
+			quote: None,
+		};
+		let jwt = Arc::new(JwtService::new(test_auth_config()).unwrap());
+		let admin_address = Address::from([0x11u8; 20]);
+		let token = jwt
+			.generate_access_token(&admin_address.to_string(), vec![AuthScope::AdminAll])
+			.unwrap();
+
+		let state = build_test_app_state(None).await;
+		{
+			let mut config = state.config.write().await;
+			let api = config.api.get_or_insert_with(|| api_config.clone());
+			api.auth = Some(AuthConfig {
+				admin: Some(AdminConfig {
+					enabled: true,
+					domain: "localhost".to_string(),
+					chain_id: Some(1),
+					nonce_ttl_seconds: 300,
+					whitelist: vec![AdminWhitelistEntry {
+						address: admin_address,
+						role: AdminRole::Admin,
+					}],
+				}),
+				..test_auth_config()
+			});
+		}
+		let app = build_public_api_routes(&api_config, Some(&jwt), Some(state.config.clone()))
+			.with_state(state);
+
+		let response = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("POST")
+					.uri("/quotes")
+					.header("content-type", "application/json")
+					.header("authorization", format!("Bearer {token}"))
+					.body(Body::from("{}"))
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_ne!(
+			response.status(),
+			StatusCode::UNAUTHORIZED,
+			"still-whitelisted AdminAll token should pass public-route live recheck"
+		);
+		assert_ne!(
+			response.status(),
+			StatusCode::FORBIDDEN,
+			"AdminAll token should still satisfy public CreateQuotes scope"
+		);
 	}
 
 	#[tokio::test(flavor = "multi_thread")]

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -591,7 +591,13 @@ async fn handle_auth_refresh(
 	State(state): State<AppState>,
 	Json(payload): Json<crate::apis::auth::RefreshRequest>,
 ) -> impl IntoResponse {
-	crate::apis::auth::refresh_token(State(state.jwt_service), Json(payload)).await
+	let siwe_state = crate::apis::auth::SiweAuthState {
+		jwt_service: state.jwt_service,
+		config: state.config,
+		siwe_nonce_store: state.siwe_nonce_store,
+	};
+
+	crate::apis::auth::refresh_token(State(siwe_state), Json(payload)).await
 }
 
 /// Handles POST /api/v1/auth/siwe/nonce requests.

--- a/crates/solver-service/src/server.rs
+++ b/crates/solver-service/src/server.rs
@@ -386,6 +386,9 @@ pub async fn start_server(
 				AuthState {
 					jwt_service: jwt.clone(),
 					required_scope: solver_types::AuthScope::AdminRead,
+					// Admin routes re-check the live whitelist on every request so
+					// a removed admin's still-unexpired token is rejected at once.
+					admin_whitelist_config: Some(app_state.config.clone()),
 				},
 				auth_middleware,
 			));
@@ -393,6 +396,7 @@ pub async fn start_server(
 				AuthState {
 					jwt_service: jwt.clone(),
 					required_scope: solver_types::AuthScope::AdminAll,
+					admin_whitelist_config: Some(app_state.config.clone()),
 				},
 				auth_middleware,
 			));
@@ -452,6 +456,8 @@ fn build_public_api_routes(
 				AuthState {
 					jwt_service: jwt.clone(),
 					required_scope: solver_types::AuthScope::CreateQuotes,
+					// Public-client routes carry no admin scope: no whitelist gating.
+					admin_whitelist_config: None,
 				},
 				auth_middleware,
 			));
@@ -475,6 +481,7 @@ fn build_public_api_routes(
 					AuthState {
 						jwt_service: jwt.clone(),
 						required_scope: solver_types::AuthScope::CreateOrders,
+						admin_whitelist_config: None,
 					},
 					auth_middleware,
 				),
@@ -486,6 +493,7 @@ fn build_public_api_routes(
 					AuthState {
 						jwt_service: jwt.clone(),
 						required_scope: solver_types::AuthScope::ReadOrders,
+						admin_whitelist_config: None,
 					},
 					auth_middleware,
 				));


### PR DESCRIPTION
## Summary

Admin-auth hardening for **M-18** and **M-25** (includes review fixes).

### M-18 — Arbitrary spender approvals bypass the withdrawal allowlist
`handle_approve_tokens` forwarded an admin-supplied `spender` straight to on-chain `approve` with no allowlist check, bypassing the `recipient_allowed` control the sibling `handle_withdrawal` enforces — a compromised admin key could `approve(attacker, U256::MAX)` across all tokens/chains. The spender is now validated **per affected network**: it must be a configured input/output settler on *every* chain the approval would touch — the specific requested `chain_id`, or every known network for the all-chains scope (an empty affected set is rejected). A settler configured only on another chain no longer passes (closes the cross-chain address-confusion gap).

### M-25 — Removed admins retain self-renewing API access
- **Refresh re-derives scope from live config:** admin-scoped refresh no longer copies the embedded scope; it re-resolves from the live whitelist (`resolve_siwe_runtime_config` → `resolve_siwe_scopes`). A `sub` no longer whitelisted is rejected (401); a demoted admin's scope is re-derived from the current role.
- **Admin refresh works in admin-only configs:** the `orders_auth_enabled` gate is applied **after** decoding the refresh claims and only to non-admin (public-client) tokens, so a valid admin SIWE refresh is not blocked when public-client auth is disabled.
- **Immediate revocation:** `auth_middleware` rechecks the **live admin whitelist** for admin-scoped access tokens, so a removed admin's still-unexpired token is rejected at once rather than lingering until expiry. Public-client routes are never whitelist-gated.

## Verification
- `cargo test -p solver-service`: 686 passed (incl. per-chain rejection, all-chains-partial rejection, admin-refresh-with-public-auth-off, removed-admin-middleware-rejection)
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`, `cargo fmt --all -- --check`, `cargo check --all-targets --all-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
