### PR TITLE
fix: overwrite stale stage hash on confirmed-replacement conflict (M-03)

### DIFF
--- a/crates/solver-core/src/handlers/transaction.rs
+++ b/crates/solver-core/src/handlers/transaction.rs
@@ -95,12 +95,29 @@ impl TransactionHandler {
 		match stage_hash(order, tx_type) {
 			Some(stored_hash) if stored_hash == observed_hash => Ok(()),
 			Some(stored_hash) => {
+				let stored_hash = stored_hash.clone();
+				// A different confirmed tx landed for this stage (e.g. a same-nonce
+				// gas-bump replacement). The in-hand confirmation receipt proves
+				// `observed_hash` is the canonical tx, so overwrite the stored hash
+				// with it; otherwise recovery would resolve the stage to the
+				// superseded `stored_hash` whose receipt no longer exists and the
+				// order would stall forever. The overwrite always targets a
+				// chain-confirmed tx and produces no new on-chain action, so it is
+				// consistent with the OIF idempotency invariant.
+				let canonical_hash = observed_hash.clone();
+				self.state_machine
+					.update_order_with(order_id, |order| {
+						set_stage_hash(order, tx_type, canonical_hash.clone());
+					})
+					.await
+					.map_err(|e| TransactionError::State(e.to_string()))?;
+
 				self.event_bus
 					.publish(SolverEvent::Delivery(
 						DeliveryEvent::TransactionCanonicalHashConflict {
 							order_id: order_id.to_string(),
 							tx_type,
-							stored_hash: stored_hash.clone(),
+							stored_hash,
 							observed_hash: observed_hash.clone(),
 						},
 					))
@@ -109,24 +126,31 @@ impl TransactionHandler {
 			},
 			None => {
 				let repair_hash = observed_hash.clone();
-				let updated = self
-					.state_machine
+				// A concurrent write may have populated the stage hash between our
+				// read and this update. Capture whatever was there so we can report
+				// a conflict, but always overwrite with the in-hand confirmed
+				// `observed_hash`: it is the canonical (chain-confirmed) tx for this
+				// stage, so recovery must resolve to it rather than a superseded hash.
+				let prior_hash = Arc::new(std::sync::Mutex::new(None));
+				let prior_hash_for_update = prior_hash.clone();
+				self.state_machine
 					.update_order_with(order_id, |order| {
-						if stage_hash(order, tx_type).is_none() {
-							set_stage_hash(order, tx_type, repair_hash.clone());
-						}
+						*prior_hash_for_update.lock().unwrap() =
+							stage_hash(order, tx_type).cloned();
+						set_stage_hash(order, tx_type, repair_hash.clone());
 					})
 					.await
 					.map_err(|e| TransactionError::State(e.to_string()))?;
 
-				if let Some(stored_hash) = stage_hash(&updated, tx_type) {
-					if stored_hash != observed_hash {
+				let prior_hash = prior_hash.lock().unwrap().take();
+				if let Some(stored_hash) = prior_hash {
+					if &stored_hash != observed_hash {
 						self.event_bus
 							.publish(SolverEvent::Delivery(
 								DeliveryEvent::TransactionCanonicalHashConflict {
 									order_id: order_id.to_string(),
 									tx_type,
-									stored_hash: stored_hash.clone(),
+									stored_hash,
 									observed_hash: observed_hash.clone(),
 								},
 							))
@@ -931,8 +955,12 @@ mod tests {
 			.await
 			.unwrap();
 
+		// The in-hand confirmation receipt proves `observed_hash` is the canonical
+		// tx for this stage (e.g. a same-nonce gas-bump replacement landed). The
+		// handler must OVERWRITE the stored hash with the observed one so recovery
+		// resolves the stage to a tx whose receipt actually exists.
 		let updated_order = state_machine.get_order(&order.id).await.unwrap();
-		assert_eq!(updated_order.fill_tx_hash, Some(stored_hash.clone()));
+		assert_eq!(updated_order.fill_tx_hash, Some(observed_hash.clone()));
 		let events = drain_events(&mut receiver);
 		assert_eq!(
 			events
@@ -1413,9 +1441,11 @@ mod tests {
 
 	/// Regression for the AlreadyApplied-conflict branch on the Prepare stage.
 	/// An order already past Prepare with a stored `prepare_tx_hash` receives
-	/// a duplicate Prepare confirmation carrying a different hash. The
-	/// handler must emit `TransactionCanonicalHashConflict`, leave the stored
-	/// hash unchanged, and NOT re-publish `OrderEvent::Executing`.
+	/// a duplicate Prepare confirmation carrying a different hash (e.g. a
+	/// same-nonce gas-bump replacement landed). The handler must OVERWRITE the
+	/// stored hash with the observed (chain-confirmed) one, still emit
+	/// `TransactionCanonicalHashConflict`, and NOT re-publish
+	/// `OrderEvent::Executing`.
 	#[tokio::test]
 	async fn duplicate_prepare_confirmed_with_different_hash_emits_canonical_hash_conflict() {
 		let stored_hash = TransactionHash(vec![0x33; 32]);
@@ -1441,8 +1471,10 @@ mod tests {
 			.await
 			.unwrap();
 
+		// The in-hand confirmation receipt proves `observed_hash` is the canonical
+		// tx for this stage, so the handler must OVERWRITE the stored hash with it.
 		let updated_order = state_machine.get_order(&order.id).await.unwrap();
-		assert_eq!(updated_order.prepare_tx_hash, Some(stored_hash.clone()));
+		assert_eq!(updated_order.prepare_tx_hash, Some(observed_hash.clone()));
 		let events = drain_events(&mut receiver);
 		assert_eq!(
 			events

--- a/crates/solver-core/src/handlers/transaction.rs
+++ b/crates/solver-core/src/handlers/transaction.rs
@@ -131,6 +131,16 @@ impl TransactionHandler {
 				// a conflict, but always overwrite with the in-hand confirmed
 				// `observed_hash`: it is the canonical (chain-confirmed) tx for this
 				// stage, so recovery must resolve to it rather than a superseded hash.
+				//
+				// The overwrite is intentionally unconditional. `observed_hash` is
+				// the hash from an in-hand success receipt (this branch is reached
+				// only via `handle_confirmed`, past its `receipt.success` gate), and
+				// OIF on-chain idempotency guarantees exactly one confirmation per
+				// stage nonce. So `observed_hash` IS the confirmed-lineage hash;
+				// there is no other authoritative candidate to prefer, and the write
+				// re-points stored state at a chain-confirmed tx without triggering
+				// any new on-chain action — consistent with the idempotency
+				// invariant.
 				let prior_hash = Arc::new(std::sync::Mutex::new(None));
 				let prior_hash_for_update = prior_hash.clone();
 				self.state_machine

--- a/crates/solver-core/src/recovery/mod.rs
+++ b/crates/solver-core/src/recovery/mod.rs
@@ -82,7 +82,13 @@ enum ReconcileResult {
 	Finalized,
 }
 
-fn choose_recovery_attempt_hash(
+/// Returns the hash of a `Confirmed`-lineage attempt for this stage, if any.
+///
+/// A confirmed-lineage hash is **authoritative**: the chain accepted exactly
+/// one transaction for the stage's nonce, and this is its hash. It outranks a
+/// possibly-stale order field, which may still point at a superseded
+/// replacement that confirmed while the solver was down.
+fn confirmed_recovery_attempt_hash(
 	attempts: &[TransactionAttempt],
 	tx_type: TransactionType,
 ) -> Option<TransactionHash> {
@@ -103,6 +109,25 @@ fn choose_recovery_attempt_hash(
 			}
 		}
 	}
+
+	None
+}
+
+fn choose_recovery_attempt_hash(
+	attempts: &[TransactionAttempt],
+	tx_type: TransactionType,
+) -> Option<TransactionHash> {
+	// A confirmed-lineage hash wins over any merely-pending tip.
+	if let Some(hash) = confirmed_recovery_attempt_hash(attempts, tx_type) {
+		return Some(hash);
+	}
+
+	let stage_attempts: Vec<TransactionAttempt> = attempts
+		.iter()
+		.filter(|attempt| attempt.tx_type == tx_type)
+		.cloned()
+		.collect();
+	let components = lineage_components(&stage_attempts);
 
 	components
 		.iter()
@@ -878,12 +903,31 @@ impl RecoveryService {
 		attempts: &[TransactionAttempt],
 		tx_type: TransactionType,
 	) -> StageResolution {
+		// Layer 0: authoritative confirmed-lineage hash.
+		//
+		// A same-nonce replacement may have confirmed while the solver was
+		// down, in which case the order field was never corrected live and
+		// still points at a superseded hash. The confirmed-lineage hash is
+		// the canonical on-chain transaction for the stage's nonce, so it
+		// outranks the order field for ALL stages (not just Fill). When it
+		// differs from the stale field, repair the field before returning.
+		// Only a CONFIRMED hash is authoritative here — a merely-pending
+		// ledger tip must never override a present field (handled by Layer 1
+		// taking precedence over the pending fallback below).
+		if let Some(tx_hash) = confirmed_recovery_attempt_hash(attempts, tx_type) {
+			if order_stage_hash(order, tx_type).as_ref() != Some(&tx_hash) {
+				self.write_repaired_hash(order, tx_type, tx_hash.clone())
+					.await;
+			}
+			return StageResolution::Hash(tx_hash);
+		}
+
 		// Layer 1: order field
 		if let Some(tx_hash) = order_stage_hash(order, tx_type) {
 			return StageResolution::Hash(tx_hash);
 		}
 
-		// Layer 2: attempt ledger fallback
+		// Layer 2: attempt ledger fallback (pending tip; no field present)
 		if let Some(tx_hash) = choose_recovery_attempt_hash(attempts, tx_type) {
 			self.write_repaired_hash(order, tx_type, tx_hash.clone())
 				.await;
@@ -2591,6 +2635,134 @@ mod tests {
 			other => panic!("expected Hash, got {:?}", std::mem::discriminant(&other)),
 		}
 		assert_eq!(order.fill_tx_hash, Some(recovered_hash));
+	}
+
+	#[tokio::test]
+	async fn resolve_stage_prefers_confirmed_lineage_over_stale_order_field_non_fill() {
+		// A same-nonce replacement confirmed while the solver was DOWN. The
+		// order field still holds the SUPERSEDED hash (never corrected live),
+		// but the attempt ledger holds the CONFIRMED replacement. Resolution
+		// must prefer the confirmed-lineage hash and repair the stale field —
+		// not return the stale hash (which would later 404 the receipt probe
+		// and stall a non-Fill stage forever).
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let (attempt_store, _attempts_tmp) = empty_attempt_store();
+
+		let stale_hash = TransactionHash(vec![0xa1; 32]);
+		let confirmed_hash = TransactionHash(vec![0xc2; 32]);
+
+		let mut order = create_test_order_with_status(OrderStatus::Executed);
+		// Stale order-field hash for a NON-Fill stage (PostFill).
+		order.post_fill_tx_hash = Some(stale_hash.clone());
+		state_machine.store_order(&order).await.unwrap();
+
+		// Ledger lineage: superseded parent (stale) -> Confirmed replacement.
+		let mut superseded = sample_attempt(
+			"superseded",
+			TransactionType::PostFill,
+			TransactionAttemptStatus::Replaced,
+			Some(0xa1),
+			100,
+		);
+		let mut confirmed = sample_attempt(
+			"confirmed",
+			TransactionType::PostFill,
+			TransactionAttemptStatus::Confirmed,
+			Some(0xc2),
+			200,
+		);
+		confirmed.replacement_of = Some("superseded".to_string());
+		superseded.replaced_by = Some("confirmed".to_string());
+		let attempts = vec![superseded, confirmed];
+
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine.clone(),
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+			empty_networks_config(),
+		);
+
+		let resolution = recovery_service
+			.resolve_stage(&mut order, &attempts, TransactionType::PostFill)
+			.await;
+
+		match resolution {
+			StageResolution::Hash(h) => assert_eq!(
+				h, confirmed_hash,
+				"resolution must return the CONFIRMED replacement, not the stale order field"
+			),
+			other => panic!("expected Hash, got {:?}", std::mem::discriminant(&other)),
+		}
+		// The stale order field must be repaired to the confirmed hash, both
+		// in memory and in persisted storage.
+		assert_eq!(order.post_fill_tx_hash, Some(confirmed_hash.clone()));
+		let stored = state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.post_fill_tx_hash, Some(confirmed_hash));
+	}
+
+	#[tokio::test]
+	async fn resolve_stage_keeps_order_field_when_ledger_only_pending() {
+		// Guard against over-correction: a merely-PENDING ledger hash must NOT
+		// override a present order field. Only a CONFIRMED-lineage hash is
+		// authoritative over the field.
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		let (attempt_store, _attempts_tmp) = empty_attempt_store();
+
+		let field_hash = TransactionHash(vec![0xf0; 32]);
+
+		let mut order = create_test_order_with_status(OrderStatus::Executed);
+		order.post_fill_tx_hash = Some(field_hash.clone());
+
+		// Ledger has only a Broadcast (pending) attempt with a different hash.
+		let attempts = vec![sample_attempt(
+			"pending",
+			TransactionType::PostFill,
+			TransactionAttemptStatus::Broadcast,
+			Some(0xbb),
+			100,
+		)];
+
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let settlement = Arc::new(SettlementService::new(HashMap::new(), String::new(), 20));
+		let event_bus = EventBus::new(100);
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine.clone(),
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+			empty_networks_config(),
+		);
+
+		let resolution = recovery_service
+			.resolve_stage(&mut order, &attempts, TransactionType::PostFill)
+			.await;
+
+		match resolution {
+			StageResolution::Hash(h) => assert_eq!(
+				h, field_hash,
+				"a pending ledger hash must not override the present order field"
+			),
+			other => panic!("expected Hash, got {:?}", std::mem::discriminant(&other)),
+		}
+		assert_eq!(order.post_fill_tx_hash, Some(field_hash));
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

**M-03 — Stale order stage hash strands orders with confirmed same-nonce replacements** (includes review fix).

A same-nonce gas-bump replacement can confirm a *different* tx than the one stored in the order's stage hash, stranding the order at Claim/PreClaim/PostFill/Prepare — recovery resolves to the stale stored hash whose receipt no longer exists, and the order never advances. Two paths fixed:

- **Live duplicate-confirmation** (`crates/solver-core/src/handlers/transaction.rs`): `reconcile_already_applied_stage_hash` now overwrites the stored stage hash with the confirmed (in-hand receipt) hash and still emits `TransactionCanonicalHashConflict`. The unconditional overwrite is sound — the branch runs past the `receipt.success` gate and on-chain idempotency guarantees exactly one confirmation per nonce, so `observed_hash` is the canonical tx (documented in-code).

- **Recovery resolution** (`crates/solver-core/src/recovery/mod.rs`): a new **Layer 0** in `resolve_stage` prefers the authoritative *confirmed-lineage* attempt-ledger hash over a possibly-stale order field for **all** stages (and repairs the field), so a replacement that confirmed while the solver was down is resolved correctly — not just on the Fill stage. A *pending-only* ledger entry never overrides a present order field.

Idempotency preserved: resolution only re-points stored state at a chain-confirmed tx; it triggers no new on-chain action.

## Verification
- `cargo test -p solver-core`: 382 passed (updated `canonical_hash_conflict` tests + new confirmed-lineage and pending-only recovery tests)
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`, `cargo fmt --all -- --check`, `cargo check --all-targets --all-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
