### PR TITLE
fix: delivery-pipeline robustness (M-12, M-13, M-15)

### DIFF
--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -44,6 +44,22 @@ use tracing::instrument;
 
 const INTENT_QUEUE_CAPACITY: usize = 1024;
 
+/// Upper bound on handler tasks that have been spawned but not yet completed.
+///
+/// `spawn_handler` acquires one of these permits BEFORE `tokio::spawn` and the
+/// spawned task holds it for its whole lifetime. This caps the number of
+/// in-flight (including parked) handler tasks, so a bounded intake — the H-09
+/// intent queue / event bus — cannot be drained into unlimited parked
+/// semaphore-waiter tasks (unbounded memory growth).
+///
+/// Sized to match `INTENT_QUEUE_CAPACITY`: the queue can hold at most that many
+/// pending items, so allowing the same number of concurrent handlers means the
+/// common path never blocks on this bound — backpressure only engages at true
+/// saturation. It is far above the single-permit `transaction_semaphore`, so a
+/// merely contended transaction permit never blocks dispatch (preserving the
+/// M-13 property that a held transaction permit cannot stall the event loop).
+const MAX_INFLIGHT_HANDLERS: usize = INTENT_QUEUE_CAPACITY;
+
 /// Errors that can occur during engine operations.
 ///
 /// These errors represent various failure modes that can occur while
@@ -416,6 +432,12 @@ impl SolverEngine {
 		let transaction_semaphore = Arc::new(Semaphore::new(1)); // Serialize transaction submissions
 		let general_semaphore = Arc::new(Semaphore::new(100)); // Allow concurrent non-tx operations
 
+		// Bounds the number of spawned-but-not-yet-completed handler tasks. Each
+		// `spawn_handler` call acquires a permit before spawning and holds it for
+		// the task's lifetime, so a bounded intake cannot fan out into unlimited
+		// parked semaphore-waiter tasks. See `MAX_INFLIGHT_HANDLERS`.
+		let dispatch_semaphore = Arc::new(Semaphore::new(MAX_INFLIGHT_HANDLERS));
+
 		let rebalance_handle = if let Some(bridge_service) = &self.bridge_service {
 			// Rebalance preflight: cross-check operator-declared route data
 			// against on-chain state before starting the monitor. Catches wrong
@@ -576,12 +598,12 @@ impl SolverEngine {
 			tokio::select! {
 				// Handle discovered intents
 				Some(intent) = intent_rx.recv() => {
-					self.spawn_handler(&general_semaphore, move |engine| async move {
+					self.spawn_handler(&dispatch_semaphore, &general_semaphore, move |engine| async move {
 						if let Err(e) = engine.intent_handler.handle(intent).await {
 							return Err(EngineError::Service(format!("Failed to handle intent: {e}")));
 						}
 						Ok(())
-					});
+					}).await;
 				}
 
 				// Handle events
@@ -589,7 +611,7 @@ impl SolverEngine {
 					match event {
 						SolverEvent::Order(OrderEvent::Preparing { intent, order, params }) => {
 							// Preparing sends a prepare transaction - use transaction semaphore
-							self.spawn_handler(&transaction_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &transaction_semaphore, move |engine| async move {
 								let order_id = order.id.clone();
 								if let Err(e) = engine.order_handler.handle_preparation(intent.source, order, params).await {
 									let error_msg = format!("Failed to handle order preparation: {e}");
@@ -603,7 +625,7 @@ impl SolverEngine {
 									return Err(EngineError::Service(error_msg));
 								}
 								Ok(())
-							});
+							}).await;
 						}
 						SolverEvent::Order(OrderEvent::Executing { order, params }) => {
 							tracing::info!(
@@ -612,7 +634,7 @@ impl SolverEngine {
 								"Handling order execution event"
 							);
 							// Executing sends a fill transaction - use transaction semaphore
-							self.spawn_handler(&transaction_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &transaction_semaphore, move |engine| async move {
 								let order_id = order.id.clone();
 								if let Err(e) = engine.order_handler.handle_execution(order, params).await {
 									let error_msg = format!("Failed to handle order execution: {e}");
@@ -626,7 +648,7 @@ impl SolverEngine {
 									return Err(EngineError::Service(error_msg));
 								}
 								Ok(())
-							});
+							}).await;
 						}
 
 						SolverEvent::Delivery(DeliveryEvent::TransactionPending { order_id, tx_hash, tx_type, tx_chain_id: _ }) => {
@@ -647,7 +669,7 @@ impl SolverEngine {
 							);
 							// Confirmation handling doesn't directly send transactions - use general semaphore
 							// Note: This may trigger OrderEvent::Executing which will be serialized separately
-							self.spawn_handler(&general_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &general_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
 								match engine.transaction_handler.handle_confirmed(order_id, tx_hash, tx_type, receipt).await {
 									Ok(()) => Ok(()),
@@ -671,7 +693,7 @@ impl SolverEngine {
 										Err(EngineError::Service(error_msg))
 									}
 								}
-							});
+							}).await;
 						}
 
 						SolverEvent::Delivery(DeliveryEvent::TransactionFailed { order_id, tx_hash, tx_type, error }) => {
@@ -683,12 +705,12 @@ impl SolverEngine {
 								"Transaction failed"
 							);
 							// Failure handling doesn't send transactions - use general semaphore
-							self.spawn_handler(&general_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &general_semaphore, move |engine| async move {
 								if let Err(e) = engine.transaction_handler.handle_failed(order_id, tx_hash, tx_type, error).await {
 									return Err(EngineError::Service(format!("Failed to handle transaction failure: {e}")));
 								}
 								Ok(())
-							});
+							}).await;
 						}
 
 						// Handle PostFillReady - use settlement handler
@@ -698,7 +720,7 @@ impl SolverEngine {
 								order_id = %order_id,
 								"Handling post-fill readiness event"
 							);
-							self.spawn_handler(&transaction_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &transaction_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
 								if let Err(e) = engine.settlement_handler.handle_post_fill_ready(order_id).await {
 									return engine.handle_settlement_stage_error(
@@ -709,12 +731,12 @@ impl SolverEngine {
 									).await;
 								}
 								Ok(())
-							});
+							}).await;
 						}
 
 						// Handle PreClaimReady - use settlement handler
 						SolverEvent::Settlement(SettlementEvent::PreClaimReady { order_id }) => {
-							self.spawn_handler(&transaction_semaphore, move |engine| async move {
+							self.spawn_handler(&dispatch_semaphore, &transaction_semaphore, move |engine| async move {
 								let order_id_clone = order_id.clone();
 								if let Err(e) = engine.settlement_handler.handle_pre_claim_ready(order_id).await {
 									return engine.handle_settlement_stage_error(
@@ -725,7 +747,7 @@ impl SolverEngine {
 									).await;
 								}
 								Ok(())
-							});
+							}).await;
 						}
 
 						// Handle StartMonitoring - spawn settlement monitor
@@ -753,7 +775,7 @@ impl SolverEngine {
 								let mut batch = std::mem::take(&mut claim_batch);
 								claim_batch.clear();
 								// Claim sends a transaction - use transaction semaphore
-								self.spawn_handler(&transaction_semaphore, move |engine| async move {
+								self.spawn_handler(&dispatch_semaphore, &transaction_semaphore, move |engine| async move {
 									if let Err(e) = engine.settlement_handler.process_claim_batch(&mut batch).await {
 										return engine.handle_settlement_stage_error(
 											&e.order_id,
@@ -763,7 +785,7 @@ impl SolverEngine {
 										).await;
 									}
 									Ok(())
-								});
+								}).await;
 							}
 						}
 
@@ -947,30 +969,64 @@ impl SolverEngine {
 
 	/// Helper method to spawn handler tasks with semaphore-based concurrency control.
 	///
-	/// This method:
-	/// 1. Clones the engine and spawns the handler in a new task
-	/// 2. Acquires the semaphore permit INSIDE the spawned task, so the caller
-	///    (the `select!` event loop) returns immediately and keeps polling even
-	///    when the permit is contended
-	/// 3. Handles errors by logging them appropriately
+	/// Two semaphores cooperate here, with distinct responsibilities:
 	///
-	/// Acquiring the permit inside the task (rather than inline before
-	/// `tokio::spawn`) preserves the semaphore's serialization purpose — at most
-	/// `permits` handlers run concurrently, which is what serializes nonce
-	/// allocation on the single-permit `transaction_semaphore`. The only thing
-	/// that changes is that ordering among already-spawned waiters becomes
-	/// tokio's fair acquisition queue rather than the event-arrival order; that
-	/// is acceptable because nonce allocation only requires mutual exclusion, not
-	/// a specific order. Crucially, a held permit can no longer park the event
-	/// loop and stall unrelated event processing.
-	fn spawn_handler<F, Fut>(&self, semaphore: &Arc<Semaphore>, handler: F)
-	where
+	/// * `dispatch` (capacity `MAX_INFLIGHT_HANDLERS`) — acquired BEFORE
+	///   `tokio::spawn` and held for the spawned task's whole lifetime. This
+	///   bounds the number of spawned-but-not-yet-completed handler tasks, so a
+	///   bounded intake (the H-09 intent queue / event bus) cannot be drained
+	///   into unlimited parked waiter tasks (unbounded memory growth, M-13
+	///   regression). Sized well above the single transaction permit, so the
+	///   common path finds a permit immediately and this `.await` does not park
+	///   the event loop; the loop only blocks here at TRUE saturation.
+	/// * `semaphore` (the per-event-type `transaction_semaphore` /
+	///   `general_semaphore`) — acquired INSIDE the spawned task, so a merely
+	///   contended transaction permit can no longer park the `select!` event loop
+	///   (the original M-13 fix). This serializes nonce allocation on the
+	///   single-permit `transaction_semaphore` via mutual exclusion; ordering
+	///   among already-spawned waiters becomes tokio's fair acquisition queue
+	///   rather than event-arrival order, which is acceptable because nonce
+	///   allocation only requires mutual exclusion, not a specific order.
+	///
+	/// Net effect: bounded in-flight memory WITHOUT reintroducing the per-event
+	/// stall — backpressure engages only when `MAX_INFLIGHT_HANDLERS` tasks are
+	/// already in flight, not on every contended single transaction permit.
+	/// Handler errors are logged.
+	async fn spawn_handler<F, Fut>(
+		&self,
+		dispatch: &Arc<Semaphore>,
+		semaphore: &Arc<Semaphore>,
+		handler: F,
+	) where
 		F: FnOnce(SolverEngine) -> Fut + Send + 'static,
 		Fut: Future<Output = Result<(), EngineError>> + Send,
 	{
 		let engine = self.clone();
 		let semaphore = semaphore.clone();
+
+		// Acquire the dispatch permit BEFORE spawning. This bounds the number of
+		// spawned-but-not-yet-completed handler tasks to the dispatch capacity
+		// (`MAX_INFLIGHT_HANDLERS`), so a bounded intake cannot be drained into
+		// unlimited parked semaphore-waiter tasks (the H-09 memory-exhaustion
+		// concern). Under normal load a permit is immediately available, so this
+		// `.await` completes synchronously and does NOT park the event loop;
+		// crucially, a merely contended single transaction permit never consumes
+		// a dispatch permit at acquisition time, so it cannot stall dispatch
+		// (preserving the M-13 property). The loop only blocks here at TRUE
+		// saturation — `MAX_INFLIGHT_HANDLERS` tasks already in flight — which is
+		// correct, bounded backpressure rather than the original per-event stall.
+		let dispatch_permit = match dispatch.clone().acquire_owned().await {
+			Ok(permit) => permit,
+			Err(e) => {
+				tracing::error!("Failed to acquire dispatch permit: {}", e);
+				return;
+			},
+		};
+
 		tokio::spawn(async move {
+			// Hold the dispatch permit for the whole task lifetime; it is
+			// released on completion, freeing a slot for the next dispatch.
+			let _dispatch_permit = dispatch_permit;
 			match semaphore.acquire_owned().await {
 				Ok(permit) => {
 					let _permit = permit; // Keep permit alive for duration of task
@@ -1264,11 +1320,14 @@ mod tests {
 		);
 
 		let semaphore = Arc::new(Semaphore::new(1));
+		let dispatch = Arc::new(Semaphore::new(64));
 
 		// Test handler that returns an error - should be logged but not panic
-		engine.spawn_handler(&semaphore, move |_engine| async move {
-			Err(EngineError::Service("Test error".to_string()))
-		});
+		engine
+			.spawn_handler(&dispatch, &semaphore, move |_engine| async move {
+				Err(EngineError::Service("Test error".to_string()))
+			})
+			.await;
 	}
 
 	/// M-13: dispatching a second handler must not block the event loop while a
@@ -1283,6 +1342,10 @@ mod tests {
 
 		// Single-permit semaphore mirrors the transaction_semaphore.
 		let semaphore = Arc::new(Semaphore::new(1));
+		// Ample dispatch capacity so the M-13 dispatch path under test never
+		// parks on dispatch backpressure — we are isolating the transaction
+		// permit contention, not the saturation bound.
+		let dispatch = Arc::new(Semaphore::new(64));
 
 		// Hold the only permit for the duration of the dispatch under test.
 		let held = semaphore.clone().acquire_owned().await.unwrap();
@@ -1290,15 +1353,18 @@ mod tests {
 		// Signals when the spawned handler actually begins executing.
 		let (ran_tx, mut ran_rx) = tokio::sync::oneshot::channel::<()>();
 
-		// Dispatching a handler must return promptly even though no permit is
-		// available — the spawned task waits for the permit, the caller does not.
-		// If permit acquisition happened INLINE (pre-fix), this call would block
-		// the caller until `held` is released, so the timeout below would elapse.
+		// Dispatching a handler must return promptly even though no transaction
+		// permit is available — the spawned task waits for the permit, the caller
+		// does not. If transaction-permit acquisition happened INLINE (pre-fix),
+		// this call would block the caller until `held` is released, so the
+		// timeout below would elapse.
 		tokio::time::timeout(std::time::Duration::from_secs(2), async {
-			engine.spawn_handler(&semaphore, move |_engine| async move {
-				let _ = ran_tx.send(());
-				Ok(())
-			});
+			engine
+				.spawn_handler(&dispatch, &semaphore, move |_engine| async move {
+					let _ = ran_tx.send(());
+					Ok(())
+				})
+				.await;
 		})
 		.await
 		.expect("spawn_handler must dispatch without blocking on a contended permit");
@@ -1320,6 +1386,80 @@ mod tests {
 			.await
 			.expect("handler must run once the permit is released")
 			.expect("handler completion signal");
+	}
+
+	/// M-13 regression: the number of spawned-but-not-yet-completed handler
+	/// tasks must be bounded by the dispatch semaphore capacity, even when a
+	/// held transaction permit keeps every handler parked.
+	///
+	/// Without a bound, a bounded intake (the H-09 intent queue / event bus) can
+	/// be drained into UNLIMITED parked semaphore-waiter tasks → unbounded
+	/// memory growth. With a dispatch permit acquired BEFORE `tokio::spawn`, the
+	/// `(cap + 1)`th dispatch must block until an earlier in-flight task
+	/// completes — so no more than `cap` tasks are ever live at once.
+	#[tokio::test]
+	async fn spawn_handler_bounds_inflight_tasks() {
+		use std::sync::atomic::{AtomicUsize, Ordering};
+
+		let engine = create_test_engine().await;
+
+		// Tiny dispatch capacity so we can saturate it cheaply.
+		const CAP: usize = 2;
+		let dispatch = Arc::new(Semaphore::new(CAP));
+
+		// Single-permit transaction semaphore, held for the whole test so every
+		// spawned handler parks on it and therefore never releases its dispatch
+		// permit. This is the worst case for memory: maximal parked waiters.
+		let tx_semaphore = Arc::new(Semaphore::new(1));
+		let held = tx_semaphore.clone().acquire_owned().await.unwrap();
+
+		// Counts handler tasks that have actually been spawned (dispatched).
+		let dispatched = Arc::new(AtomicUsize::new(0));
+
+		// Drive far more dispatches than the cap from a background task. Each
+		// `spawn_handler` call acquires a dispatch permit before spawning; once
+		// CAP permits are held by parked tasks, further calls must block here.
+		let n = CAP * 8;
+		let driver = {
+			let engine = engine.clone();
+			let dispatch = dispatch.clone();
+			let tx_semaphore = tx_semaphore.clone();
+			let dispatched = dispatched.clone();
+			tokio::spawn(async move {
+				for _ in 0..n {
+					let dispatched = dispatched.clone();
+					engine
+						.spawn_handler(&dispatch, &tx_semaphore, move |_engine| async move {
+							dispatched.fetch_add(1, Ordering::SeqCst);
+							Ok(())
+						})
+						.await;
+				}
+			})
+		};
+
+		// Give the driver ample time to run as far as it can. Pre-fix (no bound)
+		// it dispatches all `n` tasks. Post-fix it stalls after `CAP`.
+		tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+		let live = dispatched.load(Ordering::SeqCst);
+		assert!(
+			live <= CAP,
+			"in-flight handler tasks must be bounded by the dispatch capacity: \
+			 expected <= {CAP}, observed {live}",
+		);
+		assert!(
+			!driver.is_finished(),
+			"driver must be blocked on the dispatch semaphore, not have dispatched all {n} tasks",
+		);
+
+		// Releasing the transaction permit lets parked tasks complete, freeing
+		// dispatch permits so the driver can finish all `n` dispatches.
+		drop(held);
+		tokio::time::timeout(std::time::Duration::from_secs(5), driver)
+			.await
+			.expect("driver must finish once parked tasks complete")
+			.expect("driver task must not panic");
 	}
 
 	#[test]

--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -581,8 +581,7 @@ impl SolverEngine {
 							return Err(EngineError::Service(format!("Failed to handle intent: {e}")));
 						}
 						Ok(())
-					})
-					.await;
+					});
 				}
 
 				// Handle events
@@ -604,8 +603,7 @@ impl SolverEngine {
 									return Err(EngineError::Service(error_msg));
 								}
 								Ok(())
-							})
-							.await;
+							});
 						}
 						SolverEvent::Order(OrderEvent::Executing { order, params }) => {
 							tracing::info!(
@@ -628,8 +626,7 @@ impl SolverEngine {
 									return Err(EngineError::Service(error_msg));
 								}
 								Ok(())
-							})
-							.await;
+							});
 						}
 
 						SolverEvent::Delivery(DeliveryEvent::TransactionPending { order_id, tx_hash, tx_type, tx_chain_id: _ }) => {
@@ -674,8 +671,7 @@ impl SolverEngine {
 										Err(EngineError::Service(error_msg))
 									}
 								}
-							})
-							.await;
+							});
 						}
 
 						SolverEvent::Delivery(DeliveryEvent::TransactionFailed { order_id, tx_hash, tx_type, error }) => {
@@ -692,8 +688,7 @@ impl SolverEngine {
 									return Err(EngineError::Service(format!("Failed to handle transaction failure: {e}")));
 								}
 								Ok(())
-							})
-							.await;
+							});
 						}
 
 						// Handle PostFillReady - use settlement handler
@@ -714,8 +709,7 @@ impl SolverEngine {
 									).await;
 								}
 								Ok(())
-							})
-							.await;
+							});
 						}
 
 						// Handle PreClaimReady - use settlement handler
@@ -731,8 +725,7 @@ impl SolverEngine {
 									).await;
 								}
 								Ok(())
-							})
-							.await;
+							});
 						}
 
 						// Handle StartMonitoring - spawn settlement monitor
@@ -770,8 +763,7 @@ impl SolverEngine {
 										).await;
 									}
 									Ok(())
-								})
-								.await;
+								});
 							}
 						}
 
@@ -956,28 +948,41 @@ impl SolverEngine {
 	/// Helper method to spawn handler tasks with semaphore-based concurrency control.
 	///
 	/// This method:
-	/// 1. Acquires a permit from the semaphore to limit concurrent tasks
-	/// 2. Clones the engine and spawns the handler in a new task
+	/// 1. Clones the engine and spawns the handler in a new task
+	/// 2. Acquires the semaphore permit INSIDE the spawned task, so the caller
+	///    (the `select!` event loop) returns immediately and keeps polling even
+	///    when the permit is contended
 	/// 3. Handles errors by logging them appropriately
-	async fn spawn_handler<F, Fut>(&self, semaphore: &Arc<Semaphore>, handler: F)
+	///
+	/// Acquiring the permit inside the task (rather than inline before
+	/// `tokio::spawn`) preserves the semaphore's serialization purpose — at most
+	/// `permits` handlers run concurrently, which is what serializes nonce
+	/// allocation on the single-permit `transaction_semaphore`. The only thing
+	/// that changes is that ordering among already-spawned waiters becomes
+	/// tokio's fair acquisition queue rather than the event-arrival order; that
+	/// is acceptable because nonce allocation only requires mutual exclusion, not
+	/// a specific order. Crucially, a held permit can no longer park the event
+	/// loop and stall unrelated event processing.
+	fn spawn_handler<F, Fut>(&self, semaphore: &Arc<Semaphore>, handler: F)
 	where
 		F: FnOnce(SolverEngine) -> Fut + Send + 'static,
 		Fut: Future<Output = Result<(), EngineError>> + Send,
 	{
 		let engine = self.clone();
-		match semaphore.clone().acquire_owned().await {
-			Ok(permit) => {
-				tokio::spawn(async move {
+		let semaphore = semaphore.clone();
+		tokio::spawn(async move {
+			match semaphore.acquire_owned().await {
+				Ok(permit) => {
 					let _permit = permit; // Keep permit alive for duration of task
 					if let Err(e) = handler(engine).await {
 						tracing::error!("Handler error: {}", e);
 					}
-				});
-			},
-			Err(e) => {
-				tracing::error!("Failed to acquire semaphore permit: {}", e);
-			},
-		}
+				},
+				Err(e) => {
+					tracing::error!("Failed to acquire semaphore permit: {}", e);
+				},
+			}
+		});
 	}
 }
 
@@ -1261,11 +1266,60 @@ mod tests {
 		let semaphore = Arc::new(Semaphore::new(1));
 
 		// Test handler that returns an error - should be logged but not panic
-		engine
-			.spawn_handler(&semaphore, move |_engine| async move {
-				Err(EngineError::Service("Test error".to_string()))
-			})
-			.await;
+		engine.spawn_handler(&semaphore, move |_engine| async move {
+			Err(EngineError::Service("Test error".to_string()))
+		});
+	}
+
+	/// M-13: dispatching a second handler must not block the event loop while a
+	/// contended permit is held. The `transaction_semaphore` is `Semaphore::new(1)`
+	/// to serialize nonce allocation; if the permit is acquired INLINE (before the
+	/// spawn) then a second tx event parks the whole `select!` loop until the
+	/// in-flight handler releases the permit. Permit acquisition must therefore
+	/// happen INSIDE the spawned task, so `spawn_handler` returns immediately.
+	#[tokio::test]
+	async fn spawn_handler_does_not_block_when_permit_contended() {
+		let engine = create_test_engine().await;
+
+		// Single-permit semaphore mirrors the transaction_semaphore.
+		let semaphore = Arc::new(Semaphore::new(1));
+
+		// Hold the only permit for the duration of the dispatch under test.
+		let held = semaphore.clone().acquire_owned().await.unwrap();
+
+		// Signals when the spawned handler actually begins executing.
+		let (ran_tx, mut ran_rx) = tokio::sync::oneshot::channel::<()>();
+
+		// Dispatching a handler must return promptly even though no permit is
+		// available — the spawned task waits for the permit, the caller does not.
+		// If permit acquisition happened INLINE (pre-fix), this call would block
+		// the caller until `held` is released, so the timeout below would elapse.
+		tokio::time::timeout(std::time::Duration::from_secs(2), async {
+			engine.spawn_handler(&semaphore, move |_engine| async move {
+				let _ = ran_tx.send(());
+				Ok(())
+			});
+		})
+		.await
+		.expect("spawn_handler must dispatch without blocking on a contended permit");
+
+		// While the permit is held the spawned handler must NOT have run — it is
+		// parked on the semaphore inside its own task, not in the caller.
+		assert!(
+			matches!(
+				ran_rx.try_recv(),
+				Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+			),
+			"handler must not run while the permit is held",
+		);
+
+		// Releasing the permit lets the queued task acquire it and run, proving
+		// serialization is preserved (mutual exclusion via the semaphore).
+		drop(held);
+		tokio::time::timeout(std::time::Duration::from_secs(2), ran_rx)
+			.await
+			.expect("handler must run once the permit is released")
+			.expect("handler completion signal");
 	}
 
 	#[test]

--- a/crates/solver-delivery/src/implementations/evm/alloy.rs
+++ b/crates/solver-delivery/src/implementations/evm/alloy.rs
@@ -48,6 +48,20 @@ const TX_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// Best-effort startup nonce reads must not block solver startup indefinitely
 /// when an RPC endpoint accepts connections but does not respond.
 const INITIAL_NONCE_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// TCP connect timeout for the HTTP RPC transport. Caps the time spent waiting
+/// for a connection before an RPC call can fail and be retried/looped.
+const RPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Per-request timeout for the HTTP RPC transport. Bounds a single RPC call so
+/// an endpoint that accepts but never answers cannot hang a request forever.
+/// This is the transport-level backstop beneath the per-call `tokio::time::timeout`
+/// in `poll_for_confirmation` (M-12).
+const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Upper bound on any single confirmation probe call. Each `get_receipt` /
+/// `get_block_number` await in `poll_for_confirmation` is wrapped in
+/// `tokio::time::timeout(min(remaining_budget, this), ..)` so the loop always
+/// returns to the deadline check and the confirmation timeout is enforced even
+/// when an RPC call never answers (M-12).
+const RPC_PROBE_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Drift-monitor parameters. The monitor periodically compares local nonce
 /// cache against chain pending. Some lead is normal during in-flight
@@ -637,8 +651,27 @@ impl AlloyDelivery {
 				10,   // cups: compute units per second
 			);
 
-			// Create RPC client with retry capabilities
-			let client = RpcClient::builder().layer(retry_layer).http(url);
+			// Build the underlying reqwest client with explicit connect and
+			// request timeouts so an RPC endpoint that accepts connections but
+			// never answers cannot hang a call indefinitely (M-12). Without
+			// these, `RetryBackoffLayer` retries a hung call but never bounds
+			// each attempt, so `tx_confirmation_timeout_seconds` is unenforceable.
+			let http_client = reqwest::Client::builder()
+				.connect_timeout(RPC_CONNECT_TIMEOUT)
+				.timeout(RPC_REQUEST_TIMEOUT)
+				.build()
+				.map_err(|e| {
+					DeliveryError::Network(format!(
+						"Failed to build HTTP client for network {network_id}: {e}"
+					))
+				})?;
+
+			// Create RPC client with retry capabilities over the timeout-bounded
+			// HTTP transport. `http_with_client` preserves the RetryBackoffLayer
+			// while swapping in our pre-built reqwest client.
+			let client = RpcClient::builder()
+				.layer(retry_layer)
+				.http_with_client(http_client, url);
 
 			// Build the provider WITHOUT a NonceFiller — we own nonce assignment via
 			// `ResettableNonceManager` so we can resync from chain after a
@@ -3252,14 +3285,36 @@ async fn poll_for_confirmation(
 	tracing::debug!(?tx_hash, min_confirmations, "Starting tx confirmation poll");
 
 	loop {
-		if Instant::now() >= deadline {
+		let remaining = deadline.saturating_duration_since(Instant::now());
+		if remaining.is_zero() {
 			tracing::warn!(?tx_hash, "Tx confirmation deadline reached → Indeterminate");
 			return PollOutcome::Indeterminate(format!(
 				"Tx {tx_hash:?} did not reach {min_confirmations} confirmations within timeout"
 			));
 		}
 
-		match probe.get_receipt(tx_hash).await {
+		// Bound each RPC call so a hung endpoint (accepts but never answers)
+		// cannot stall confirmation monitoring past `confirmation_timeout`
+		// (M-12). A per-call timeout is treated as a transient error: we loop
+		// back to the deadline check, which terminalizes the budget when
+		// exhausted. The bound is min(remaining budget, RPC_PROBE_CALL_TIMEOUT)
+		// so we never wait longer than the overall confirmation deadline.
+		let call_budget = remaining.min(RPC_PROBE_CALL_TIMEOUT);
+
+		let receipt_result =
+			match tokio::time::timeout(call_budget, probe.get_receipt(tx_hash)).await {
+				Ok(result) => result,
+				Err(_) => {
+					tracing::warn!(
+						?tx_hash,
+						"get_transaction_receipt timed out; will retry until deadline"
+					);
+					// Skip the sleep — the budget already elapsed; re-check deadline.
+					continue;
+				},
+			};
+
+		match receipt_result {
 			Ok(Some(receipt)) => {
 				if !receipt.status() {
 					tracing::warn!(?tx_hash, "Tx reverted on chain");
@@ -3277,7 +3332,24 @@ async fn poll_for_confirmation(
 						continue;
 					},
 				};
-				match probe.get_block_number().await {
+				// Re-derive the call budget: the receipt fetch above may have
+				// consumed part of the overall deadline (M-12).
+				let block_budget = deadline
+					.saturating_duration_since(Instant::now())
+					.min(RPC_PROBE_CALL_TIMEOUT);
+				let block_result =
+					match tokio::time::timeout(block_budget, probe.get_block_number()).await {
+						Ok(result) => result,
+						Err(_) => {
+							tracing::warn!(
+								?tx_hash,
+								"get_block_number timed out; will retry until deadline"
+							);
+							// Budget elapsed — re-check deadline without sleeping.
+							continue;
+						},
+					};
+				match block_result {
 					Ok(current_block) => {
 						let confirmations = current_block.saturating_sub(receipt_block);
 						if last_logged_confirmations != Some(confirmations) {
@@ -4526,6 +4598,47 @@ mod tests {
 			assert!(
 				matches!(outcome, PollOutcome::Indeterminate(_)),
 				"expected Indeterminate on deadline; got {outcome:?}",
+			);
+		}
+
+		/// Probe whose `get_receipt` never resolves, simulating an RPC endpoint
+		/// that accepts the request but never answers (M-12). With unbounded
+		/// awaits in `poll_for_confirmation`, this hangs forever and the
+		/// confirmation timeout is never enforced.
+		struct HangingProbe;
+
+		#[async_trait]
+		impl ConfirmationProbe for HangingProbe {
+			async fn get_receipt(
+				&self,
+				_tx_hash: B256,
+			) -> Result<Option<AlloyReceipt>, TransportError> {
+				// Never resolves.
+				std::future::pending().await
+			}
+
+			async fn get_block_number(&self) -> Result<u64, TransportError> {
+				std::future::pending().await
+			}
+		}
+
+		#[tokio::test]
+		async fn returns_within_deadline_when_probe_hangs() {
+			// M-12: an RPC call that hangs must not stall confirmation monitoring
+			// past `confirmation_timeout`. Each probe call is bounded so the loop
+			// returns to the deadline check; the overall budget (TIMEOUT_SHORT)
+			// must be enforced. We wrap in a generous outer timeout so a hang
+			// fails the test loudly instead of stalling CI.
+			let probe = HangingProbe;
+			let outcome = tokio::time::timeout(
+				Duration::from_secs(5),
+				poll_for_confirmation(&probe, B256::ZERO, 3, TIMEOUT_SHORT, POLL),
+			)
+			.await
+			.expect("poll_for_confirmation must return within the confirmation deadline");
+			assert!(
+				matches!(outcome, PollOutcome::Indeterminate(_)),
+				"expected Indeterminate when probe hangs past deadline; got {outcome:?}",
 			);
 		}
 

--- a/crates/solver-delivery/src/implementations/evm/nonce.rs
+++ b/crates/solver-delivery/src/implementations/evm/nonce.rs
@@ -240,6 +240,13 @@ pub fn classify_submission_outcome(message: &str) -> SubmissionOutcome {
 		|| lower.contains("fee cap less than block base fee")
 		|| lower.contains("max fee per gas below block base fee");
 
+	// EIP-1559 tip-above-cap: geth `ErrTipAboveFeeCap` in core/error.go,
+	// "max priority fee per gas higher than max fee per gas". This is a
+	// pre-pool transaction validation (ValidateTransaction / GasFeeCapTooLow
+	// guard), so the tx never entered any mempool — safe to roll back the
+	// nonce. Without this it falls through to `Ambiguous` and leaks the nonce.
+	let tip_above_fee_cap = lower.contains("max priority fee per gas higher than max fee per gas");
+
 	if lower.contains("insufficient funds")
 		|| lower.contains("transaction underpriced")
 		|| lower.contains("intrinsic gas too low")
@@ -248,6 +255,8 @@ pub fn classify_submission_outcome(message: &str) -> SubmissionOutcome {
 		|| fee_cap_below_base_fee
 		// Nonce upper-bound (the lower-bound `nonce too low` was handled above)
 		|| lower.contains("nonce too high")
+		// EIP-1559 priority-fee > fee-cap (geth ErrTipAboveFeeCap)
+		|| tip_above_fee_cap
 		// Signature / sender / chain pre-validation
 		|| lower.contains("invalid sender")
 		|| lower.contains("invalid signature")
@@ -580,6 +589,20 @@ mod tests {
 		);
 		assert_eq!(
 			classify_submission_outcome("max fee per gas below block base fee"),
+			DefinitelyRejected
+		);
+		// EIP-1559 tip-above-cap: geth `ErrTipAboveFeeCap`. Pre-pool validation
+		// rejection — the tx never entered any mempool, so the nonce is safe to
+		// roll back. Must not fall through to `Ambiguous` (would leak the nonce).
+		assert_eq!(
+			classify_submission_outcome("max priority fee per gas higher than max fee per gas"),
+			DefinitelyRejected
+		);
+		assert_eq!(
+			classify_submission_outcome(
+				"err: max priority fee per gas higher than max fee per gas: \
+				 address 0x..., maxPriorityFeePerGas: 2, maxFeePerGas: 1"
+			),
 			DefinitelyRejected
 		);
 	}


### PR DESCRIPTION
## Summary

Delivery-pipeline robustness for **M-12**, **M-13**, **M-15** (M-13 includes review fix).

- **M-13 — Contended transaction permit stalls the event loop.** The transaction permit is acquired **inside** the spawned task, so a held permit no longer parks the `select!` event loop. Additionally, a **bounded dispatch semaphore** (`MAX_INFLIGHT_HANDLERS = 1024`) is acquired **before** spawn, so a bounded intake (the intent queue / event bus) cannot fan out into unlimited parked waiter tasks. Backpressure engages only at true saturation — far above the single transaction permit — so this fixes both the original event-loop stall and the unbounded-waiter regression.

- **M-12 — Unbounded RPC awaits stall confirmation monitoring past its timeout.** `poll_for_confirmation` wraps each `get_receipt` / `get_block_number` in `tokio::time::timeout(remaining_budget)`, and the HTTP transport is built via `http_with_client` with explicit connect (10s) and request (30s) timeouts, preserving the existing `RetryBackoffLayer`. An endpoint that accepts but never answers can no longer hang past the confirmation deadline.

- **M-15 — Misclassified EIP-1559 priority-fee rejection leaks nonces.** Added the canonical geth `"max priority fee per gas higher than max fee per gas"` (`ErrTipAboveFeeCap`) string to the `DefinitelyRejected` allowlist so the nonce is reclaimed instead of leaked.

## Verification
- `cargo test -p solver-core`: 382 passed (bounded-dispatch + no-stall tests); `cargo test -p solver-delivery`: 146 passed, no hang (probe-hang timeout test + priority-fee classifier test)
- `cargo clippy --all-features --all-targets -- -D warnings --allow deprecated`, `cargo fmt --all -- --check`, `cargo check --all-targets --all-features`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added concurrency limits for internal task handling to prevent resource exhaustion during high-activity periods
  * Implemented explicit network timeouts for blockchain confirmation monitoring to improve reliability and prevent indefinite hangs
  * Enhanced transaction error classification for EIP-1559 fee validation failures to prevent nonce state management issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->