### PR TITLE
Fix settlement backend retry classification

### DIFF
--- a/crates/solver-core/src/engine/mod.rs
+++ b/crates/solver-core/src/engine/mod.rs
@@ -188,6 +188,8 @@ fn settlement_failure_policy(
 			},
 			SettlementServiceError::ProverUnavailable(_) => SettlementFailurePolicy::RetryLater,
 			SettlementServiceError::SlotDerivationMismatch => SettlementFailurePolicy::FailOrder,
+			SettlementServiceError::BackendUnavailable(_) => SettlementFailurePolicy::RetryLater,
+			SettlementServiceError::StorageUnavailable(_) => SettlementFailurePolicy::RetryLater,
 		},
 		SettlementError::Storage(_) | SettlementError::Service(_) | SettlementError::State(_) => {
 			SettlementFailurePolicy::FailOrder
@@ -2484,6 +2486,57 @@ mod tests {
 				"expected {error:?} to be permanent"
 			);
 		}
+	}
+
+	#[test]
+	fn settlement_policy_retries_backend_infrastructure_errors() {
+		let errors = vec![
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::BackendUnavailable("rpc down".to_string()),
+			),
+			crate::handlers::settlement::SettlementError::SettlementService(
+				solver_settlement::SettlementError::StorageUnavailable("storage down".to_string()),
+			),
+		];
+
+		for error in errors {
+			for stage in [
+				TransactionType::PostFill,
+				TransactionType::PreClaim,
+				TransactionType::Claim,
+			] {
+				assert_eq!(
+					settlement_failure_policy(stage, &error),
+					SettlementFailurePolicy::RetryLater,
+					"expected {error:?} at {stage:?} to be retryable"
+				);
+			}
+		}
+	}
+
+	#[tokio::test]
+	async fn post_fill_ready_backend_error_leaves_order_retryable() {
+		let engine = create_test_engine().await;
+		let order = OrderBuilder::new()
+			.with_id("post-fill-backend-error-order".to_string())
+			.with_status(OrderStatus::Executed)
+			.build();
+		engine.state_machine.store_order(&order).await.unwrap();
+
+		let result = engine
+			.handle_settlement_stage_error(
+				&order.id,
+				TransactionType::PostFill,
+				"PostFillReady",
+				crate::handlers::settlement::SettlementError::SettlementService(
+					solver_settlement::SettlementError::BackendUnavailable("rpc down".to_string()),
+				),
+			)
+			.await;
+
+		assert!(result.is_err());
+		let stored = engine.state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.status, OrderStatus::Executed);
 	}
 
 	#[tokio::test]

--- a/crates/solver-core/src/recovery/mod.rs
+++ b/crates/solver-core/src/recovery/mod.rs
@@ -3817,6 +3817,83 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn recovery_keeps_order_non_terminal_on_broadcaster_readiness_retry() {
+		// H-02 regression: a recoverable (non-terminal) Broadcaster readiness
+		// result during claim recovery must keep the order retryable, not
+		// transition it to terminal Failed(Claim). Waiting(_) re-emits
+		// StartMonitoring; only PermanentFailure transitions to Failed.
+		let temp_dir = tempfile::tempdir().unwrap();
+		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(
+			temp_dir.path().to_path_buf(),
+			TtlConfig::default(),
+		))));
+		let mut order = create_test_order_with_status(OrderStatus::PreClaimed);
+		order.fill_tx_hash = Some(TransactionHash(vec![0xbb; 32]));
+		order.settlement_name = Some("broadcaster".to_string());
+		let state_machine = Arc::new(OrderStateMachine::new(storage.clone()));
+		state_machine.store_order(&order).await.unwrap();
+
+		let mut mock_settlement = MockSettlementInterface::new();
+		mock_settlement
+			.expect_readiness()
+			.times(1)
+			.returning(|_, _| {
+				Box::pin(async move {
+					SettlementReadiness::Waiting(
+						solver_settlement::WaitingReason::StorageUnavailable,
+					)
+				})
+			});
+
+		let settlement_impls: HashMap<String, Box<dyn solver_settlement::SettlementInterface>> =
+			HashMap::from([(
+				"broadcaster".to_string(),
+				Box::new(mock_settlement) as Box<dyn solver_settlement::SettlementInterface>,
+			)]);
+		let settlement = Arc::new(SettlementService::new(
+			settlement_impls,
+			"broadcaster".to_string(),
+			20,
+		));
+		let delivery = Arc::new(DeliveryService::new(HashMap::new(), 1, 20, 60));
+		let event_bus = EventBus::new(100);
+		let mut receiver = event_bus.subscribe();
+		let (attempt_store, _attempts_tmp) = empty_attempt_store();
+
+		let recovery_service = RecoveryService::new(
+			storage.clone(),
+			state_machine.clone(),
+			delivery,
+			settlement,
+			event_bus,
+			attempt_store,
+			empty_networks_config(),
+		);
+
+		recovery_service
+			.publish_recovery_event(
+				order.clone(),
+				ReconcileResult::NeedsClaim {
+					fill_proof: Some(create_test_fill_proof()),
+				},
+			)
+			.await;
+
+		// The order must stay non-terminal (still PreClaimed), not Failed(Claim).
+		let stored = state_machine.get_order(&order.id).await.unwrap();
+		assert_eq!(stored.status, OrderStatus::PreClaimed);
+
+		// A retryable readiness result re-emits StartMonitoring rather than failing.
+		let event = receiver.try_recv().unwrap();
+		match event {
+			SolverEvent::Settlement(SettlementEvent::StartMonitoring { order_id, .. }) => {
+				assert_eq!(order_id, order.id);
+			},
+			other => panic!("Expected StartMonitoring event, got {other:?}"),
+		}
+	}
+
+	#[tokio::test]
 	async fn test_publish_recovery_event_needs_execution() {
 		let temp_dir = tempfile::tempdir().unwrap();
 		let storage = Arc::new(StorageService::new(Box::new(FileStorage::new(

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -835,7 +835,8 @@ impl BroadcasterSettlement {
 			// retryable; recovery re-emits StartMonitoring for Waiting(_), whereas
 			// PermanentFailure would terminally fail an order that may have made
 			// on-chain progress (H-02).
-			Err(e) => {
+			Err(SettlementError::BackendUnavailable(e))
+			| Err(SettlementError::StorageUnavailable(e)) => {
 				tracing::warn!(
 					order_id = %order.id,
 					error = %e,
@@ -843,6 +844,7 @@ impl BroadcasterSettlement {
 				);
 				return SettlementReadiness::Waiting(WaitingReason::StorageUnavailable);
 			},
+			Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
 		};
 
 		let submission = match state.submission.as_ref() {
@@ -1842,18 +1844,49 @@ mod tests {
 		)))
 	}
 
-	/// A storage backend whose reads always fail with a backend (non-NotFound)
-	/// error. Used to exercise the recoverable storage-unavailable path. Only
-	/// `get_bytes` is exercised by the load path; the remaining methods return
-	/// the same backend error so any accidental use is loud rather than silent.
-	struct FailingStorage;
+	#[derive(Clone, Copy)]
+	enum FailingStorageMode {
+		Backend,
+		Serialization,
+	}
+
+	/// A storage backend whose reads always fail. Used to exercise recoverable
+	/// and permanent storage failure paths. Only `get_bytes` is exercised by the
+	/// load path; the remaining methods return the same error so any accidental
+	/// use is loud rather than silent.
+	struct FailingStorage {
+		mode: FailingStorageMode,
+	}
+
+	impl FailingStorage {
+		fn backend() -> Self {
+			Self {
+				mode: FailingStorageMode::Backend,
+			}
+		}
+
+		fn serialization() -> Self {
+			Self {
+				mode: FailingStorageMode::Serialization,
+			}
+		}
+
+		fn error(&self) -> solver_storage::StorageError {
+			match self.mode {
+				FailingStorageMode::Backend => {
+					solver_storage::StorageError::Backend("simulated storage outage".to_string())
+				},
+				FailingStorageMode::Serialization => solver_storage::StorageError::Serialization(
+					"simulated corrupt state".to_string(),
+				),
+			}
+		}
+	}
 
 	#[async_trait]
 	impl solver_storage::StorageInterface for FailingStorage {
 		async fn get_bytes(&self, _key: &str) -> Result<Vec<u8>, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn set_bytes(
 			&self,
@@ -1862,36 +1895,26 @@ mod tests {
 			_indexes: Option<solver_storage::StorageIndexes>,
 			_ttl: Option<Duration>,
 		) -> Result<(), solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn delete(&self, _key: &str) -> Result<(), solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn exists(&self, _key: &str) -> Result<bool, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn query(
 			&self,
 			_namespace: &str,
 			_filter: solver_storage::QueryFilter,
 		) -> Result<Vec<String>, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn get_batch(
 			&self,
 			_keys: &[String],
 		) -> Result<Vec<(String, Vec<u8>)>, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		fn config_schema(&self) -> Box<dyn ConfigSchema> {
 			Box::new(solver_storage::implementations::memory::MemoryStorageSchema)
@@ -1902,9 +1925,7 @@ mod tests {
 			_value: Vec<u8>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn compare_and_swap(
 			&self,
@@ -1913,9 +1934,7 @@ mod tests {
 			_new_value: Vec<u8>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn compare_and_swap_with_indexes(
 			&self,
@@ -1925,14 +1944,10 @@ mod tests {
 			_indexes: Option<solver_storage::StorageIndexes>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn delete_if_exists(&self, _key: &str) -> Result<bool, solver_storage::StorageError> {
-			Err(solver_storage::StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 	}
 
@@ -3220,7 +3235,7 @@ mod tests {
 		// tracker has an empty cache, so the readiness load hits storage and the
 		// simulated outage surfaces as StorageUnavailable.
 		settlement.message_tracker = Arc::new(BroadcasterMessageTracker::new(Arc::new(
-			StorageService::new(Box::new(FailingStorage)),
+			StorageService::new(Box::new(FailingStorage::backend())),
 		)));
 
 		let readiness = settlement
@@ -3242,6 +3257,49 @@ mod tests {
 				SettlementReadiness::Waiting(WaitingReason::StorageUnavailable)
 			),
 			"expected Waiting(StorageUnavailable), got {readiness:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn broadcaster_readiness_permanent_storage_failure_is_permanent_failure() {
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_id("readiness-corrupt-storage-order")
+			.with_input_chain_ids(vec![421614])
+			.with_output_chain_ids(vec![11155111])
+			.with_data(make_eip7683_order_data(
+				&input_oracle,
+				vec![make_output(11155111, address_to_bytes32(&output_oracle))],
+			))
+			.build();
+
+		let mut settlement = test_settlement(OracleConfig {
+			input_oracles: HashMap::from([(421614u64, vec![input_oracle])]),
+			output_oracles: HashMap::from([(11155111u64, vec![output_oracle])]),
+			routes: HashMap::from([(421614u64, vec![11155111u64])]),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		settlement.message_tracker = Arc::new(BroadcasterMessageTracker::new(Arc::new(
+			StorageService::new(Box::new(FailingStorage::serialization())),
+		)));
+
+		let readiness = settlement
+			.readiness(
+				&order,
+				&FillProof {
+					tx_hash: TransactionHash(vec![0xaa; 32]),
+					block_number: 1,
+					oracle_address: with_0x_prefix(&hex::encode(vec![0x33; 20])),
+					attestation_data: None,
+					filled_timestamp: now_seconds(),
+				},
+			)
+			.await;
+
+		assert!(
+			matches!(readiness, SettlementReadiness::PermanentFailure(_)),
+			"expected PermanentFailure, got {readiness:?}"
 		);
 	}
 

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -600,7 +600,7 @@ impl BroadcasterSettlement {
 			.get_transaction_receipt(FixedBytes::<32>::from_slice(&fill_tx_hash.0))
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!("Failed to get fill receipt: {e}"))
+				SettlementError::BackendUnavailable(format!("Failed to get fill receipt: {e}"))
 			})?
 			.ok_or_else(|| {
 				SettlementError::ValidationFailed("Fill transaction not found".to_string())
@@ -642,7 +642,7 @@ impl BroadcasterSettlement {
 			.get_transaction_receipt(FixedBytes::<32>::from_slice(&tx_hash.0))
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
+				SettlementError::BackendUnavailable(format!(
 					"Failed to get {label} receipt on chain {chain_id}: {e}"
 				))
 			})?;
@@ -715,7 +715,7 @@ impl BroadcasterSettlement {
 				)
 			})?;
 		let current_block = provider.get_block_number().await.map_err(|e| {
-			SettlementError::ValidationFailed(format!(
+			SettlementError::BackendUnavailable(format!(
 				"Failed to get current block for broadcaster recovery: {e}"
 			))
 		})?;
@@ -736,7 +736,7 @@ impl BroadcasterSettlement {
 			.from_block(from_block)
 			.to_block(current_block);
 		let logs = provider.get_logs(&filter).await.map_err(|e| {
-			SettlementError::ValidationFailed(format!(
+			SettlementError::BackendUnavailable(format!(
 				"Failed to scan broadcaster logs for recovery: {e}"
 			))
 		})?;
@@ -831,7 +831,18 @@ impl BroadcasterSettlement {
 		let state = match self.load_or_recover_state(order).await {
 			Ok(Some(state)) => state,
 			Ok(None) => return SettlementReadiness::Waiting(WaitingReason::NoSubmissionState),
-			Err(e) => return SettlementReadiness::PermanentFailure(e.to_string()),
+			// A recoverable state-load/storage/backend failure must keep the order
+			// retryable; recovery re-emits StartMonitoring for Waiting(_), whereas
+			// PermanentFailure would terminally fail an order that may have made
+			// on-chain progress (H-02).
+			Err(e) => {
+				tracing::warn!(
+					order_id = %order.id,
+					error = %e,
+					"Broadcaster readiness state load failed; waiting and retrying"
+				);
+				return SettlementReadiness::Waiting(WaitingReason::StorageUnavailable);
+			},
 		};
 
 		let submission = match state.submission.as_ref() {
@@ -1207,7 +1218,9 @@ impl SettlementInterface for BroadcasterSettlement {
 		let receipt = provider
 			.get_transaction_receipt(FixedBytes::<32>::from_slice(&tx_hash.0))
 			.await
-			.map_err(|e| SettlementError::ValidationFailed(format!("Failed to get receipt: {e}")))?
+			.map_err(|e| {
+				SettlementError::BackendUnavailable(format!("Failed to get receipt: {e}"))
+			})?
 			.ok_or_else(|| {
 				SettlementError::ValidationFailed("Transaction not found".to_string())
 			})?;
@@ -1222,7 +1235,9 @@ impl SettlementInterface for BroadcasterSettlement {
 		let block = provider
 			.get_block_by_number(BlockNumberOrTag::Number(tx_block))
 			.await
-			.map_err(|e| SettlementError::ValidationFailed(format!("Failed to get block: {e}")))?;
+			.map_err(|e| {
+				SettlementError::BackendUnavailable(format!("Failed to get block: {e}"))
+			})?;
 
 		let block_timestamp = block
 			.ok_or_else(|| SettlementError::ValidationFailed("Block not found".to_string()))?
@@ -1343,9 +1358,7 @@ impl SettlementInterface for BroadcasterSettlement {
 					error = %e,
 					"isProven check failed in pre-claim path; will retry"
 				);
-				return Err(SettlementError::ValidationFailed(format!(
-					"isProven RPC error: {e}"
-				)));
+				return Err(e);
 			},
 		}
 
@@ -1827,6 +1840,100 @@ mod tests {
 		Arc::new(StorageService::new(Box::new(
 			solver_storage::implementations::memory::MemoryStorage::new(),
 		)))
+	}
+
+	/// A storage backend whose reads always fail with a backend (non-NotFound)
+	/// error. Used to exercise the recoverable storage-unavailable path. Only
+	/// `get_bytes` is exercised by the load path; the remaining methods return
+	/// the same backend error so any accidental use is loud rather than silent.
+	struct FailingStorage;
+
+	#[async_trait]
+	impl solver_storage::StorageInterface for FailingStorage {
+		async fn get_bytes(&self, _key: &str) -> Result<Vec<u8>, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn set_bytes(
+			&self,
+			_key: &str,
+			_value: Vec<u8>,
+			_indexes: Option<solver_storage::StorageIndexes>,
+			_ttl: Option<Duration>,
+		) -> Result<(), solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn delete(&self, _key: &str) -> Result<(), solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn exists(&self, _key: &str) -> Result<bool, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn query(
+			&self,
+			_namespace: &str,
+			_filter: solver_storage::QueryFilter,
+		) -> Result<Vec<String>, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn get_batch(
+			&self,
+			_keys: &[String],
+		) -> Result<Vec<(String, Vec<u8>)>, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		fn config_schema(&self) -> Box<dyn ConfigSchema> {
+			Box::new(solver_storage::implementations::memory::MemoryStorageSchema)
+		}
+		async fn set_nx(
+			&self,
+			_key: &str,
+			_value: Vec<u8>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn compare_and_swap(
+			&self,
+			_key: &str,
+			_expected: &[u8],
+			_new_value: Vec<u8>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn compare_and_swap_with_indexes(
+			&self,
+			_key: &str,
+			_expected: &[u8],
+			_new_value: Vec<u8>,
+			_indexes: Option<solver_storage::StorageIndexes>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn delete_if_exists(&self, _key: &str) -> Result<bool, solver_storage::StorageError> {
+			Err(solver_storage::StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
 	}
 
 	fn test_settlement(oracle_config: OracleConfig) -> BroadcasterSettlement {
@@ -3083,6 +3190,234 @@ mod tests {
 			SettlementReadiness::PermanentFailure(ref msg)
 				if msg.contains("Stored output oracle does not match order-bound output oracle")
 		));
+	}
+
+	#[tokio::test]
+	async fn broadcaster_readiness_storage_failure_waits_instead_of_permanent_failure() {
+		// A recoverable storage outage during the readiness state load must keep
+		// the order retryable (Waiting), not terminally fail it (PermanentFailure).
+		// Recovery re-emits StartMonitoring for Waiting(_), so the order stays
+		// non-terminal and can be re-driven once storage recovers (H-02).
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_id("readiness-storage-outage-order")
+			.with_input_chain_ids(vec![421614])
+			.with_output_chain_ids(vec![11155111])
+			.with_data(make_eip7683_order_data(
+				&input_oracle,
+				vec![make_output(11155111, address_to_bytes32(&output_oracle))],
+			))
+			.build();
+
+		let mut settlement = test_settlement(OracleConfig {
+			input_oracles: HashMap::from([(421614u64, vec![input_oracle])]),
+			output_oracles: HashMap::from([(11155111u64, vec![output_oracle])]),
+			routes: HashMap::from([(421614u64, vec![11155111u64])]),
+			selection_strategy: OracleSelectionStrategy::First,
+		});
+		// Swap in a message tracker whose storage reads always fail. The fresh
+		// tracker has an empty cache, so the readiness load hits storage and the
+		// simulated outage surfaces as StorageUnavailable.
+		settlement.message_tracker = Arc::new(BroadcasterMessageTracker::new(Arc::new(
+			StorageService::new(Box::new(FailingStorage)),
+		)));
+
+		let readiness = settlement
+			.readiness(
+				&order,
+				&FillProof {
+					tx_hash: TransactionHash(vec![0xaa; 32]),
+					block_number: 1,
+					oracle_address: with_0x_prefix(&hex::encode(vec![0x33; 20])),
+					attestation_data: None,
+					filled_timestamp: now_seconds(),
+				},
+			)
+			.await;
+
+		assert!(
+			matches!(
+				readiness,
+				SettlementReadiness::Waiting(WaitingReason::StorageUnavailable)
+			),
+			"expected Waiting(StorageUnavailable), got {readiness:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn broadcaster_fill_receipt_transport_error_is_retryable_backend_unavailable() {
+		let server = MockServer::start().await;
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(500))
+			.mount(&server)
+			.await;
+
+		let destination_chain = 11155111u64;
+		let networks = test_networks_with_http(&[destination_chain], &server.uri());
+		let settlement = BroadcasterSettlement {
+			providers: create_providers_for_chains(&[destination_chain], &networks).unwrap(),
+			..test_settlement(empty_oracle_config())
+		};
+		let order = OrderBuilder::new()
+			.with_output_chain_ids(vec![destination_chain])
+			.with_fill_tx_hash(Some(TransactionHash(vec![0xaa; 32])))
+			.build();
+
+		let err = settlement
+			.fetch_fill_receipt_logs(&order, destination_chain)
+			.await
+			.expect_err("receipt transport failure must surface as retryable");
+		assert!(
+			matches!(err, SettlementError::BackendUnavailable(_)),
+			"expected BackendUnavailable, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn broadcaster_recovery_receipt_transport_error_is_retryable_backend_unavailable() {
+		let server = MockServer::start().await;
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(500))
+			.mount(&server)
+			.await;
+
+		let destination_chain = 11155111u64;
+		let networks = test_networks_with_http(&[destination_chain], &server.uri());
+		let settlement = BroadcasterSettlement {
+			providers: create_providers_for_chains(&[destination_chain], &networks).unwrap(),
+			..test_settlement(empty_oracle_config())
+		};
+
+		let err = settlement
+			.fetch_transaction_receipt(
+				destination_chain,
+				&TransactionHash(vec![0xbb; 32]),
+				"post-fill",
+			)
+			.await
+			.expect_err("receipt transport failure must surface as retryable");
+		assert!(
+			matches!(err, SettlementError::BackendUnavailable(_)),
+			"expected BackendUnavailable, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn broadcaster_get_attestation_transport_error_is_retryable_backend_unavailable() {
+		let server = MockServer::start().await;
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(500))
+			.mount(&server)
+			.await;
+
+		let source_chain = 421614u64;
+		let destination_chain = 11155111u64;
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_input_chain_ids(vec![source_chain])
+			.with_output_chain_ids(vec![destination_chain])
+			.with_data(make_eip7683_order_data(
+				&input_oracle,
+				vec![make_output(
+					destination_chain,
+					address_to_bytes32(&output_oracle),
+				)],
+			))
+			.build();
+		let networks = test_networks_with_http(&[destination_chain], &server.uri());
+		let settlement = BroadcasterSettlement {
+			providers: create_providers_for_chains(&[destination_chain], &networks).unwrap(),
+			..test_settlement(OracleConfig {
+				input_oracles: HashMap::from([(source_chain, vec![input_oracle])]),
+				output_oracles: HashMap::from([(destination_chain, vec![output_oracle])]),
+				routes: HashMap::from([(source_chain, vec![destination_chain])]),
+				selection_strategy: OracleSelectionStrategy::First,
+			})
+		};
+
+		let err = settlement
+			.get_attestation(&order, &TransactionHash(vec![0xcc; 32]))
+			.await
+			.expect_err("receipt transport failure must surface as retryable");
+		assert!(
+			matches!(err, SettlementError::BackendUnavailable(_)),
+			"expected BackendUnavailable, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn broadcaster_pre_claim_is_proven_transport_error_stays_retryable() {
+		let server = MockServer::start().await;
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(500))
+			.mount(&server)
+			.await;
+
+		let source_chain = 421614u64;
+		let destination_chain = 11155111u64;
+		let input_oracle = solver_types::Address(vec![0x33; 20]);
+		let output_oracle = solver_types::Address(vec![0x44; 20]);
+		let order = OrderBuilder::new()
+			.with_id("pre-claim-is-proven-rpc-error-order")
+			.with_input_chain_ids(vec![source_chain])
+			.with_output_chain_ids(vec![destination_chain])
+			.with_data(make_eip7683_order_data(
+				&input_oracle,
+				vec![make_output(
+					destination_chain,
+					address_to_bytes32(&output_oracle),
+				)],
+			))
+			.build();
+		let networks = test_networks_with_http(&[source_chain], &server.uri());
+		let settlement = BroadcasterSettlement {
+			providers: create_providers_for_chains(&[source_chain], &networks).unwrap(),
+			..test_settlement(OracleConfig {
+				input_oracles: HashMap::from([(source_chain, vec![input_oracle.clone()])]),
+				output_oracles: HashMap::from([(destination_chain, vec![output_oracle.clone()])]),
+				routes: HashMap::from([(source_chain, vec![destination_chain])]),
+				selection_strategy: OracleSelectionStrategy::First,
+			})
+		};
+		settlement
+			.message_tracker
+			.track_submission(
+				&order.id,
+				BroadcasterSubmission {
+					source_chain,
+					destination_chain,
+					submission_tx_hash: TransactionHash(vec![0x55; 32]),
+					submission_timestamp: 1,
+					submission_block_number: Some(12345),
+					payload_hash: [0x66; 32],
+					message: [0x77; 32],
+					message_data: vec![0x88],
+					application: solver_types::Address(vec![0x99; 20]),
+					remote_oracle: output_oracle,
+				},
+			)
+			.await
+			.unwrap();
+
+		let err = settlement
+			.generate_pre_claim_transaction(
+				&order,
+				&FillProof {
+					tx_hash: TransactionHash(vec![0xaa; 32]),
+					block_number: 1,
+					oracle_address: with_0x_prefix(&hex::encode(&input_oracle.0)),
+					attestation_data: None,
+					filled_timestamp: now_seconds(),
+				},
+			)
+			.await
+			.expect_err("isProven transport failure must surface as retryable");
+		assert!(
+			matches!(err, SettlementError::BackendUnavailable(_)),
+			"expected BackendUnavailable, got {err:?}"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/solver-settlement/src/implementations/hyperlane.rs
+++ b/crates/solver-settlement/src/implementations/hyperlane.rs
@@ -701,7 +701,7 @@ impl HyperlaneSettlement {
 			.block(alloy_rpc_types::eth::BlockId::latest())
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!("Failed to quote gas payment: {e}"))
+				SettlementError::BackendUnavailable(format!("Failed to quote gas payment: {e}"))
 			})?;
 
 		// Decode the result
@@ -772,7 +772,7 @@ impl HyperlaneSettlement {
 			.get_transaction_receipt(FixedBytes::<32>::from_slice(&fill_tx_hash.0))
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!("Failed to get fill receipt: {e}"))
+				SettlementError::BackendUnavailable(format!("Failed to get fill receipt: {e}"))
 			})?
 			.ok_or_else(|| {
 				SettlementError::ValidationFailed("Fill transaction not found".to_string())
@@ -999,7 +999,9 @@ impl SettlementInterface for HyperlaneSettlement {
 		let receipt = provider
 			.get_transaction_receipt(hash)
 			.await
-			.map_err(|e| SettlementError::ValidationFailed(format!("Failed to get receipt: {e}")))?
+			.map_err(|e| {
+				SettlementError::BackendUnavailable(format!("Failed to get receipt: {e}"))
+			})?
 			.ok_or_else(|| {
 				SettlementError::ValidationFailed("Transaction not found".to_string())
 			})?;
@@ -1016,7 +1018,9 @@ impl SettlementInterface for HyperlaneSettlement {
 		let block = provider
 			.get_block_by_number(alloy_rpc_types::BlockNumberOrTag::Number(tx_block))
 			.await
-			.map_err(|e| SettlementError::ValidationFailed(format!("Failed to get block: {e}")))?;
+			.map_err(|e| {
+				SettlementError::BackendUnavailable(format!("Failed to get block: {e}"))
+			})?;
 
 		let block_timestamp = block
 			.ok_or_else(|| SettlementError::ValidationFailed("Block not found".to_string()))?
@@ -1068,7 +1072,7 @@ impl SettlementInterface for HyperlaneSettlement {
 			.get_transaction_receipt(FixedBytes::<32>::from_slice(&post_fill_tx_hash.0))
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!("Failed to get post-fill receipt: {e}"))
+				SettlementError::BackendUnavailable(format!("Failed to get post-fill receipt: {e}"))
 			})?
 			.ok_or_else(|| {
 				SettlementError::ValidationFailed("Post-fill transaction not found".to_string())
@@ -2320,6 +2324,64 @@ mod tests {
 		assert_eq!(
 			settlement.message_tracker.get_message_id(&order.id).await,
 			Some(expected_message_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn hyperlane_recover_post_fill_state_maps_rpc_transport_error_to_backend_unavailable() {
+		let server = MockServer::start().await;
+		let origin_chain = 1u64;
+		let dest_chain = 2u64;
+		let fill_tx_hash = TransactionHash(vec![0xfa; 32]);
+		let post_fill_tx_hash = TransactionHash(vec![0xfb; 32]);
+		let order_id = [0x42; 32];
+		let (order, _output, _output_settler) = make_hyperlane_recovery_order(
+			order_id,
+			origin_chain,
+			dest_chain,
+			fill_tx_hash.clone(),
+			post_fill_tx_hash.clone(),
+		);
+
+		// The destination RPC is unreachable/erroring: every eth_getTransactionReceipt
+		// returns HTTP 500, which alloy surfaces as a transport error. This must be
+		// classified as a retryable backend failure, not a terminal validation error.
+		Mock::given(method("POST"))
+			.respond_with(ResponseTemplate::new(500))
+			.mount(&server)
+			.await;
+
+		let provider = ProviderBuilder::new()
+			.connect_http(server.uri().parse().expect("valid RPC URL"))
+			.erased();
+		let domains = HashMap::from([
+			(origin_chain, origin_chain as u32),
+			(dest_chain, dest_chain as u32),
+		]);
+		let settlement = test_hyperlane_settlement_with_providers(
+			OracleConfig {
+				input_oracles: HashMap::from([(
+					origin_chain,
+					vec![solver_types::Address(vec![0x33; 20])],
+				)]),
+				output_oracles: HashMap::from([(
+					dest_chain,
+					vec![solver_types::Address(vec![0x44; 20])],
+				)]),
+				routes: HashMap::from([(origin_chain, vec![dest_chain])]),
+				selection_strategy: OracleSelectionStrategy::First,
+			},
+			HashMap::from([(dest_chain, provider)]),
+			domains,
+		);
+
+		let err = settlement
+			.recover_post_fill_state(&order)
+			.await
+			.expect_err("RPC transport failure must surface as an error");
+		assert!(
+			matches!(err, SettlementError::BackendUnavailable(_)),
+			"expected BackendUnavailable, got {err:?}"
 		);
 	}
 

--- a/crates/solver-settlement/src/lib.rs
+++ b/crates/solver-settlement/src/lib.rs
@@ -67,6 +67,12 @@ pub enum SettlementError {
 	/// Slot derivation mismatch detected between expected and proved slot.
 	#[error("Slot derivation mismatch")]
 	SlotDerivationMismatch,
+	/// External settlement backend/RPC infrastructure is temporarily unavailable.
+	#[error("Backend unavailable: {0}")]
+	BackendUnavailable(String),
+	/// Settlement backend storage is temporarily unavailable.
+	#[error("Storage unavailable: {0}")]
+	StorageUnavailable(String),
 }
 
 /// Direction for pushing L1 block hashes into an L2 buffer contract.

--- a/crates/solver-settlement/src/utils.rs
+++ b/crates/solver-settlement/src/utils.rs
@@ -373,7 +373,11 @@ where
 				Ok(Some(state))
 			},
 			Err(StorageError::NotFound(_)) => Ok(None),
-			Err(e) => Err(SettlementError::StorageUnavailable(format!(
+			Err(StorageError::Backend(e)) => Err(SettlementError::StorageUnavailable(format!(
+				"Failed to load settlement message state for namespace '{}' key '{}': {e}",
+				self.namespace, key
+			))),
+			Err(e) => Err(SettlementError::ValidationFailed(format!(
 				"Failed to load settlement message state for namespace '{}' key '{}': {e}",
 				self.namespace, key
 			))),
@@ -397,8 +401,13 @@ where
 				ttl,
 			)
 			.await
-			.map_err(|e| {
-				SettlementError::StorageUnavailable(format!("Failed to persist message state: {e}"))
+			.map_err(|e| match e {
+				StorageError::Backend(e) => SettlementError::StorageUnavailable(format!(
+					"Failed to persist message state: {e}"
+				)),
+				e => SettlementError::ValidationFailed(format!(
+					"Failed to persist message state: {e}"
+				)),
 			})?;
 
 		let mut cache = self.cache.write().await;
@@ -440,16 +449,57 @@ mod tests {
 	use async_trait::async_trait;
 	use solver_types::ConfigSchema;
 
-	/// Storage backend whose reads/writes always fail with a backend
-	/// (non-`NotFound`) error, used to exercise the storage-unavailable mapping.
-	struct FailingStorage;
+	#[derive(Clone, Copy)]
+	enum FailingStorageMode {
+		Backend,
+		Serialization,
+		Configuration,
+	}
+
+	/// Storage backend whose reads/writes always fail, used to exercise
+	/// transient and permanent storage error classification.
+	struct FailingStorage {
+		mode: FailingStorageMode,
+	}
+
+	impl FailingStorage {
+		fn backend() -> Self {
+			Self {
+				mode: FailingStorageMode::Backend,
+			}
+		}
+
+		fn serialization() -> Self {
+			Self {
+				mode: FailingStorageMode::Serialization,
+			}
+		}
+
+		fn configuration() -> Self {
+			Self {
+				mode: FailingStorageMode::Configuration,
+			}
+		}
+
+		fn error(&self) -> StorageError {
+			match self.mode {
+				FailingStorageMode::Backend => {
+					StorageError::Backend("simulated storage outage".to_string())
+				},
+				FailingStorageMode::Serialization => {
+					StorageError::Serialization("simulated corrupt state".to_string())
+				},
+				FailingStorageMode::Configuration => {
+					StorageError::Configuration("simulated bad config".to_string())
+				},
+			}
+		}
+	}
 
 	#[async_trait]
 	impl solver_storage::StorageInterface for FailingStorage {
 		async fn get_bytes(&self, _key: &str) -> Result<Vec<u8>, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn set_bytes(
 			&self,
@@ -458,36 +508,26 @@ mod tests {
 			_indexes: Option<solver_storage::StorageIndexes>,
 			_ttl: Option<Duration>,
 		) -> Result<(), StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn delete(&self, _key: &str) -> Result<(), StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn exists(&self, _key: &str) -> Result<bool, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn query(
 			&self,
 			_namespace: &str,
 			_filter: solver_storage::QueryFilter,
 		) -> Result<Vec<String>, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn get_batch(
 			&self,
 			_keys: &[String],
 		) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		fn config_schema(&self) -> Box<dyn ConfigSchema> {
 			Box::new(solver_storage::implementations::memory::MemoryStorageSchema)
@@ -498,9 +538,7 @@ mod tests {
 			_value: Vec<u8>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn compare_and_swap(
 			&self,
@@ -509,9 +547,7 @@ mod tests {
 			_new_value: Vec<u8>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn compare_and_swap_with_indexes(
 			&self,
@@ -521,20 +557,16 @@ mod tests {
 			_indexes: Option<solver_storage::StorageIndexes>,
 			_ttl: Option<Duration>,
 		) -> Result<bool, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 		async fn delete_if_exists(&self, _key: &str) -> Result<bool, StorageError> {
-			Err(StorageError::Backend(
-				"simulated storage outage".to_string(),
-			))
+			Err(self.error())
 		}
 	}
 
 	#[tokio::test]
 	async fn message_tracker_load_maps_backend_error_to_storage_unavailable() {
-		let storage = Arc::new(StorageService::new(Box::new(FailingStorage)));
+		let storage = Arc::new(StorageService::new(Box::new(FailingStorage::backend())));
 		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
 
 		let err = tracker
@@ -549,7 +581,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn message_tracker_save_maps_backend_error_to_storage_unavailable() {
-		let storage = Arc::new(StorageService::new(Box::new(FailingStorage)));
+		let storage = Arc::new(StorageService::new(Box::new(FailingStorage::backend())));
 		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
 
 		let err = tracker
@@ -559,6 +591,40 @@ mod tests {
 		assert!(
 			matches!(err, SettlementError::StorageUnavailable(_)),
 			"expected StorageUnavailable, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn message_tracker_load_maps_serialization_error_to_validation_failed() {
+		let storage = Arc::new(StorageService::new(Box::new(
+			FailingStorage::serialization(),
+		)));
+		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
+
+		let err = tracker
+			.load("order-1")
+			.await
+			.expect_err("corrupt storage state must surface as an error");
+		assert!(
+			matches!(err, SettlementError::ValidationFailed(_)),
+			"expected ValidationFailed, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn message_tracker_save_maps_configuration_error_to_validation_failed() {
+		let storage = Arc::new(StorageService::new(Box::new(
+			FailingStorage::configuration(),
+		)));
+		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
+
+		let err = tracker
+			.save("order-1", &"state".to_string(), None)
+			.await
+			.expect_err("bad storage config must surface as an error");
+		assert!(
+			matches!(err, SettlementError::ValidationFailed(_)),
+			"expected ValidationFailed, got {err:?}"
 		);
 	}
 

--- a/crates/solver-settlement/src/utils.rs
+++ b/crates/solver-settlement/src/utils.rs
@@ -319,10 +319,9 @@ pub async fn check_is_proven(
 		..Default::default()
 	};
 
-	let result = provider
-		.call(request)
-		.await
-		.map_err(|e| SettlementError::ValidationFailed(format!("Failed to call isProven: {e}")))?;
+	let result = provider.call(request).await.map_err(|e| {
+		SettlementError::BackendUnavailable(format!("Failed to call isProven: {e}"))
+	})?;
 
 	Ok(result.len() >= 32 && result[31] != 0)
 }
@@ -374,7 +373,7 @@ where
 				Ok(Some(state))
 			},
 			Err(StorageError::NotFound(_)) => Ok(None),
-			Err(e) => Err(SettlementError::ValidationFailed(format!(
+			Err(e) => Err(SettlementError::StorageUnavailable(format!(
 				"Failed to load settlement message state for namespace '{}' key '{}': {e}",
 				self.namespace, key
 			))),
@@ -399,7 +398,7 @@ where
 			)
 			.await
 			.map_err(|e| {
-				SettlementError::ValidationFailed(format!("Failed to persist message state: {e}"))
+				SettlementError::StorageUnavailable(format!("Failed to persist message state: {e}"))
 			})?;
 
 		let mut cache = self.cache.write().await;
@@ -438,6 +437,130 @@ fn validate_routes(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use async_trait::async_trait;
+	use solver_types::ConfigSchema;
+
+	/// Storage backend whose reads/writes always fail with a backend
+	/// (non-`NotFound`) error, used to exercise the storage-unavailable mapping.
+	struct FailingStorage;
+
+	#[async_trait]
+	impl solver_storage::StorageInterface for FailingStorage {
+		async fn get_bytes(&self, _key: &str) -> Result<Vec<u8>, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn set_bytes(
+			&self,
+			_key: &str,
+			_value: Vec<u8>,
+			_indexes: Option<solver_storage::StorageIndexes>,
+			_ttl: Option<Duration>,
+		) -> Result<(), StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn delete(&self, _key: &str) -> Result<(), StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn exists(&self, _key: &str) -> Result<bool, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn query(
+			&self,
+			_namespace: &str,
+			_filter: solver_storage::QueryFilter,
+		) -> Result<Vec<String>, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn get_batch(
+			&self,
+			_keys: &[String],
+		) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		fn config_schema(&self) -> Box<dyn ConfigSchema> {
+			Box::new(solver_storage::implementations::memory::MemoryStorageSchema)
+		}
+		async fn set_nx(
+			&self,
+			_key: &str,
+			_value: Vec<u8>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn compare_and_swap(
+			&self,
+			_key: &str,
+			_expected: &[u8],
+			_new_value: Vec<u8>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn compare_and_swap_with_indexes(
+			&self,
+			_key: &str,
+			_expected: &[u8],
+			_new_value: Vec<u8>,
+			_indexes: Option<solver_storage::StorageIndexes>,
+			_ttl: Option<Duration>,
+		) -> Result<bool, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+		async fn delete_if_exists(&self, _key: &str) -> Result<bool, StorageError> {
+			Err(StorageError::Backend(
+				"simulated storage outage".to_string(),
+			))
+		}
+	}
+
+	#[tokio::test]
+	async fn message_tracker_load_maps_backend_error_to_storage_unavailable() {
+		let storage = Arc::new(StorageService::new(Box::new(FailingStorage)));
+		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
+
+		let err = tracker
+			.load("order-1")
+			.await
+			.expect_err("backend outage must surface as an error");
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"expected StorageUnavailable, got {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn message_tracker_save_maps_backend_error_to_storage_unavailable() {
+		let storage = Arc::new(StorageService::new(Box::new(FailingStorage)));
+		let tracker = SettlementMessageTracker::<String>::new(storage, "test-namespace");
+
+		let err = tracker
+			.save("order-1", &"state".to_string(), None)
+			.await
+			.expect_err("backend outage must surface as an error");
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"expected StorageUnavailable, got {err:?}"
+		);
+	}
 
 	#[test]
 	fn test_parse_selection_strategy() {


### PR DESCRIPTION
## Summary
- Add retryable settlement backend/storage error variants for transient infrastructure failures.
- Retype Hyperlane, Broadcaster, and settlement message tracker transport/storage failures at the source.
- Keep validation, proof mismatch, missing config, missing state, failed receipts, and exhausted recovery windows terminal.

## Root Cause
Some RPC and storage backend outages were wrapped as `ValidationFailed`, which the engine treats as `FailOrder`. That could terminally fail an order after on-chain progress when retrying would be the correct recovery behavior.

## Review Follow-up
- Fixed missed Broadcaster receipt, block, log scan, and pre-claim `isProven` transport paths that still mapped to `ValidationFailed`.
- Added focused Broadcaster regression tests for those retryable paths.

## Test Plan
- `cargo test -p solver-settlement broadcaster_`
- `cargo test -p solver-core settlement_policy_`
- `cargo test -p solver-core backend_error_leaves_order_retryable`
- `cargo test -p solver-settlement`
- `cargo check --all-targets`
- `cargo check --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo test -p solver-e2e-tests` compiled and ran, but fails on pre-existing `fixture_route_matches_production_config_shape` because `config/katana-ethereum-hyperlane-mainnet-kms.json` is absent from this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary backend, RPC, and storage outages so settlement flows retry instead of failing immediately.
  - Orders now stay retryable during transient settlement and recovery errors, reducing unnecessary failed settlements.
  - Broadened error handling across multiple settlement paths, including receipt lookups, attestation checks, and recovery steps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->