### PR TITLE
fix(settlement): keep transient tracker errors retryable (H-02 follow-up)

### DIFF
--- a/crates/solver-settlement/Cargo.toml
+++ b/crates/solver-settlement/Cargo.toml
@@ -29,4 +29,5 @@ tracing = "0.1"
 uuid = { workspace = true }
 
 [dev-dependencies]
+solver-storage = { path = "../solver-storage", features = ["testing"] }
 wiremock = "0.5"

--- a/crates/solver-settlement/src/implementations/broadcaster.rs
+++ b/crates/solver-settlement/src/implementations/broadcaster.rs
@@ -250,14 +250,11 @@ impl BroadcasterMessageTracker {
 		order_id: &str,
 		submission: BroadcasterSubmission,
 	) -> Result<(), SettlementError> {
+		// Propagate the typed error (StorageUnavailable is retryable); do not
+		// collapse a transient storage fault into terminal ValidationFailed.
 		let mut state = self
 			.load(order_id)
-			.await
-			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to load broadcaster submission state for order {order_id}: {e}"
-				))
-			})?
+			.await?
 			.unwrap_or(BroadcasterMessageState {
 				submission: None,
 				proof: None,
@@ -273,14 +270,11 @@ impl BroadcasterMessageTracker {
 		order_id: &str,
 		proof: BroadcasterProofData,
 	) -> Result<(), SettlementError> {
+		// Propagate the typed error (StorageUnavailable is retryable); do not
+		// collapse a transient storage fault into terminal ValidationFailed.
 		let mut state = self
 			.load(order_id)
-			.await
-			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to load broadcaster proof state for order {order_id}: {e}"
-				))
-			})?
+			.await?
 			.unwrap_or(BroadcasterMessageState {
 				submission: None,
 				proof: None,
@@ -291,14 +285,11 @@ impl BroadcasterMessageTracker {
 	}
 
 	async fn mark_verified(&self, order_id: &str) -> Result<(), SettlementError> {
+		// Propagate the typed error (StorageUnavailable is retryable); do not
+		// collapse a transient storage fault into terminal ValidationFailed.
 		let mut state = self
 			.load(order_id)
-			.await
-			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to load broadcaster verification state for order {order_id}: {e}"
-				))
-			})?
+			.await?
 			.unwrap_or(BroadcasterMessageState {
 				submission: None,
 				proof: None,
@@ -4208,5 +4199,81 @@ mod tests {
 		let err = parse_pusher_directions(&config, &empty_oracle_config()).unwrap_err();
 		let msg = err.to_string();
 		assert!(msg.contains("l2_chain_id"), "unexpected msg: {msg}");
+	}
+}
+
+#[cfg(test)]
+mod tracker_resilience_tests {
+	use super::*;
+	use solver_storage::{MockStorageInterface, StorageError, StorageService};
+
+	// A tracker whose storage backend fails every read with a transient backend
+	// fault — the shape produced by a momentary Redis outage.
+	fn failing_tracker() -> BroadcasterMessageTracker {
+		let mut backend = MockStorageInterface::new();
+		backend.expect_get_bytes().returning(|_| {
+			Box::pin(async { Err(StorageError::Backend("simulated redis outage".to_string())) })
+		});
+		BroadcasterMessageTracker::new(Arc::new(StorageService::new(Box::new(backend))))
+	}
+
+	fn dummy_submission() -> BroadcasterSubmission {
+		BroadcasterSubmission {
+			source_chain: 1,
+			destination_chain: 2,
+			submission_tx_hash: TransactionHash(vec![0u8; 32]),
+			submission_timestamp: 0,
+			submission_block_number: None,
+			payload_hash: [0u8; 32],
+			message: [0u8; 32],
+			message_data: Vec::new(),
+			application: solver_types::Address(vec![0u8; 20]),
+			remote_oracle: solver_types::Address(vec![0u8; 20]),
+		}
+	}
+
+	fn dummy_proof() -> BroadcasterProofData {
+		BroadcasterProofData {
+			route: Vec::new(),
+			bhp_inputs: Vec::new(),
+			storage_proof: Vec::new(),
+			generated_at: 0,
+		}
+	}
+
+	#[tokio::test]
+	async fn track_submission_preserves_transient_storage_error() {
+		let err = failing_tracker()
+			.track_submission("order-transient", dummy_submission())
+			.await
+			.expect_err("a transient storage fault must surface as an error");
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"track_submission must stay retryable (StorageUnavailable), got: {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn store_proof_preserves_transient_storage_error() {
+		let err = failing_tracker()
+			.store_proof("order-transient", dummy_proof())
+			.await
+			.expect_err("a transient storage fault must surface as an error");
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"store_proof must stay retryable (StorageUnavailable), got: {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn mark_verified_preserves_transient_storage_error() {
+		let err = failing_tracker()
+			.mark_verified("order-transient")
+			.await
+			.expect_err("a transient storage fault must surface as an error");
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"mark_verified must stay retryable (StorageUnavailable), got: {err:?}"
+		);
 	}
 }

--- a/crates/solver-settlement/src/implementations/hyperlane.rs
+++ b/crates/solver-settlement/src/implementations/hyperlane.rs
@@ -450,15 +450,12 @@ impl HyperlaneSettlement {
 		let order_id = &order.id;
 
 		// Load message state
+		// Propagate the typed error (StorageUnavailable is retryable); do not
+		// collapse a transient storage fault into terminal ValidationFailed.
 		let mut state = self
 			.message_tracker
 			.load_message(order_id)
-			.await
-			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to load hyperlane message state for order {order_id}: {e}"
-				))
-			})?
+			.await?
 			.unwrap_or(HyperlaneMessageState {
 				submitted: None,
 				delivered: None,
@@ -2535,6 +2532,45 @@ mod tests {
 		assert!(
 			matches!(err, SettlementError::StorageUnavailable(_)),
 			"transient storage fault must stay retryable (StorageUnavailable), got: {err:?}"
+		);
+	}
+
+	#[tokio::test]
+	async fn check_delivery_preserves_transient_storage_error() {
+		use solver_storage::{MockStorageInterface, StorageError};
+
+		// HyperlaneSettlement whose message tracker fails every read with a
+		// transient backend fault (the shape of a momentary Redis outage).
+		let mut backend = MockStorageInterface::new();
+		backend.expect_get_bytes().returning(|_| {
+			Box::pin(async { Err(StorageError::Backend("simulated redis outage".to_string())) })
+		});
+		let settlement = HyperlaneSettlement {
+			providers: HashMap::new(),
+			oracle_config: OracleConfig {
+				input_oracles: HashMap::new(),
+				output_oracles: HashMap::new(),
+				routes: HashMap::new(),
+				selection_strategy: OracleSelectionStrategy::First,
+			},
+			mailbox_addresses: HashMap::new(),
+			igp_addresses: HashMap::new(),
+			domains: HashMap::new(),
+			message_tracker: Arc::new(MessageTracker::new(Arc::new(StorageService::new(
+				Box::new(backend),
+			)))),
+			default_gas_limit: 500_000,
+		};
+		let order = test_order_with_chains(1, 137);
+
+		let err = settlement
+			.check_delivery(&order, [0u8; 32])
+			.await
+			.expect_err("a transient storage fault must surface as an error");
+
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"check_delivery must stay retryable (StorageUnavailable), got: {err:?}"
 		);
 	}
 

--- a/crates/solver-settlement/src/implementations/hyperlane.rs
+++ b/crates/solver-settlement/src/implementations/hyperlane.rs
@@ -281,14 +281,11 @@ impl MessageTracker {
 		};
 
 		// Load existing state or create new
+		// Propagate the typed error (StorageUnavailable is retryable); do not
+		// collapse a transient storage fault into terminal ValidationFailed.
 		let mut state = self
 			.load_message(&order_id)
-			.await
-			.map_err(|e| {
-				SettlementError::ValidationFailed(format!(
-					"Failed to load hyperlane submission state for order {order_id}: {e}"
-				))
-			})?
+			.await?
 			.unwrap_or(HyperlaneMessageState {
 				submitted: None,
 				delivered: None,
@@ -2504,6 +2501,40 @@ mod tests {
 		assert_eq!(
 			settlement.message_tracker.get_message_id(&order.id).await,
 			Some(expected_message_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn track_submission_preserves_transient_storage_error() {
+		use solver_storage::{MockStorageInterface, StorageError};
+
+		// A storage backend that fails every read with a transient backend fault
+		// (the shape produced by a momentary Redis outage).
+		let mut backend = MockStorageInterface::new();
+		backend.expect_get_bytes().returning(|_| {
+			Box::pin(async { Err(StorageError::Backend("simulated redis outage".to_string())) })
+		});
+		let storage = Arc::new(StorageService::new(Box::new(backend)));
+		let tracker = MessageTracker::new(storage);
+
+		let err = tracker
+			.track_submission(
+				"order-transient".to_string(),
+				[0u8; 32], // message_id
+				1,         // origin_chain
+				2,         // destination_chain
+				TransactionHash(vec![0u8; 32]),
+				U256::ZERO, // gas_payment
+				[0u8; 32],  // payload_hash
+				[0u8; 32],  // solver_identifier
+				0,          // fill_timestamp
+			)
+			.await
+			.expect_err("a transient storage fault must surface as an error");
+
+		assert!(
+			matches!(err, SettlementError::StorageUnavailable(_)),
+			"transient storage fault must stay retryable (StorageUnavailable), got: {err:?}"
 		);
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #410 for audit finding **H-02** (transient settlement-callback failure permanently marks confirmed orders as failed).

#410 added the retryable `SettlementError::StorageUnavailable` / `BackendUnavailable` variants (classified `RetryLater` by `settlement_failure_policy`) and retyped the **leaf** tracker functions — `SettlementMessageTracker::load` / `save` now map `StorageError::Backend` → `StorageUnavailable`.

But several **intermediate** tracker methods still wrapped that `load` in `.map_err(|e| SettlementError::ValidationFailed(...))?`, overwriting the retryable variant before it reached the engine. `ValidationFailed` is classified `FailOrder` (terminal), so a momentary storage/Redis fault after on-chain confirmation still moved the order to `Failed` — after which recovery excludes it, stranding solver capital. The recovery replay funnels through the same site, so recovery could not rescue it either.

This PR removes those re-wraps so the typed error propagates via `?`, keeping transient storage faults retryable. No new types, no policy change.

## Sites fixed (all 5 in the same class)

| Site | File |
| --- | --- |
| `MessageTracker::track_submission` | `hyperlane.rs` |
| `MessageTracker::check_delivery` | `hyperlane.rs` |
| `BroadcasterMessageTracker::track_submission` | `broadcaster.rs` |
| `BroadcasterMessageTracker::store_proof` | `broadcaster.rs` |
| `BroadcasterMessageTracker::mark_verified` | `broadcaster.rs` |

`track_submission` runs on the PostFill confirm callback and the recovery replay (`recover_post_fill_state`), so it was a live strand. `check_delivery` is reached via `can_claim`, which currently swallows the error and returns `false` — so it was not yet a live strand, but it is the identical shape and is fixed here to close the class and prevent a future refactor from silently re-arming it.

The soft path at `broadcaster.rs` `buffer_coverage_check` (`tracing::warn!` on load error → returns `None`) is intentionally left untouched — it already degrades gracefully and never reaches the terminal policy.

## The change

```rust
// before
let mut state = self.load_message(&order_id).await
    .map_err(|e| SettlementError::ValidationFailed(format!("... {e}")))?
    .unwrap_or(...);
// after
let mut state = self.load_message(&order_id).await?   // StorageUnavailable stays retryable
    .unwrap_or(...);
```

Genuinely permanent conditions stay terminal: deserialization of corrupt persisted state maps to `StorageError::Serialization` → `ValidationFailed` (unchanged), and config/decode/missing-chain errors keep their `ValidationFailed`. Only true backend/connection faults become retryable.

## Tests

Added 5 regression tests (one per fixed site) that inject a transient fault at the real `StorageInterface::get_bytes` seam (`MockStorageInterface` returning `StorageError::Backend`) and assert the tracker method surfaces `SettlementError::StorageUnavailable(_)` rather than `ValidationFailed`. Each was confirmed RED (failing on `ValidationFailed`) before the fix and GREEN after.

Uses a test-only `solver-storage = { features = ["testing"] }` dev-dependency (mirrors the existing `solver-service` pattern) to reach `MockStorageInterface`.

## Verification

- `cargo test -p solver-settlement` → **186 passed, 0 failed** (181 baseline + 5 new)
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p solver-settlement --all-features --all-targets -- -D warnings --allow deprecated` → clean

## Net effect

A momentary RPC/storage/message-tracker fault in the cross-chain post-fill callback (Hyperlane or Broadcaster) now leaves the order non-terminal for recovery to re-drive, instead of stranding an on-chain-confirmed order in `Failed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient storage issues so they are now reported as retryable errors instead of being treated as validation failures.
  * Applied this behavior across submission tracking, proof storage, verification, and delivery checks for more reliable recovery during temporary backend outages.

* **Tests**
  * Added coverage to confirm transient storage failures keep their retryable classification in key settlement flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->